### PR TITLE
Add pip ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary
- Add `pip` package ecosystem to Dependabot config (previously only had `github-actions`)
- Also cleaned up boilerplate comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)