### PR TITLE
Use triangular KKT storage in direct solver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install -y -c conda-forge scikit-sparse scikit-umfpack nanoeigenpy
+          conda install -y -c conda-forge 'scikit-sparse>=0.5' scikit-umfpack nanoeigenpy
           python -m pip install -U pip
           python -m pip install qdldl pytest
           python -m pip install -e .[test] || python -m pip install -e .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install -y -c conda-forge 'scikit-sparse>=0.5' scikit-umfpack nanoeigenpy
+          conda install -y -c conda-forge suitesparse scikit-umfpack nanoeigenpy
+          python -m pip install 'scikit-sparse>=0.5'
           python -m pip install -U pip
           python -m pip install qdldl pytest
           python -m pip install -e .[test] || python -m pip install -e .

--- a/README.md
+++ b/README.md
@@ -251,10 +251,11 @@ python -m pip install qdldl
 
 #### CHOLMOD: `qtqp.LinearSolver.CHOLMOD`
 
-Cholmod is available in the scikit sparse package. To install
+Cholmod is available in the scikit sparse package (>= 0.5). To install
 
 ```bash
-conda install scikit-sparse -c conda-forge
+conda install suitesparse -c conda-forge
+pip install 'scikit-sparse>=0.5'
 ```
 
 #### Accelerate: `qtqp.LinearSolver.ACCELERATE`

--- a/src/qtqp/direct.py
+++ b/src/qtqp/direct.py
@@ -30,6 +30,22 @@ import numpy as np
 import scipy.sparse as sp
 
 
+def diag_data_indices(mat: sp.spmatrix) -> np.ndarray:
+  """Return the data-array index of each diagonal entry in a CSC/CSR matrix.
+
+  Works identically for CSC (col k, find row k) and CSR (row k, find col k).
+  """
+  mat.sort_indices()
+  dim = mat.shape[0]
+  idxs = np.empty(dim, dtype=np.intp)
+  for k in range(dim):
+    start = mat.indptr[k]
+    idxs[k] = start + np.searchsorted(
+        mat.indices[start:mat.indptr[k + 1]], k
+    )
+  return idxs
+
+
 class LinearSolver:
   """Base class for KKT linear system solvers.
 
@@ -138,16 +154,7 @@ class DirectKktSolver:
         format=self._solver.format(),
         dtype=np.float64,
     )
-    # Find the data-array index of each diagonal entry structurally.
-    # Works identically for CSC (col k, find row k) and CSR (row k, find col k).
-    self._kkt.sort_indices()
-    dim = self.n + self.m
-    self._kkt_diag_idxs = np.empty(dim, dtype=np.intp)
-    for k in range(dim):
-      start = self._kkt.indptr[k]
-      self._kkt_diag_idxs[k] = start + np.searchsorted(
-          self._kkt.indices[start:self._kkt.indptr[k + 1]], k
-      )
+    self._kkt_diag_idxs = diag_data_indices(self._kkt)
 
     # Pre-allocate reusable buffers to avoid per-call allocations.
     self._true_diags = np.empty(self.n + self.m, dtype=np.float64)

--- a/src/qtqp/direct.py
+++ b/src/qtqp/direct.py
@@ -47,8 +47,9 @@ class LinearSolver:
     pass
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
-    """Stores the KKT matrix; called by DirectKktSolver before factorize."""
+    """Stores the upper-triangular KKT matrix; called before factorize."""
     self._kkt = kkt
+    self._kkt_diag = kkt.diagonal()
 
   def factorize(self) -> None:
     """Factorizes the stored KKT matrix (with regularized diagonals).
@@ -64,7 +65,7 @@ class LinearSolver:
     raise NotImplementedError
 
   def __matmul__(self, x: np.ndarray) -> np.ndarray:
-    return self._kkt @ x
+    return self._kkt @ x + self._kkt.T @ x - self._kkt_diag * x
 
   def format(self) -> str:
     """Preferred sparse format for the KKT scaffold ('csc' or 'csr')."""
@@ -124,14 +125,16 @@ class DirectKktSolver:
     self._solver = solver
     self._solver.set_dims(n=self.n, m=self.m, z=self.z)
 
-    # Build the KKT scaffold once. Placeholder ones on the diagonal ensure
-    # those positions exist in the sparse structure; they are overwritten each
-    # iteration with the actual values (which depend on mu, s, y).
+    # Build the upper-triangular KKT scaffold once. Placeholder ones on the
+    # diagonal ensure those positions exist in the sparse structure; they are
+    # overwritten each iteration with the actual values (which depend on mu,
+    # s, y).
     n_ones = sp.eye(self.n, format="csc", dtype=np.float64)
     m_ones = sp.eye(self.m, format="csc", dtype=np.float64)
+    p_triu = sp.triu(p, format="csc")
 
     self._kkt = sp.bmat(
-        [[p + n_ones, a.T], [a, m_ones]],
+        [[p_triu + n_ones, a.T], [None, m_ones]],
         format=self._solver.format(),
         dtype=np.float64,
     )

--- a/src/qtqp/solvers_dense.py
+++ b/src/qtqp/solvers_dense.py
@@ -86,8 +86,9 @@ class ScipyDenseSolver(LinearSolver):
     n, m = self._n, self._m
     if self._A is None:
       kkt_dense = kkt.toarray()
-      self._A = np.ascontiguousarray(kkt_dense[n:, :n], dtype=np.float64)
-      P_block = kkt_dense[:n, :n].copy()
+      self._A = np.ascontiguousarray(kkt_dense[:n, n:].T, dtype=np.float64)
+      P_block = kkt_dense[:n, :n]
+      P_block = P_block + P_block.T - np.diag(np.diag(P_block))
       np.fill_diagonal(P_block, 0.0)
       self._P_offdiag = np.asfortranarray(P_block)
     diag = kkt.diagonal()

