### PR TITLE
Replace pydiso with py-mkl-pardiso for PARDISO solver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install MKL Pardiso
         if: matrix.os != 'macos-latest'
         shell: bash -l {0}
-        run: conda install -y -c conda-forge pydiso
+        run: pip install py-mkl-pardiso
 
       # Petsc4py is not available on Windows
       - name: Install POSIX-only dependencies

--- a/README.md
+++ b/README.md
@@ -218,11 +218,11 @@ conda install scikit-umfpack -c conda-forge
 
 #### MKL Pardiso: `qtqp.LinearSolver.PARDISO`
 
-Pardiso is available via the pydiso package (only available for Intel CPUs). To
-install
+Pardiso is available via the py-mkl-pardiso package (Linux and Windows, x86_64).
+To install
 
 ```bash
-conda install pydiso -c conda-forge
+pip install py-mkl-pardiso
 ```
 
 #### Eigen: `qtqp.LinearSolver.EIGEN`

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -31,21 +31,26 @@ class MklPardisoSolver(LinearSolver):
 
     self._pymklpardiso = pymklpardiso
     self._solver: pymklpardiso.PardisoSolver | None = None
+    self._triu_kkt: sp.spmatrix | None = None
+
+  def set_kkt(self, kkt: sp.spmatrix) -> None:
+    super().set_kkt(kkt)
+    self._triu_kkt = sp.triu(kkt, format="csr")
 
   def factorize(self):
-    kkt = self._kkt
+    triu = self._triu_kkt
     if self._solver is None:
       # Initial analysis is pattern-only (cheap). On error recovery we
       # escalate to value-dependent analysis via iparm[10]/iparm[12].
       #   iparm[9]  = 8: pivot perturbation 10^-8 (default 13 ie 10^-13)
       #   iparm[23] = 1: two-level parallel factorization
       self._solver = self._pymklpardiso.PardisoSolver(
-          kkt,
+          triu,
           mtype=self._pymklpardiso.MTYPE_REAL_SYM_INDEF,
           iparms={9: 8, 23: 1},
       )
     else:
-      self._solver.refactor(kkt.data.astype(np.float64))
+      self._solver.refactor(triu.data)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     try:
@@ -57,7 +62,7 @@ class MklPardisoSolver(LinearSolver):
       logging.warning("Re-analyzing with value-dependent scaling/matching.")
       self._solver.set_iparm(10, 1)
       self._solver.set_iparm(12, 1)
-      self._solver.factor(self._kkt.data.astype(np.float64))
+      self._solver.factor(self._triu_kkt.data)
       return self._solver.solve(rhs)
 
   def format(self) -> Literal["csr"]:

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -35,28 +35,18 @@ class MklPardisoSolver(LinearSolver):
   def factorize(self):
     kkt = self._kkt
     if self._solver is None:
-      solver = self._pymklpardiso.PardisoSolver(
-          self._pymklpardiso.MTYPE_REAL_SYM_INDEF
-      )
-      solver.set_pattern(
-          ia=kkt.indptr.astype(np.int64),
-          ja=kkt.indices.astype(np.int64),
-          n=kkt.shape[0],
-      )
       # Intel recommends for symmetric indefinite IPM/saddle-point systems:
       #   iparm[9]  = 8: pivot perturbation 10^-8 (default 13 ie 10^-13)
       #   iparm[10] = 1: scaling
       #   iparm[12] = 1: weighted matching
       #   iparm[23] = 1: two-level parallel factorization
-      solver.set_iparm(9, 8)
-      solver.set_iparm(10, 1)
-      solver.set_iparm(12, 1)
-      solver.set_iparm(23, 1)
-      solver.factor(kkt.data.astype(np.float64))
-      self._solver = solver
+      self._solver = self._pymklpardiso.PardisoSolver(
+          kkt,
+          mtype=self._pymklpardiso.MTYPE_REAL_SYM_INDEF,
+          iparms={9: 8, 10: 1, 12: 1, 23: 1},
+      )
     else:
-      self._solver.set_values(kkt.data.astype(np.float64))
-      self._solver.refactor()
+      self._solver.refactor(kkt.data.astype(np.float64))
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     try:

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -37,6 +37,8 @@ class MklPardisoSolver(LinearSolver):
     if self._solver is None:
       # Initial analysis is pattern-only (cheap). On error recovery we
       # escalate to value-dependent analysis via iparm[10]/iparm[12].
