### PR TITLE
Split set_kkt into set_kkt + update_diag

### DIFF
--- a/src/qtqp/direct.py
+++ b/src/qtqp/direct.py
@@ -63,9 +63,24 @@ class LinearSolver:
     pass
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
-    """Stores the upper-triangular KKT matrix; called before factorize."""
+    """Stores the upper-triangular KKT matrix; called once at init time.
+
+    Subclasses that override this should call super().set_kkt(kkt) to ensure
+    the base-class _kkt, _kkt_diag, and _kkt_diag_idxs are populated.
+    """
     self._kkt = kkt
     self._kkt_diag = kkt.diagonal()
+    self._kkt_diag_idxs = diag_data_indices(kkt)
+
+  def update_diag(self, diag: np.ndarray) -> None:
+    """Updates the KKT diagonal in place; called each iteration before factorize.
+
+    The default writes the diagonal into the stored sparse matrix and updates
+    _kkt_diag.  Backends with private copies (dense, GPU, LU-from-upper)
+    override this to update their own storage.
+    """
+    self._kkt.data[self._kkt_diag_idxs] = diag
+    np.copyto(self._kkt_diag, diag)
 
   def factorize(self) -> None:
     """Factorizes the stored KKT matrix (with regularized diagonals).
@@ -154,7 +169,7 @@ class DirectKktSolver:
         format=self._solver.format(),
         dtype=np.float64,
     )
-    self._kkt_diag_idxs = diag_data_indices(self._kkt)
+    self._solver.set_kkt(self._kkt)
 
     # Pre-allocate reusable buffers to avoid per-call allocations.
     self._true_diags = np.empty(self.n + self.m, dtype=np.float64)
@@ -192,8 +207,7 @@ class DirectKktSolver:
     # diag_correction * sol to the residual to account for the difference
     # between the regularized matrix (used for factorization and matvec) and
     # the true matrix (whose solution we seek), converging to the exact answer.
-    self._kkt.data[self._kkt_diag_idxs] = self._reg_diags
-    self._solver.set_kkt(self._kkt)
+    self._solver.update_diag(self._reg_diags)
     self._solver.factorize()
     np.subtract(self._reg_diags, self._true_diags, out=self._diag_correction)
 

--- a/src/qtqp/direct.py
+++ b/src/qtqp/direct.py
@@ -65,8 +65,9 @@ class LinearSolver:
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     """Stores the upper-triangular KKT matrix; called once at init time.
 
-    Subclasses that override this should call super().set_kkt(kkt) to ensure
-    the base-class _kkt, _kkt_diag, and _kkt_diag_idxs are populated.
+    Subclasses that rely on the base sparse storage or the default
+    update_diag/__matmul__ helpers should call super().set_kkt(kkt) so
+    _kkt, _kkt_diag, and _kkt_diag_idxs are populated.
     """
     self._kkt = kkt
     self._kkt_diag = kkt.diagonal()

--- a/src/qtqp/direct.py
+++ b/src/qtqp/direct.py
@@ -65,9 +65,8 @@ class LinearSolver:
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     """Stores the upper-triangular KKT matrix; called once at init time.
 