--- a/src/qtqp/solvers_gpu.py
+++ b/src/qtqp/solvers_gpu.py
@@ -65,11 +65,16 @@ class CuDssSolver(LinearSolver):
       sparse_system_type = (
           self.nvmath.sparse.advanced.DirectSolverMatrixType.SYMMETRIC
       )
+      sparse_system_view = (
+          self.nvmath.sparse.advanced.DirectSolverMatrixViewType.UPPER
+      )
       # Turn off annoying logs by default.
       logger = logging.getLogger("null")
       logger.disabled = True
       options = self.nvmath.sparse.advanced.DirectSolverOptions(
-          sparse_system_type=sparse_system_type, logger=logger
+          sparse_system_type=sparse_system_type,
+          sparse_system_view=sparse_system_view,
+          logger=logger,
       )
       n = self._kkt_gpu.shape[1]
       self._x_gpu = cp.empty(n, dtype=cp.float64)

--- a/src/qtqp/solvers_gpu.py
+++ b/src/qtqp/solvers_gpu.py
@@ -51,7 +51,7 @@ class CuDssSolver(LinearSolver):
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     """Transfers KKT data to GPU; does not retain the CPU matrix."""
-    super().set_kkt(kkt)
+    self._kkt_diag = kkt.diagonal()
     if self._kkt_gpu is None:
       self._kkt_gpu = self._cp_sparse.csr_matrix(kkt)
       self._kkt_diag_gpu = self._cp.asarray(self._kkt_diag)

--- a/src/qtqp/solvers_gpu.py
+++ b/src/qtqp/solvers_gpu.py
@@ -51,10 +51,13 @@ class CuDssSolver(LinearSolver):
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     """Transfers KKT data to GPU; does not retain the CPU matrix."""
+    super().set_kkt(kkt)
     if self._kkt_gpu is None:
       self._kkt_gpu = self._cp_sparse.csr_matrix(kkt)
+      self._kkt_diag_gpu = self._cp.asarray(self._kkt_diag)
     else:
       self._kkt_gpu.data.set(kkt.data)
+      self._kkt_diag_gpu.set(self._kkt_diag)
 
   def factorize(self):
     cp = self._cp
@@ -82,7 +85,11 @@ class CuDssSolver(LinearSolver):
 
   def __matmul__(self, x: np.ndarray) -> np.ndarray:
     self._x_gpu.set(x)
-    return (self._kkt_gpu @ self._x_gpu).get()
+    return (
+        self._kkt_gpu @ self._x_gpu
+        + self._kkt_gpu.T @ self._x_gpu
+        - self._kkt_diag_gpu * self._x_gpu
+    ).get()
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     self._rhs_gpu.set(rhs)
@@ -136,8 +143,9 @@ class CupyDenseSolver(LinearSolver):
     n, m = self._n, self._m
     if self._A_gpu is None:
       kkt_dense = kkt.toarray()
-      self._A_gpu = cp.asarray(kkt_dense[n:, :n], dtype=cp.float64)
-      P_block = kkt_dense[:n, :n].copy()
+      self._A_gpu = cp.asarray(kkt_dense[:n, n:].T, dtype=cp.float64)
+      P_block = kkt_dense[:n, :n]
+      P_block = P_block + P_block.T - np.diag(np.diag(P_block))
       np.fill_diagonal(P_block, 0.0)
       self._P_offdiag_gpu = cp.asarray(P_block, dtype=cp.float64)
     diag = kkt.diagonal()

--- a/src/qtqp/solvers_gpu.py
+++ b/src/qtqp/solvers_gpu.py
@@ -51,7 +51,7 @@ class CuDssSolver(LinearSolver):
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     """Transfers KKT data to GPU; does not retain the CPU matrix."""
-    self._kkt_diag = kkt.diagonal()
+    super().set_kkt(kkt)
     if self._kkt_gpu is None:
       self._kkt_gpu = self._cp_sparse.csr_matrix(kkt)
       self._kkt_diag_gpu = self._cp.asarray(self._kkt_diag)

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -85,13 +85,13 @@ class QdldlSolver(LinearSolver):
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     super().set_kkt(kkt)
-    self._factor_kkt = kkt.T.tocsc()
+    self._factor_kkt = kkt
 
   def factorize(self):
     if self.factorization is None:
-      self.factorization = self.qdldl.Solver(self._factor_kkt)
+      self.factorization = self.qdldl.Solver(self._factor_kkt, upper=True)
     else:
-      self.factorization.update(self._factor_kkt)
+      self.factorization.update(self._factor_kkt, upper=True)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     return self.factorization.solve(rhs)
@@ -133,18 +133,15 @@ class CholModSolver(LinearSolver):
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     super().set_kkt(kkt)
-    # CHOLMOD reads the lower triangle of a symmetric sparse matrix, so use a
-    # CSC lower-triangular view for factorization while retaining the shared
-    # upper-triangular KKT for residual matvecs.
-    self._factor_kkt = kkt.T.tocsc()
+    self._factor_kkt = kkt
 
   def factorize(self):
     if self.factorization is None:
       self.factorization = self.cholmod.cholesky(
-          self._factor_kkt, mode="simplicial"
+          self._factor_kkt, mode="simplicial", lower=False
       )
     else:
-      self.factorization.cholesky_inplace(self._factor_kkt)
+      self.factorization.cholesky_inplace(self._factor_kkt, lower=False)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     return self.factorization(rhs)
@@ -164,8 +161,9 @@ class EigenSolver(LinearSolver):
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     super().set_kkt(kkt)
-    # The nanoeigenpy binding follows Eigen's lower-triangular selfadjoint
-    # convention, so pass a CSC lower-triangular view into analyze/factorize.
+    # Eigen itself supports either triangle, but nanoeigenpy's Python module
+    # exposes only the default Lower-flavored SimplicialLDLT class, so adapt
+    # the shared upper-triangular KKT into the lower triangle here.
     self._factor_kkt = kkt.T.tocsc()
 
   def factorize(self):

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -38,12 +38,8 @@ class MklPardisoSolver(LinearSolver):
     self._pymklpardiso = pymklpardiso
     self._solver: pymklpardiso.PardisoSolver | None = None
 