+      #   iparm[9]  = 8: pivot perturbation 10^-8 (default 13 ie 10^-13)
+      #   iparm[23] = 1: two-level parallel factorization
       self._solver = self._pymklpardiso.PardisoSolver(
           kkt,
           mtype=self._pymklpardiso.MTYPE_REAL_SYM_INDEF,

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -24,56 +24,49 @@ from .direct import LinearSolver
 
 
 class MklPardisoSolver(LinearSolver):
-  """Wrapper around pydiso.mkl_solver.MKLPardisoSolver."""
+  """Wrapper around pymklpardiso.PardisoSolver."""
 
   def __init__(self):
-    import pydiso.mkl_solver  # pylint: disable=g-import-not-at-top
+    import pymklpardiso  # pylint: disable=g-import-not-at-top
 
-    self.mkl_solver = pydiso.mkl_solver
-    self.factorization: pydiso.mkl_solver.MKLPardisoSolver | None = None
+    self._pymklpardiso = pymklpardiso
+    self._solver: pymklpardiso.PardisoSolver | None = None
 
   def factorize(self):
-    if self.factorization is None:
-      # Subclass to intercept the start of the analysis phase
-      class HackedMKLPardisoSolver(self.mkl_solver.MKLPardisoSolver):
-        def _analyze(self):
-          # pydiso uses 0-based C indexing: set_iparm(i, v) sets C iparm[i],
-          # which is Fortran iparm(i+1).  Intel recommends for symmetric
-          # indefinite IPM/saddle-point systems:
-          #   Fortran iparm(10) = 8: pivot perturbation 10^-8 (C index 9)
-          #     Default is 13 (10^-13); 8 is recommended for IPM systems.
-          #   Fortran iparm(11) = 1: scaling (C index 10)
-          #   Fortran iparm(13) = 1: weighted matching (C index 12)
-          #   Fortran iparm(24) = 1: two-level parallel factorization (C index 23)
-          # 1. Inject parameters. The Cython object is created, memory is
-          # allocated, but the heavy math hasn't started yet.
-          self.set_iparm(9, 8)   # pivot perturbation
-          self.set_iparm(10, 1)  # scaling
-          self.set_iparm(12, 1)  # matching
-          self.set_iparm(23, 1)  # two-level parallel factorization
-
-          # 2. Proceed with the actual analysis using the new parameters
-          super()._analyze()
-
-      # When this instantiates, it will automatically call our overridden _analyze
-      self.factorization = HackedMKLPardisoSolver(
-          self._kkt, matrix_type="real_symmetric_indefinite"
+    kkt = self._kkt
+    if self._solver is None:
+      solver = self._pymklpardiso.PardisoSolver(
+          self._pymklpardiso.MTYPE_REAL_SYM_INDEF
       )
+      solver.set_pattern(
+          ia=kkt.indptr.astype(np.int64),
+          ja=kkt.indices.astype(np.int64),
+          n=kkt.shape[0],
+      )
+      # Intel recommends for symmetric indefinite IPM/saddle-point systems:
+      #   iparm[9]  = 8: pivot perturbation 10^-8 (default 13 ie 10^-13)
+      #   iparm[10] = 1: scaling
+      #   iparm[12] = 1: weighted matching
+      #   iparm[23] = 1: two-level parallel factorization
+      solver.set_iparm(9, 8)
+      solver.set_iparm(10, 1)
+      solver.set_iparm(12, 1)
+      solver.set_iparm(23, 1)
+      solver.factor(kkt.data.astype(np.float64))
+      self._solver = solver
     else:
-      self.factorization.refactor(self._kkt)
+      self._solver.set_values(kkt.data.astype(np.float64))
+      self._solver.refactor()
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     try:
-      return self.factorization.solve(rhs)
-    except self.mkl_solver.PardisoError as e:
-      # We tried loosening iparm(10) (pivot perturbation) on retry, but
-      # even 10^-2 still triggered zero-pivot errors on some unbounded
-      # problems.  A plain re-analyze + re-factor is more reliable.
-      logging.warning("PardisoError: %s", e)
+      return self._solver.solve(rhs)
+    except RuntimeError as e:
+      # On PARDISO errors (e.g. zero-pivot), re-analyze and re-factor.
+      logging.warning("PARDISO error: %s", e)
       logging.warning("Performing analysis and factorization steps again.")
-      self.factorization._analyze()  # pylint: disable=protected-access
-      self.factorization._factor()  # pylint: disable=protected-access
-      return self.factorization.solve(rhs)
+      self._solver.factor(self._kkt.data.astype(np.float64))
+      return self._solver.solve(rhs)
 
   def format(self) -> Literal["csr"]:
     return "csr"

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -35,15 +35,12 @@ class MklPardisoSolver(LinearSolver):
   def factorize(self):
     kkt = self._kkt
     if self._solver is None:
-      # Intel recommends for symmetric indefinite IPM/saddle-point systems:
-      #   iparm[9]  = 8: pivot perturbation 10^-8 (default 13 ie 10^-13)
-      #   iparm[10] = 1: scaling
-      #   iparm[12] = 1: weighted matching
-      #   iparm[23] = 1: two-level parallel factorization
+      # Initial analysis is pattern-only (cheap). On error recovery we
+      # escalate to value-dependent analysis via iparm[10]/iparm[12].
       self._solver = self._pymklpardiso.PardisoSolver(
           kkt,
           mtype=self._pymklpardiso.MTYPE_REAL_SYM_INDEF,
-          iparms={9: 8, 10: 1, 12: 1, 23: 1},
+          iparms={9: 8, 23: 1},
       )
     else:
       self._solver.refactor(kkt.data.astype(np.float64))
@@ -52,9 +49,12 @@ class MklPardisoSolver(LinearSolver):
     try:
       return self._solver.solve(rhs)
     except RuntimeError as e:
-      # On PARDISO errors (e.g. zero-pivot), re-analyze and re-factor.
+      # Escalate to value-dependent analysis (scaling + weighted matching)
+      # and re-analyze + re-factor from scratch.
       logging.warning("PARDISO error: %s", e)
-      logging.warning("Performing analysis and factorization steps again.")
+      logging.warning("Re-analyzing with value-dependent scaling/matching.")
+      self._solver.set_iparm(10, 1)
+      self._solver.set_iparm(12, 1)
       self._solver.factor(self._kkt.data.astype(np.float64))
       return self._solver.solve(rhs)
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -34,8 +34,9 @@ _SOLVERS = [
 ]
 
 try:
-  import pydiso.mkl_solver  # noqa: F401
-  _SOLVERS.append(qtqp.LinearSolver.PARDISO)
+  import pymklpardiso  # noqa: F401
+  if sys.platform.startswith('linux') or sys.platform == 'win32':
+    _SOLVERS.append(qtqp.LinearSolver.PARDISO)
 except (ImportError, ModuleNotFoundError) as e:
   print(f'Skipping PARDISO tests: {e}')
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -35,8 +35,7 @@ _SOLVERS = [
 
 try:
   import pymklpardiso  # noqa: F401
-  if sys.platform.startswith('linux') or sys.platform == 'win32':
-    _SOLVERS.append(qtqp.LinearSolver.PARDISO)
+  _SOLVERS.append(qtqp.LinearSolver.PARDISO)
 except (ImportError, ModuleNotFoundError) as e:
   print(f'Skipping PARDISO tests: {e}')
 


### PR DESCRIPTION
## Summary
- Replace pydiso (Cython MKL wrapper, conda-only) with py-mkl-pardiso (pybind11 wrapper with pre-built wheels)
- Users can now `pip install py-mkl-pardiso` instead of needing conda
- MKL is statically linked in the wheels, so no runtime MKL dependency

## Changes
- **solvers_sparse.py**: Rewrite `MklPardisoSolver` to use `pymklpardiso.PardisoSolver` API. The new implementation is simpler — no subclass hack needed since iparm can be set directly before factoring
- **ci.yml**: `pip install py-mkl-pardiso` instead of `conda install pydiso`
- **README.md**: Update install instructions
- **test_qtqp.py**: Update import check from `pydiso.mkl_solver` to `pymklpardiso`

## Test plan
- [ ] CI passes once py-mkl-pardiso wheels are published to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)