-    Subclasses that rely on the base sparse storage or the default
-    update_diag/__matmul__ helpers should call super().set_kkt(kkt) so
-    _kkt, _kkt_diag, and _kkt_diag_idxs are populated.
+    Subclasses that override this should call super().set_kkt(kkt) to ensure
+    the base-class _kkt, _kkt_diag, and _kkt_diag_idxs are populated.
     """
     self._kkt = kkt
     self._kkt_diag = kkt.diagonal()

--- a/src/qtqp/solvers_dense.py
+++ b/src/qtqp/solvers_dense.py
@@ -83,6 +83,7 @@ class ScipyDenseSolver(LinearSolver):
     self._g = np.empty(n, dtype=np.float64)
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
+    super().set_kkt(kkt)
     n = self._n
     kkt_dense = kkt.toarray()
     self._A = np.ascontiguousarray(kkt_dense[:n, n:].T, dtype=np.float64)

--- a/src/qtqp/solvers_dense.py
+++ b/src/qtqp/solvers_dense.py
@@ -83,17 +83,17 @@ class ScipyDenseSolver(LinearSolver):
     self._g = np.empty(n, dtype=np.float64)
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
-    n, m = self._n, self._m
-    if self._A is None:
-      kkt_dense = kkt.toarray()
-      self._A = np.ascontiguousarray(kkt_dense[:n, n:].T, dtype=np.float64)
-      P_block = kkt_dense[:n, :n]
-      P_block = P_block + P_block.T - np.diag(np.diag(P_block))
-      np.fill_diagonal(P_block, 0.0)
-      self._P_offdiag = np.asfortranarray(P_block)
-    diag = kkt.diagonal()
-    np.copyto(self._R_x, diag[:n])
-    np.negative(diag[n:], out=self._R_y)
+    n = self._n
+    kkt_dense = kkt.toarray()
+    self._A = np.ascontiguousarray(kkt_dense[:n, n:].T, dtype=np.float64)
+    P_block = kkt_dense[:n, :n]
+    P_block = P_block + P_block.T - np.diag(np.diag(P_block))
+    np.fill_diagonal(P_block, 0.0)
+    self._P_offdiag = np.asfortranarray(P_block)
+
+  def update_diag(self, diag: np.ndarray) -> None:
+    np.copyto(self._R_x, diag[:self._n])
+    np.negative(diag[self._n:], out=self._R_y)
 
   def factorize(self) -> None:
     # G = P_offdiag + diag(R_x) + A' diag(1/R_y) A

--- a/src/qtqp/solvers_gpu.py
+++ b/src/qtqp/solvers_gpu.py
@@ -146,6 +146,7 @@ class CupyDenseSolver(LinearSolver):
     self._L = None  # Lower-triangular Cholesky factor
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
+    super().set_kkt(kkt)
     cp = self._cp
     n = self._n
     kkt_dense = kkt.toarray()

--- a/src/qtqp/solvers_gpu.py
+++ b/src/qtqp/solvers_gpu.py
@@ -50,14 +50,15 @@ class CuDssSolver(LinearSolver):
     self._rhs_gpu: cupy.ndarray | None = None
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
-    """Transfers KKT data to GPU; does not retain the CPU matrix."""
+    """Transfers KKT to GPU; called once at init time."""
     super().set_kkt(kkt)
-    if self._kkt_gpu is None:
-      self._kkt_gpu = self._cp_sparse.csr_matrix(kkt)
-      self._kkt_diag_gpu = self._cp.asarray(self._kkt_diag)
-    else:
-      self._kkt_gpu.data.set(kkt.data)
-      self._kkt_diag_gpu.set(self._kkt_diag)
+    self._kkt_gpu = self._cp_sparse.csr_matrix(kkt)
+    self._kkt_diag_gpu = self._cp.asarray(self._kkt_diag)
+
+  def update_diag(self, diag: np.ndarray) -> None:
+    super().update_diag(diag)
+    self._kkt_gpu.data.set(self._kkt.data)
+    self._kkt_diag_gpu.set(self._kkt_diag)
 
   def factorize(self):
     cp = self._cp
@@ -145,17 +146,17 @@ class CupyDenseSolver(LinearSolver):
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     cp = self._cp
-    n, m = self._n, self._m
-    if self._A_gpu is None:
-      kkt_dense = kkt.toarray()
-      self._A_gpu = cp.asarray(kkt_dense[:n, n:].T, dtype=cp.float64)
-      P_block = kkt_dense[:n, :n]
-      P_block = P_block + P_block.T - np.diag(np.diag(P_block))
-      np.fill_diagonal(P_block, 0.0)
-      self._P_offdiag_gpu = cp.asarray(P_block, dtype=cp.float64)
-    diag = kkt.diagonal()
-    self._R_x_gpu.set(diag[:n])
-    self._R_y_gpu.set(-diag[n:])
+    n = self._n
+    kkt_dense = kkt.toarray()
+    self._A_gpu = cp.asarray(kkt_dense[:n, n:].T, dtype=cp.float64)
+    P_block = kkt_dense[:n, :n]
+    P_block = P_block + P_block.T - np.diag(np.diag(P_block))
+    np.fill_diagonal(P_block, 0.0)
+    self._P_offdiag_gpu = cp.asarray(P_block, dtype=cp.float64)
+
+  def update_diag(self, diag: np.ndarray) -> None:
+    self._R_x_gpu.set(diag[:self._n])
+    self._R_y_gpu.set(-diag[self._n:])
 
   def factorize(self) -> None:
     cp = self._cp

--- a/src/qtqp/solvers_gpu.py
+++ b/src/qtqp/solvers_gpu.py
@@ -54,11 +54,12 @@ class CuDssSolver(LinearSolver):
     super().set_kkt(kkt)
     self._kkt_gpu = self._cp_sparse.csr_matrix(kkt)
     self._kkt_diag_gpu = self._cp.asarray(self._kkt_diag)
+    self._kkt_diag_idxs_gpu = self._cp.asarray(self._kkt_diag_idxs)
 
   def update_diag(self, diag: np.ndarray) -> None:
-    super().update_diag(diag)
-    self._kkt_gpu.data.set(self._kkt.data)
-    self._kkt_diag_gpu.set(self._kkt_diag)
+    diag_gpu = self._cp.asarray(diag)
+    self._kkt_gpu.data[self._kkt_diag_idxs_gpu] = diag_gpu
+    self._cp.copyto(self._kkt_diag_gpu, diag_gpu)
 
   def factorize(self):
     cp = self._cp

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -98,15 +98,15 @@ class ScipySolver(LinearSolver):
 
   def __init__(self):
     self.factorization = None
-    self._full_kkt: sp.spmatrix | None = None
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     super().set_kkt(kkt)
-    if self._full_kkt is None:
-      self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
-      self._full_diag_idxs = diag_data_indices(self._full_kkt)
-    else:
-      self._full_kkt.data[self._full_diag_idxs] = kkt.diagonal()
+    self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
+    self._full_diag_idxs = diag_data_indices(self._full_kkt)
+
+  def update_diag(self, diag: np.ndarray) -> None:
+    super().update_diag(diag)
+    self._full_kkt.data[self._full_diag_idxs] = diag
 
   def __matmul__(self, x: np.ndarray) -> np.ndarray:
     return self._full_kkt @ x
@@ -152,7 +152,6 @@ class EigenSolver(LinearSolver):
 
     self.nanoeigenpy = nanoeigenpy
     self._solver: nanoeigenpy.SimplicialLDLT | None = None
-    self._lower_diag_idxs: np.ndarray | None = None
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     # Eigen itself supports either triangle, but nanoeigenpy's Python module
@@ -160,13 +159,11 @@ class EigenSolver(LinearSolver):
     # the shared upper-triangular KKT into the lower triangle here.  The base
     # symmetric matvec works with either stored triangle, so we only keep the
     # lower-triangular view.
-    if self._lower_diag_idxs is None:
-      super().set_kkt(kkt.T.tocsc())
-      self._lower_diag_idxs = diag_data_indices(self._kkt)
-    else:
-      diag = kkt.diagonal()
-      self._kkt.data[self._lower_diag_idxs] = diag
-      self._kkt_diag = diag
+    super().set_kkt(kkt.T.tocsc())
+
+  def update_diag(self, diag: np.ndarray) -> None:
+    self._kkt.data[self._kkt_diag_idxs] = diag
+    np.copyto(self._kkt_diag, diag)
 
   def factorize(self):
     if self._solver is None:
@@ -329,15 +326,15 @@ class UmfpackSolver(LinearSolver):
     self._umfpack = umfpack
     self._ctx = umfpack.UmfpackContext("di")
     self._symbolic_done = False
-    self._full_kkt: sp.spmatrix | None = None
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     super().set_kkt(kkt)
-    if self._full_kkt is None:
-      self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
-      self._full_diag_idxs = diag_data_indices(self._full_kkt)
-    else:
-      self._full_kkt.data[self._full_diag_idxs] = kkt.diagonal()
+    self._full_kkt = _full_symmetric_from_upper(kkt, "csc")
+    self._full_diag_idxs = diag_data_indices(self._full_kkt)
+
+  def update_diag(self, diag: np.ndarray) -> None:
+    super().update_diag(diag)
+    self._full_kkt.data[self._full_diag_idxs] = diag
 
   def __matmul__(self, x: np.ndarray) -> np.ndarray:
     return self._full_kkt @ x


### PR DESCRIPTION
## Summary
- Split the `LinearSolver.set_kkt` method into two: `set_kkt(kkt)` called once at init for one-time setup (symbolic analysis, GPU transfer, full-matrix reconstruction), and `update_diag(diag)` called each IPM iteration to write the new diagonal values.
- The base class provides default implementations so backends sharing the KKT reference (Pardiso, QDLDL, CHOLMOD, Accelerate, MUMPS) need no overrides.
- `DirectKktSolver` no longer writes to the scaffold directly or tracks diagonal indices — it just calls `solver.update_diag(reg_diags)`.
- Dense and GPU backends override `update_diag` to update their own storage (R_x/R_y buffers, GPU arrays).
- LU backends (Scipy, UMFPACK) and Eigen override `update_diag` to also update their private full/lower-triangular copies.

## Test plan
- [x] Full test suite (1950 tests) passes locally excluding EIGEN (not installed)
- [x] CHOLMOD (268 tests), Accelerate, SCIPY, UMFPACK, QDLDL, SCIPY_DENSE all pass
- [x] `test_upper_triangular_kkt_matvec_matches_full` passes
- [x] `test_nonsymmetric_p` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)