-  def set_kkt(self, kkt: sp.spmatrix) -> None:
-    super().set_kkt(kkt)
-    self._triu_kkt = kkt
-
   def factorize(self):
-    triu = self._triu_kkt
+    triu = self._kkt
     if self._solver is None:
       # Initial analysis is pattern-only (cheap). On error recovery we
       # escalate to value-dependent analysis via iparm[10]/iparm[12].
@@ -67,7 +63,7 @@ class MklPardisoSolver(LinearSolver):
       logging.warning("Re-analyzing with value-dependent scaling/matching.")
       self._solver.set_iparm(10, 1)
       self._solver.set_iparm(12, 1)
-      self._solver.factor(self._triu_kkt.data)
+      self._solver.factor(self._kkt.data)
       return self._solver.solve(rhs)
 
   def format(self) -> Literal["csr"]:
@@ -188,9 +184,6 @@ class MumpsSolver(LinearSolver):
     self._ksp = None
     self._b = None
     self._x = None
-
-  def set_kkt(self, kkt: sp.spmatrix) -> None:
-    super().set_kkt(kkt)
 
   def factorize(self):
     PETSc = self._PETSc

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -132,14 +132,13 @@ class CholModSolver(LinearSolver):
 
   def factorize(self):
     if self.factorization is None:
-      self.factorization = self.cholmod.cholesky(
-          self._kkt, mode="simplicial", lower=False
+      self.factorization = self.cholmod.CholeskyFactor(
+          self._kkt, supernodal_mode="simplicial", lower=False
       )
-    else:
-      self.factorization.cholesky_inplace(self._kkt, lower=False)
+    self.factorization.factorize(self._kkt, ldl=True)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
-    return self.factorization(rhs)
+    return self.factorization.solve(rhs)
 
   def format(self) -> Literal["csc"]:
     return "csc"

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -128,37 +128,17 @@ class CholModSolver(LinearSolver):
     import sksparse.cholmod  # pylint: disable=g-import-not-at-top
 
     self.cholmod = sksparse.cholmod
-    # scikit-sparse >=0.5 has CholeskyFactor with lower= support;
-    # older versions only read the lower triangle via cholesky().
-    self._new_api = hasattr(sksparse.cholmod, "CholeskyFactor")
-    self.factorization = None
-
-  def set_kkt(self, kkt: sp.spmatrix) -> None:
-    if self._new_api:
-      super().set_kkt(kkt)
-    else:
-      # Old API reads lower triangle only; transpose upper to lower.
-      super().set_kkt(kkt.T.tocsc())
+    self.factorization: sksparse.cholmod.CholeskyFactor | None = None
 
   def factorize(self):
-    if self._new_api:
-      if self.factorization is None:
-        self.factorization = self.cholmod.CholeskyFactor(
-            self._kkt, supernodal_mode="simplicial", lower=False
-        )
-      self.factorization.factorize(self._kkt, ldl=True)
-    else:
-      if self.factorization is None:
-        self.factorization = self.cholmod.cholesky(
-            self._kkt, mode="simplicial"
-        )
-      else:
-        self.factorization.cholesky_inplace(self._kkt)
+    if self.factorization is None:
+      self.factorization = self.cholmod.CholeskyFactor(
+          self._kkt, supernodal_mode="simplicial", lower=False
+      )
+    self.factorization.factorize(self._kkt, ldl=True)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
-    if self._new_api:
-      return self.factorization.solve(rhs)
-    return self.factorization(rhs)
+    return self.factorization.solve(rhs)
 
   def format(self) -> Literal["csc"]:
     return "csc"

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -97,8 +97,10 @@ class ScipySolver(LinearSolver):
 
   def __init__(self):
     self.factorization = None
+    self._full_kkt: sp.spmatrix | None = None
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
+    super().set_kkt(kkt)
     self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
 
   def __matmul__(self, x: np.ndarray) -> np.ndarray:
@@ -318,6 +320,7 @@ class UmfpackSolver(LinearSolver):
     self._symbolic_done = False
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
+    super().set_kkt(kkt)
     self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
 
   def __matmul__(self, x: np.ndarray) -> np.ndarray:

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -83,15 +83,11 @@ class QdldlSolver(LinearSolver):
     self.qdldl = qdldl
     self.factorization: qdldl.Solver | None = None
 
-  def set_kkt(self, kkt: sp.spmatrix) -> None:
-    super().set_kkt(kkt)
-    self._factor_kkt = kkt
-
   def factorize(self):
     if self.factorization is None:
-      self.factorization = self.qdldl.Solver(self._factor_kkt, upper=True)
+      self.factorization = self.qdldl.Solver(self._kkt, upper=True)
     else:
-      self.factorization.update(self._factor_kkt, upper=True)
+      self.factorization.update(self._kkt, upper=True)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     return self.factorization.solve(rhs)
@@ -131,17 +127,13 @@ class CholModSolver(LinearSolver):
     self.cholmod = sksparse.cholmod
     self.factorization: sksparse.cholmod.CholeskyFactor | None = None
 
-  def set_kkt(self, kkt: sp.spmatrix) -> None:
-    super().set_kkt(kkt)
-    self._factor_kkt = kkt
-
   def factorize(self):
     if self.factorization is None:
       self.factorization = self.cholmod.cholesky(
-          self._factor_kkt, mode="simplicial", lower=False
+          self._kkt, mode="simplicial", lower=False
       )
     else:
-      self.factorization.cholesky_inplace(self._factor_kkt, lower=False)
+      self.factorization.cholesky_inplace(self._kkt, lower=False)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     return self.factorization(rhs)

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -103,8 +103,10 @@ class ScipySolver(LinearSolver):
     self.factorization = None
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
-    super().set_kkt(kkt)
     self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
+
+  def __matmul__(self, x: np.ndarray) -> np.ndarray:
+    return self._full_kkt @ x
 
   def factorize(self):
     self.factorization = sp.linalg.factorized(self._full_kkt)
@@ -178,19 +180,24 @@ class MumpsSolver(LinearSolver):
     self._b = None
     self._x = None
 
+  def set_kkt(self, kkt: sp.spmatrix) -> None:
+    self._full_kkt = _full_symmetric_from_upper(kkt, "csr")
+
+  def __matmul__(self, x: np.ndarray) -> np.ndarray:
+    return self._full_kkt @ x
+
   def factorize(self):
     PETSc = self._PETSc
-    kkt = self._kkt
+    kkt = self._full_kkt
 
     if self._mat is None:
-      # First call: build a symmetric PETSc Mat from upper-triangular CSR,
-      # configure KSP + MUMPS, and reuse it across iterations.
-      # createSBAIJ shares the scipy data buffer, so
+      # First call: build PETSc Mat from full CSR, configure KSP + MUMPS.
+      # createAIJWithArrays shares the scipy data buffer, so
       # DirectKktSolver's in-place diagonal updates are visible to PETSc
       # without any copy.  On subsequent factorize calls we just bump the
       # state counter and refactorize.
-      self._mat = PETSc.Mat().createSBAIJ(
-          size=kkt.shape, bsize=1, csr=(kkt.indptr, kkt.indices, kkt.data)
+      self._mat = PETSc.Mat().createAIJWithArrays(
+          kkt.shape, (kkt.indptr, kkt.indices, kkt.data)
       )
       self._mat.setOption(PETSc.Mat.Option.SYMMETRIC, True)
       self._mat.setOption(PETSc.Mat.Option.SPD, False)
@@ -200,7 +207,7 @@ class MumpsSolver(LinearSolver):
       self._ksp = PETSc.KSP().create()
       self._ksp.setType(PETSc.KSP.Type.PREONLY)
       self._pc = self._ksp.getPC()
-      self._pc.setType(PETSc.PC.Type.CHOLESKY)
+      self._pc.setType(PETSc.PC.Type.LU)
       self._pc.setFactorSolverType("mumps")
       self._ksp.setOperators(self._mat)
 
@@ -304,8 +311,10 @@ class UmfpackSolver(LinearSolver):
     self._symbolic_done = False
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
-    super().set_kkt(kkt)
     self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
+
+  def __matmul__(self, x: np.ndarray) -> np.ndarray:
+    return self._full_kkt @ x
 
   def factorize(self):
     if not self._symbolic_done:

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -83,11 +83,15 @@ class QdldlSolver(LinearSolver):
     self.qdldl = qdldl
     self.factorization: qdldl.Solver | None = None
 
+  def set_kkt(self, kkt: sp.spmatrix) -> None:
+    super().set_kkt(kkt)
+    self._factor_kkt = kkt.T.tocsc()
+
   def factorize(self):
     if self.factorization is None:
-      self.factorization = self.qdldl.Solver(self._kkt)
+      self.factorization = self.qdldl.Solver(self._factor_kkt)
     else:
-      self.factorization.update(self._kkt)
+      self.factorization.update(self._factor_kkt)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     return self.factorization.solve(rhs)
@@ -127,11 +131,20 @@ class CholModSolver(LinearSolver):
     self.cholmod = sksparse.cholmod
     self.factorization: sksparse.cholmod.CholeskyFactor | None = None
 
+  def set_kkt(self, kkt: sp.spmatrix) -> None:
+    super().set_kkt(kkt)
+    # CHOLMOD reads the lower triangle of a symmetric sparse matrix, so use a
+    # CSC lower-triangular view for factorization while retaining the shared
+    # upper-triangular KKT for residual matvecs.
+    self._factor_kkt = kkt.T.tocsc()
+
   def factorize(self):
     if self.factorization is None:
-      self.factorization = self.cholmod.cholesky(self._kkt, mode="simplicial")
+      self.factorization = self.cholmod.cholesky(
+          self._factor_kkt, mode="simplicial"
+      )
     else:
-      self.factorization.cholesky_inplace(self._kkt)
+      self.factorization.cholesky_inplace(self._factor_kkt)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     return self.factorization(rhs)
@@ -149,12 +162,18 @@ class EigenSolver(LinearSolver):
     self.nanoeigenpy = nanoeigenpy
     self._solver: nanoeigenpy.SimplicialLDLT | None = None
 
+  def set_kkt(self, kkt: sp.spmatrix) -> None:
+    super().set_kkt(kkt)
+    # The nanoeigenpy binding follows Eigen's lower-triangular selfadjoint
+    # convention, so pass a CSC lower-triangular view into analyze/factorize.
+    self._factor_kkt = kkt.T.tocsc()
+
   def factorize(self):
     if self._solver is None:
       self._solver = self.nanoeigenpy.SimplicialLDLT()
-      self._solver.analyzePattern(self._kkt)
+      self._solver.analyzePattern(self._factor_kkt)
 
-    self._solver.factorize(self._kkt)
+    self._solver.factorize(self._factor_kkt)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     return self._solver.solve(rhs)

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -128,17 +128,37 @@ class CholModSolver(LinearSolver):
     import sksparse.cholmod  # pylint: disable=g-import-not-at-top
 
     self.cholmod = sksparse.cholmod
-    self.factorization: sksparse.cholmod.CholeskyFactor | None = None
+    # scikit-sparse >=0.5 has CholeskyFactor with lower= support;
+    # older versions only read the lower triangle via cholesky().
+    self._new_api = hasattr(sksparse.cholmod, "CholeskyFactor")
+    self.factorization = None
+
+  def set_kkt(self, kkt: sp.spmatrix) -> None:
+    if self._new_api:
+      super().set_kkt(kkt)
+    else:
+      # Old API reads lower triangle only; transpose upper to lower.
+      super().set_kkt(kkt.T.tocsc())
 
   def factorize(self):
-    if self.factorization is None:
-      self.factorization = self.cholmod.CholeskyFactor(
-          self._kkt, supernodal_mode="simplicial", lower=False
-      )
-    self.factorization.factorize(self._kkt, ldl=True)
+    if self._new_api:
+      if self.factorization is None:
+        self.factorization = self.cholmod.CholeskyFactor(
+            self._kkt, supernodal_mode="simplicial", lower=False
+        )
+      self.factorization.factorize(self._kkt, ldl=True)
+    else:
+      if self.factorization is None:
+        self.factorization = self.cholmod.cholesky(
+            self._kkt, mode="simplicial"
+        )
+      else:
+        self.factorization.cholesky_inplace(self._kkt)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
-    return self.factorization.solve(rhs)
+    if self._new_api:
+      return self.factorization.solve(rhs)
+    return self.factorization(rhs)
 
   def format(self) -> Literal["csc"]:
     return "csc"

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -21,25 +21,13 @@ import numpy as np
 import scipy.sparse as sp
 
 from .direct import LinearSolver
+from .direct import diag_data_indices
 
 
 def _full_symmetric_from_upper(kkt: sp.spmatrix, format: Literal["csc", "csr"]) -> sp.spmatrix:
   """Reconstruct a full symmetric matrix from stored upper-triangular entries."""
   diag = sp.diags(kkt.diagonal(), format=format)
   return (kkt + kkt.T - diag).asformat(format)
-
-
-def _diag_data_indices(mat: sp.spmatrix) -> np.ndarray:
-  """Return the data-array index of each diagonal entry in a CSC/CSR matrix."""
-  mat.sort_indices()
-  dim = mat.shape[0]
-  idxs = np.empty(dim, dtype=np.intp)
-  for k in range(dim):
-    start = mat.indptr[k]
-    idxs[k] = start + np.searchsorted(
-        mat.indices[start:mat.indptr[k + 1]], k
-    )
-  return idxs
 
 
 class MklPardisoSolver(LinearSolver):
@@ -116,7 +104,7 @@ class ScipySolver(LinearSolver):
     super().set_kkt(kkt)
     if self._full_kkt is None:
       self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
-      self._full_diag_idxs = _diag_data_indices(self._full_kkt)
+      self._full_diag_idxs = diag_data_indices(self._full_kkt)
     else:
       self._full_kkt.data[self._full_diag_idxs] = kkt.diagonal()
 
@@ -175,7 +163,7 @@ class EigenSolver(LinearSolver):
     # lower-triangular view.
     if self._lower_diag_idxs is None:
       super().set_kkt(kkt.T.tocsc())
-      self._lower_diag_idxs = _diag_data_indices(self._kkt)
+      self._lower_diag_idxs = diag_data_indices(self._kkt)
     else:
       diag = kkt.diagonal()
       self._kkt.data[self._lower_diag_idxs] = diag
@@ -348,7 +336,7 @@ class UmfpackSolver(LinearSolver):
     super().set_kkt(kkt)
     if self._full_kkt is None:
       self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
-      self._full_diag_idxs = _diag_data_indices(self._full_kkt)
+      self._full_diag_idxs = diag_data_indices(self._full_kkt)
     else:
       self._full_kkt.data[self._full_diag_idxs] = kkt.diagonal()
 

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -181,23 +181,21 @@ class MumpsSolver(LinearSolver):
     self._x = None
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
-    self._full_kkt = _full_symmetric_from_upper(kkt, "csr")
-
-  def __matmul__(self, x: np.ndarray) -> np.ndarray:
-    return self._full_kkt @ x
+    super().set_kkt(kkt)
 
   def factorize(self):
     PETSc = self._PETSc
-    kkt = self._full_kkt
+    kkt = self._kkt
 
     if self._mat is None:
-      # First call: build PETSc Mat from full CSR, configure KSP + MUMPS.
-      # createAIJWithArrays shares the scipy data buffer, so
+      # First call: build a symmetric PETSc Mat from upper-triangular CSR,
+      # configure KSP + MUMPS, and reuse it across iterations.
+      # createSBAIJ shares the scipy data buffer, so
       # DirectKktSolver's in-place diagonal updates are visible to PETSc
       # without any copy.  On subsequent factorize calls we just bump the
       # state counter and refactorize.
-      self._mat = PETSc.Mat().createAIJWithArrays(
-          kkt.shape, (kkt.indptr, kkt.indices, kkt.data)
+      self._mat = PETSc.Mat().createSBAIJ(
+          size=kkt.shape, bsize=1, csr=(kkt.indptr, kkt.indices, kkt.data)
       )
       self._mat.setOption(PETSc.Mat.Option.SYMMETRIC, True)
       self._mat.setOption(PETSc.Mat.Option.SPD, False)
@@ -207,7 +205,11 @@ class MumpsSolver(LinearSolver):
       self._ksp = PETSc.KSP().create()
       self._ksp.setType(PETSc.KSP.Type.PREONLY)
       self._pc = self._ksp.getPC()
-      self._pc.setType(PETSc.PC.Type.LU)
+      # PETSc exposes MUMPS's symmetric-indefinite LDL^T path through the
+      # "cholesky" factor interface. That name is a misnomer here: because
+      # MAT_SPD remains false above, MUMPS treats the matrix as general
+      # symmetric (quasidefinite KKT), not SPD.
+      self._pc.setType(PETSc.PC.Type.CHOLESKY)
       self._pc.setFactorSolverType("mumps")
       self._ksp.setOperators(self._mat)
 

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -29,6 +29,19 @@ def _full_symmetric_from_upper(kkt: sp.spmatrix, format: Literal["csc", "csr"]) 
   return (kkt + kkt.T - diag).asformat(format)
 
 
+def _diag_data_indices(mat: sp.spmatrix) -> np.ndarray:
+  """Return the data-array index of each diagonal entry in a CSC/CSR matrix."""
+  mat.sort_indices()
+  dim = mat.shape[0]
+  idxs = np.empty(dim, dtype=np.intp)
+  for k in range(dim):
+    start = mat.indptr[k]
+    idxs[k] = start + np.searchsorted(
+        mat.indices[start:mat.indptr[k + 1]], k
+    )
+  return idxs
+
+
 class MklPardisoSolver(LinearSolver):
   """Wrapper around pymklpardiso.PardisoSolver."""
 
@@ -101,7 +114,11 @@ class ScipySolver(LinearSolver):
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     super().set_kkt(kkt)
-    self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
+    if self._full_kkt is None:
+      self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
+      self._full_diag_idxs = _diag_data_indices(self._full_kkt)
+    else:
+      self._full_kkt.data[self._full_diag_idxs] = kkt.diagonal()
 
   def __matmul__(self, x: np.ndarray) -> np.ndarray:
     return self._full_kkt @ x
@@ -148,6 +165,7 @@ class EigenSolver(LinearSolver):
 
     self.nanoeigenpy = nanoeigenpy
     self._solver: nanoeigenpy.SimplicialLDLT | None = None
+    self._lower_diag_idxs: np.ndarray | None = None
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     # Eigen itself supports either triangle, but nanoeigenpy's Python module
@@ -155,7 +173,13 @@ class EigenSolver(LinearSolver):
     # the shared upper-triangular KKT into the lower triangle here.  The base
     # symmetric matvec works with either stored triangle, so we only keep the
     # lower-triangular view.
-    super().set_kkt(kkt.T.tocsc())
+    if self._lower_diag_idxs is None:
+      super().set_kkt(kkt.T.tocsc())
+      self._lower_diag_idxs = _diag_data_indices(self._kkt)
+    else:
+      diag = kkt.diagonal()
+      self._kkt.data[self._lower_diag_idxs] = diag
+      self._kkt_diag = diag
 
   def factorize(self):
     if self._solver is None:
@@ -318,10 +342,15 @@ class UmfpackSolver(LinearSolver):
     self._umfpack = umfpack
     self._ctx = umfpack.UmfpackContext("di")
     self._symbolic_done = False
+    self._full_kkt: sp.spmatrix | None = None
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     super().set_kkt(kkt)
-    self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
+    if self._full_kkt is None:
+      self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
+      self._full_diag_idxs = _diag_data_indices(self._full_kkt)
+    else:
+      self._full_kkt.data[self._full_diag_idxs] = kkt.diagonal()
 
   def __matmul__(self, x: np.ndarray) -> np.ndarray:
     return self._full_kkt @ x

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -23,6 +23,12 @@ import scipy.sparse as sp
 from .direct import LinearSolver
 
 
+def _full_symmetric_from_upper(kkt: sp.spmatrix, format: Literal["csc", "csr"]):
+  """Reconstruct a full symmetric matrix from stored upper-triangular entries."""
+  diag = sp.diags(kkt.diagonal(), format=format)
+  return (kkt + kkt.T - diag).asformat(format)
+
+
 class MklPardisoSolver(LinearSolver):
   """Wrapper around pymklpardiso.PardisoSolver."""
 
@@ -31,11 +37,10 @@ class MklPardisoSolver(LinearSolver):
 
     self._pymklpardiso = pymklpardiso
     self._solver: pymklpardiso.PardisoSolver | None = None
-    self._triu_kkt: sp.spmatrix | None = None
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     super().set_kkt(kkt)
-    self._triu_kkt = sp.triu(kkt, format="csr")
+    self._triu_kkt = kkt
 
   def factorize(self):
     triu = self._triu_kkt
@@ -97,8 +102,12 @@ class ScipySolver(LinearSolver):
   def __init__(self):
     self.factorization = None
 
+  def set_kkt(self, kkt: sp.spmatrix) -> None:
+    super().set_kkt(kkt)
+    self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
+
   def factorize(self):
-    self.factorization = sp.linalg.factorized(self._kkt)
+    self.factorization = sp.linalg.factorized(self._full_kkt)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     return self.factorization(rhs)
@@ -174,13 +183,14 @@ class MumpsSolver(LinearSolver):
     kkt = self._kkt
 
     if self._mat is None:
-      # First call: build PETSc Mat from CSR, configure KSP + MUMPS.
-      # createAIJWithArrays shares the scipy data buffer, so
+      # First call: build a symmetric PETSc Mat from upper-triangular CSR,
+      # configure KSP + MUMPS, and reuse it across iterations.
+      # createSBAIJ shares the scipy data buffer, so
       # DirectKktSolver's in-place diagonal updates are visible to PETSc
       # without any copy.  On subsequent factorize calls we just bump the
       # state counter and refactorize.
-      self._mat = PETSc.Mat().createAIJWithArrays(
-          kkt.shape, (kkt.indptr, kkt.indices, kkt.data)
+      self._mat = PETSc.Mat().createSBAIJ(
+          size=kkt.shape, bsize=1, csr=(kkt.indptr, kkt.indices, kkt.data)
       )
       self._mat.setOption(PETSc.Mat.Option.SYMMETRIC, True)
       self._mat.setOption(PETSc.Mat.Option.SPD, False)
@@ -190,7 +200,7 @@ class MumpsSolver(LinearSolver):
       self._ksp = PETSc.KSP().create()
       self._ksp.setType(PETSc.KSP.Type.PREONLY)
       self._pc = self._ksp.getPC()
-      self._pc.setType(PETSc.PC.Type.LU)
+      self._pc.setType(PETSc.PC.Type.CHOLESKY)
       self._pc.setFactorSolverType("mumps")
       self._ksp.setOperators(self._mat)
 
@@ -266,7 +276,7 @@ class AccelerateSolver(LinearSolver):
 
   def factorize(self):
     if self._solver is None:
-      self._solver = self._macldlt.LDLTSolver(self._kkt)
+      self._solver = self._macldlt.LDLTSolver(self._kkt, triangle="upper")
     else:
       self._solver.refactor(self._kkt.data)
 
@@ -293,14 +303,20 @@ class UmfpackSolver(LinearSolver):
     self._ctx = umfpack.UmfpackContext("di")
     self._symbolic_done = False
 
+  def set_kkt(self, kkt: sp.spmatrix) -> None:
+    super().set_kkt(kkt)
+    self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
+
   def factorize(self):
     if not self._symbolic_done:
-      self._ctx.symbolic(self._kkt)
+      self._ctx.symbolic(self._full_kkt)
       self._symbolic_done = True
-    self._ctx.numeric(self._kkt)
+    self._ctx.numeric(self._full_kkt)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
-    return self._ctx.solve(self._umfpack.UMFPACK_A, self._kkt, rhs, autoTranspose=True)
+    return self._ctx.solve(
+        self._umfpack.UMFPACK_A, self._full_kkt, rhs, autoTranspose=True
+    )
 
   def format(self) -> Literal["csc"]:
     return "csc"

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -148,18 +148,19 @@ class EigenSolver(LinearSolver):
     self._solver: nanoeigenpy.SimplicialLDLT | None = None
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
-    super().set_kkt(kkt)
     # Eigen itself supports either triangle, but nanoeigenpy's Python module
     # exposes only the default Lower-flavored SimplicialLDLT class, so adapt
-    # the shared upper-triangular KKT into the lower triangle here.
-    self._factor_kkt = kkt.T.tocsc()
+    # the shared upper-triangular KKT into the lower triangle here.  The base
+    # symmetric matvec works with either stored triangle, so we only keep the
+    # lower-triangular view.
+    super().set_kkt(kkt.T.tocsc())
 
   def factorize(self):
     if self._solver is None:
       self._solver = self.nanoeigenpy.SimplicialLDLT()
-      self._solver.analyzePattern(self._factor_kkt)
+      self._solver.analyzePattern(self._kkt)
 
-    self._solver.factorize(self._factor_kkt)
+    self._solver.factorize(self._kkt)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     return self._solver.solve(rhs)

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -23,7 +23,7 @@ import scipy.sparse as sp
 from .direct import LinearSolver
 
 
-def _full_symmetric_from_upper(kkt: sp.spmatrix, format: Literal["csc", "csr"]):
+def _full_symmetric_from_upper(kkt: sp.spmatrix, format: Literal["csc", "csr"]) -> sp.spmatrix:
   """Reconstruct a full symmetric matrix from stored upper-triangular entries."""
   diag = sp.diags(kkt.diagonal(), format=format)
   return (kkt + kkt.T - diag).asformat(format)

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -188,17 +188,19 @@ class MumpsSolver(LinearSolver):
     kkt = self._kkt
 
     if self._mat is None:
-      # First call: build a symmetric PETSc Mat from upper-triangular CSR,
-      # configure KSP + MUMPS, and reuse it across iterations.
-      # createSBAIJ shares the scipy data buffer, so
+      # First call: build a PETSc AIJ matrix from the stored upper triangle,
+      # mark it symmetric, and tell PETSc/MUMPS to ignore the absent lower
+      # triangle structurally.
+      # createAIJWithArrays shares the scipy data buffer, so
       # DirectKktSolver's in-place diagonal updates are visible to PETSc
       # without any copy.  On subsequent factorize calls we just bump the
       # state counter and refactorize.
-      self._mat = PETSc.Mat().createSBAIJ(
-          size=kkt.shape, bsize=1, csr=(kkt.indptr, kkt.indices, kkt.data)
+      self._mat = PETSc.Mat().createAIJWithArrays(
+          kkt.shape, (kkt.indptr, kkt.indices, kkt.data)
       )
       self._mat.setOption(PETSc.Mat.Option.SYMMETRIC, True)
       self._mat.setOption(PETSc.Mat.Option.SPD, False)
+      self._mat.setOption(PETSc.Mat.Option.IGNORE_LOWER_TRIANGULAR, True)
       self._mat.setOption(PETSc.Mat.Option.NEW_NONZERO_LOCATIONS, False)
       self._mat.assemble()
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -32,13 +32,13 @@ _SOLVERS = [
 
 
 class _TriangularMatvecSolver(qtqp.direct.LinearSolver):
-  """Minimal solver used to exercise the base symmetric-triangle matvec."""
+  """Minimal solver used only to exercise the base symmetric-triangle matvec."""
 
   def factorize(self):
     pass
 
   def solve(self, rhs):
-    return rhs
+    raise NotImplementedError("Test-only solver; not intended for solve().")
 
   def format(self):
     return 'csc'

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -407,8 +407,13 @@ def test_upper_triangular_kkt_matvec_matches_full():
   )
   linear_solver.update(mu=mu, s=s, y=y)
 
+  # The reference KKT below uses unregularized diagonals, so verify
+  # that regularization did not alter any diagonal entry.
+  diag_x = p.diagonal() + mu
   diag_y = np.full(m, mu, dtype=np.float64)
   diag_y[z:] = s[z:] / y[z:] + mu
+  min_reg = 1e-8
+  assert np.all(diag_x >= min_reg) and np.all(diag_y >= min_reg)
   kkt_full = sparse.bmat(
       [
           [p + sparse.diags(np.full(n, mu)), a.T],

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -33,6 +33,19 @@ _SOLVERS = [
     # qtqp.LinearSolver.CUPY_DENSE,
 ]
 
+
+class _TriangularMatvecSolver(qtqp.direct.LinearSolver):
+  """Minimal solver used to exercise the base symmetric-triangle matvec."""
+
+  def factorize(self):
+    pass
+
+  def solve(self, rhs):
+    return rhs
+
+  def format(self):
+    return 'csc'
+
 try:
   import pymklpardiso  # noqa: F401
   _SOLVERS.append(qtqp.LinearSolver.PARDISO)
@@ -378,7 +391,7 @@ def test_upper_triangular_kkt_matvec_matches_full():
       max_iterative_refinement_steps=2,
       atol=1e-12,
       rtol=1e-12,
-      solver=qtqp.direct.ScipySolver(),
+      solver=_TriangularMatvecSolver(),
   )
   linear_solver.update(mu=mu, s=s, y=y)
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -359,6 +359,49 @@ def test_direct_linear_solver(seed, linear_solver):
   )
 
 
+def test_upper_triangular_kkt_matvec_matches_full():
+  """Upper-triangular KKT storage must reproduce the full symmetric matvec."""
+  rng = np.random.default_rng(2026)
+  m, n, z = 20, 12, 4
+  a, _, _, p = _gen_feasible(m, n, z, random_state=rng)
+  mu = rng.uniform()
+  s = rng.uniform(size=m)
+  y = rng.uniform(size=m)
+  s[:z] = 0.0
+  vec = rng.normal(size=n + m)
+
+  linear_solver = qtqp.direct.DirectKktSolver(
+      a=a,
+      p=p,
+      z=z,
+      min_static_regularization=1e-8,
+      max_iterative_refinement_steps=2,
+      atol=1e-12,
+      rtol=1e-12,
+      solver=qtqp.direct.ScipySolver(),
+  )
+  linear_solver.update(mu=mu, s=s, y=y)
+
+  diag_y = np.full(m, mu, dtype=np.float64)
+  diag_y[z:] = s[z:] / y[z:] + mu
+  kkt_full = sparse.bmat(
+      [
+          [p + sparse.diags(np.full(n, mu)), a.T],
+          [a, -sparse.diags(diag_y)],
+      ],
+      format='csc',
+      dtype=np.float64,
+  )
+
+  assert (linear_solver._kkt - sparse.triu(linear_solver._kkt)).nnz == 0  # pylint: disable=protected-access
+  np.testing.assert_allclose(
+      linear_solver._solver @ vec,  # pylint: disable=protected-access
+      kkt_full @ vec,
+      rtol=1e-10,
+      atol=1e-10,
+  )
+
+
 @pytest.mark.parametrize('seed', 942 + np.arange(20))
 @pytest.mark.parametrize('linear_solver', _SOLVERS)
 def test_resolvent_operator(seed, linear_solver):

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -28,9 +28,6 @@ _SOLVERS = [
     qtqp.LinearSolver.QDLDL,
     qtqp.LinearSolver.CHOLMOD,
     qtqp.LinearSolver.EIGEN,
-    # Requires GPU:
-    # qtqp.LinearSolver.CUDSS,
-    # qtqp.LinearSolver.CUPY_DENSE,
 ]
 
 
@@ -63,6 +60,21 @@ try:
   _SOLVERS.append(qtqp.LinearSolver.MUMPS)
 except (ImportError, ModuleNotFoundError) as e:
   print(f'Skipping MUMPS tests: {e}')
+
+try:
+  import cupy  # noqa: F401
+  if cupy.cuda.runtime.getDeviceCount() > 0:
+    _SOLVERS.append(qtqp.LinearSolver.CUPY_DENSE)
+except Exception as e:  # pylint: disable=broad-exception-caught
+  print(f'Skipping CUPY_DENSE tests: {e}')
+
+try:
+  import cupy  # noqa: F401
+  import nvmath  # noqa: F401
+  if cupy.cuda.runtime.getDeviceCount() > 0:
+    _SOLVERS.append(qtqp.LinearSolver.CUDSS)
+except Exception as e:  # pylint: disable=broad-exception-caught
+  print(f'Skipping CUDSS tests: {e}')
 
 
 def _gen_feasible(m, n, z, random_state=None):


### PR DESCRIPTION
## Summary
- store only the upper-triangular KKT in `DirectKktSolver`
- compute residual matvecs from the triangular representation via `U @ x + U.T @ x - diag(U) * x`
- let symmetric sparse backends consume the triangular KKT directly, while LU backends reconstruct a full symmetric matrix locally
- update dense backends to read `A` and the symmetric `P` block from the triangular scaffold
- add a regression test for triangular-KKT matvec equivalence

## Testing
- `PYTHONPATH=../qtqp/src conda run --no-capture-output -n python312 python -m pytest ../qtqp/tests/test_qtqp.py -k "upper_triangular_kkt_matvec_matches_full or solve_tiny or nonsymmetric_p"`
- `PYTHONPATH=../qtqp/src conda run --no-capture-output -n python312 python -m pytest ../qtqp/tests/test_qtqp.py -k "direct_linear_solver and (SCIPY or UMFPACK or ACCELERATE or MUMPS)"`
- `PYTHONPATH=../qtqp/src conda run --no-capture-output -n python312 python -m pytest ../qtqp/tests/test_qtqp.py -k "resolvent_operator and (SCIPY or UMFPACK or ACCELERATE or MUMPS)"`
