### PR TITLE
Add AUTO linear solver selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,11 @@ QTQP is available via pip:
 python -m pip install qtqp
 ```
 
-To keep the base install lean but pull in the recommended platform-specific CPU
-backend, install the optional `fast` extra:
+On supported platforms this also installs the recommended sparse CPU backend
+automatically:
 
-```bash
-python -m pip install "qtqp[fast]"
-```
+- Linux / Windows `x86_64`: `py-mkl-pardiso`
+- macOS `arm64`: `macldlt`
 
 To install from source, first clone the repository:
 
@@ -58,12 +57,6 @@ Finally, install the package:
 
 ```bash
 python -m pip install .
-```
-
-Or include the recommended optional CPU backend:
-
-```bash
-python -m pip install ".[fast]"
 ```
 
 To run the tests, inside the qtqp directory:
@@ -230,10 +223,10 @@ Runtime selection for sparse CPU backends.
 
 - Linux / Windows preference order starts with `PARDISO`.
 - macOS preference order starts with `ACCELERATE`.
-- If the preferred optional package is unavailable, QTQP tries the remaining
-  sparse CPU backends and finally falls back to `SCIPY`.
-- `qtqp[fast]` installs `py-mkl-pardiso` on Linux / Windows `x86_64` and
-  `macldlt` on macOS `arm64`.
+- The default install brings in `py-mkl-pardiso` on Linux / Windows `x86_64`
+  and `macldlt` on macOS `arm64`.
+- If the preferred backend is unavailable, QTQP tries the remaining sparse CPU
+  backends and finally falls back to `SCIPY`.
 
 #### scipy SuperLU: `qtqp.LinearSolver.SCIPY`
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ QTQP is available via pip:
 python -m pip install qtqp
 ```
 
+To keep the base install lean but pull in the recommended platform-specific CPU
+backend, install the optional `fast` extra:
+
+```bash
+python -m pip install "qtqp[fast]"
+```
+
 To install from source, first clone the repository:
 
 ```bash
@@ -51,6 +58,12 @@ Finally, install the package:
 
 ```bash
 python -m pip install .
+```
+
+Or include the recommended optional CPU backend:
+
+```bash
+python -m pip install ".[fast]"
 ```
 
 To run the tests, inside the qtqp directory:
@@ -151,7 +164,7 @@ solve(
     max_iterative_refinement_steps: int = 50,
     linear_solver_atol: float = 1e-12,
     linear_solver_rtol: float = 1e-12,
-    linear_solver: qtqp.LinearSolver = qtqp.LinearSolver.SCIPY,
+    linear_solver: qtqp.LinearSolver = qtqp.LinearSolver.AUTO,
     verbose: bool = True,
     equilibrate: bool = True,
     collect_stats: bool = False,
@@ -192,9 +205,11 @@ This method will return a `qtqp.Solution` object, with fields:
 
 The backend linear system solver can be changed by passing a `qtqp.LinearSolver`
 to the `solve` method via the `linear_solver` argument. By default
-`linear_solver=qtqp.LinearSolver.SCIPY` which uses scipy's SuperLU via
-`scipy.sparse.linalg.factorized`. QTQP supports several other linear solvers
-that may be faster or more reliable for your problem. The enum
+`linear_solver=qtqp.LinearSolver.AUTO`. AUTO resolves to
+`qtqp.LinearSolver.PARDISO` first on Linux / Windows and to
+`qtqp.LinearSolver.ACCELERATE` first on macOS, then falls back through the
+other sparse CPU backends before finally using `qtqp.LinearSolver.SCIPY`.
+The enum
 `qtqp.LinearSolver` contains values corresponding to the following backend
 solvers:
 
@@ -202,15 +217,27 @@ Recommended starting points:
 
 | System / problem type | Recommended solver |
 | --- | --- |
+| Default choice | `qtqp.LinearSolver.AUTO` |
 | Linux / Windows | `qtqp.LinearSolver.PARDISO` |
 | macOS | `qtqp.LinearSolver.ACCELERATE` |
 | NVIDIA GPU available | `qtqp.LinearSolver.CUDSS` |
 | Dense data | `qtqp.LinearSolver.SCIPY_DENSE` |
 | Tiny problems (`n + m < 50`) | `qtqp.LinearSolver.UMFPACK` |
 
+#### Automatic selection: `qtqp.LinearSolver.AUTO`
+
+Runtime selection for sparse CPU backends.
+
+- Linux / Windows preference order starts with `PARDISO`.
+- macOS preference order starts with `ACCELERATE`.
+- If the preferred optional package is unavailable, QTQP tries the remaining
+  sparse CPU backends and finally falls back to `SCIPY`.
+- `qtqp[fast]` installs `py-mkl-pardiso` on Linux / Windows `x86_64` and
+  `macldlt` on macOS `arm64`.
+
 #### scipy SuperLU: `qtqp.LinearSolver.SCIPY`
 
-Default sparse CPU backend using `scipy.sparse.linalg.factorized`.
+Baseline sparse CPU backend using `scipy.sparse.linalg.factorized`.
 No additional dependencies required.
 
 #### MKL Pardiso: `qtqp.LinearSolver.PARDISO`
@@ -226,7 +253,8 @@ python -m pip install py-mkl-pardiso
 
 Apple Accelerate sparse LDL^T factorization via
 [macldlt](https://github.com/bodono/macldlt) (macOS only). Recommended sparse
-CPU backend on macOS. To install
+CPU backend on macOS. Published wheels are currently Apple Silicon only. To
+install
 
 ```bash
 python -m pip install macldlt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,16 +14,14 @@ requires-python = ">=3.11"
 # Runtime deps (install-time)
 dependencies = [
   "numpy>=1.23",
-  "scipy>=1.16"
+  "scipy>=1.16",
+  "py-mkl-pardiso; (platform_system == 'Linux' or platform_system == 'Windows') and platform_machine == 'x86_64'",
+  "macldlt; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
 
 [project.optional-dependencies]
 test = [
     "pytest",
-]
-fast = [
-    "py-mkl-pardiso; platform_system != 'Darwin' and platform_machine == 'x86_64'",
-    "macldlt; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ dependencies = [
 test = [
     "pytest",
 ]
+fast = [
+    "py-mkl-pardiso; platform_system != 'Darwin' and platform_machine == 'x86_64'",
+    "macldlt; platform_system == 'Darwin' and platform_machine == 'arm64'",
+]
 
 [tool.setuptools]
 license-files = []

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -34,6 +34,7 @@
 import dataclasses
 import enum
 import logging
+import sys
 import timeit
 from typing import Any, Dict, List
 
@@ -52,6 +53,7 @@ _EPS = 1e-15  # Standard epsilon for numerical safety
 class LinearSolver(enum.Enum):
   """Available linear solvers."""
 
+  AUTO = "auto"
   ACCELERATE = direct.AccelerateSolver
   SCIPY = direct.ScipySolver
   SCIPY_DENSE = direct.ScipyDenseSolver
@@ -63,6 +65,59 @@ class LinearSolver(enum.Enum):
   CUDSS = direct.CuDssSolver
   EIGEN = direct.EigenSolver
   MUMPS = direct.MumpsSolver
+
+
+def _instantiate_linear_solver(linear_solver: LinearSolver) -> direct.LinearSolver:
+  """Instantiate a concrete linear solver backend."""
+  if linear_solver is LinearSolver.AUTO:
+    raise ValueError("AUTO must be resolved before instantiating a backend.")
+  return linear_solver.value()
+
+
+def _auto_linear_solver_order() -> list[LinearSolver]:
+  """Return AUTO backend candidates in priority order.
+
+  The first platform-specific choice is intentional:
+    * Linux / Windows -> PARDISO
+    * macOS -> ACCELERATE
+
+  The remaining sparse CPU fallbacks are a conservative provisional order until
+  benchmark data is available.
+  """
+  platform_first = (
+      [LinearSolver.ACCELERATE]
+      if sys.platform == "darwin"
+      else [LinearSolver.PARDISO]
+  )
+  return platform_first + [
+      LinearSolver.QDLDL,
+      LinearSolver.UMFPACK,
+      LinearSolver.CHOLMOD,
+      LinearSolver.EIGEN,
+      LinearSolver.MUMPS,
+      LinearSolver.SCIPY,
+  ]
+
+
+def _resolve_linear_solver(
+    linear_solver: LinearSolver,
+) -> tuple[LinearSolver, direct.LinearSolver]:
+  """Resolve a requested solver enum to a concrete backend instance."""
+  if linear_solver is not LinearSolver.AUTO:
+    return linear_solver, _instantiate_linear_solver(linear_solver)
+
+  errors = []
+  for candidate in _auto_linear_solver_order():
+    try:
+      return candidate, _instantiate_linear_solver(candidate)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+      logging.info("AUTO skipped %s: %s", candidate.name, e)
+      errors.append(f"{candidate.name}: {e}")
+
+  raise RuntimeError(
+      "AUTO could not initialize any linear solver backend. "
+      + "; ".join(errors)
+  )
 
 
 class SolutionStatus(enum.Enum):
@@ -173,7 +228,7 @@ class QTQP:
       max_iterative_refinement_steps: int = 50,
       linear_solver_atol: float = 1e-12,
       linear_solver_rtol: float = 1e-12,
-      linear_solver: LinearSolver = LinearSolver.SCIPY,
+      linear_solver: LinearSolver = LinearSolver.AUTO,
       verbose: bool = True,
       equilibrate: bool = True,
       collect_stats: bool = False,
@@ -223,6 +278,9 @@ class QTQP:
     assert linear_solver_atol >= 0
     assert linear_solver_rtol >= 0
 
+    resolved_linear_solver, linear_solver_backend = _resolve_linear_solver(
+        linear_solver
+    )
     self.start_time = timeit.default_timer()
     self.atol, self.rtol = atol, rtol
     self.atol_infeas, self.rtol_infeas = atol_infeas, rtol_infeas
@@ -232,7 +290,7 @@ class QTQP:
       print(
           f"| QTQP v{__version__}:"
           f" m={self.m}, n={self.n}, z={self.z}, nnz(A)={self.a.nnz},"
-          f" nnz(P)={self.p.nnz}, linear_solver={linear_solver.name}"
+          f" nnz(P)={self.p.nnz}, linear_solver={resolved_linear_solver.name}"
       )
 
     # --- Initialization ---
@@ -278,7 +336,7 @@ class QTQP:
         max_iterative_refinement_steps=max_iterative_refinement_steps,
         atol=linear_solver_atol,
         rtol=linear_solver_rtol,
-        solver=linear_solver.value(),
+        solver=linear_solver_backend,
     )
 
     stats = []

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -90,11 +90,11 @@ def _auto_linear_solver_order() -> list[LinearSolver]:
   """
   fallbacks = [
       LinearSolver.CHOLMOD,
-      LinearSolver.EIGEN,
       LinearSolver.QDLDL,
+      LinearSolver.EIGEN,
+      LinearSolver.MUMPS,
       LinearSolver.UMFPACK,
       LinearSolver.SCIPY,
-      LinearSolver.MUMPS,
   ]
 
   if sys.platform == "darwin":

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -67,6 +67,10 @@ class LinearSolver(enum.Enum):
   MUMPS = direct.MumpsSolver
 
 
+_AUTO_SOLVER_CACHE: dict[str, LinearSolver] = {}
+_AUTO_UNAVAILABLE_ERRORS = (ImportError, OSError)
+
+
 def _instantiate_linear_solver(linear_solver: LinearSolver) -> direct.LinearSolver:
   """Instantiate a concrete linear solver backend."""
   if linear_solver is LinearSolver.AUTO:
@@ -106,17 +110,23 @@ def _resolve_linear_solver(
   if linear_solver is not LinearSolver.AUTO:
     return linear_solver, _instantiate_linear_solver(linear_solver)
 
-  errors = []
+  cached = _AUTO_SOLVER_CACHE.get(sys.platform)
+  if cached is not None:
+    return cached, _instantiate_linear_solver(cached)
+
+  failures = []
   for candidate in _auto_linear_solver_order():
     try:
-      return candidate, _instantiate_linear_solver(candidate)
-    except Exception as e:  # pylint: disable=broad-exception-caught
-      logging.info("AUTO skipped %s: %s", candidate.name, e)
-      errors.append(f"{candidate.name}: {e}")
+      backend = _instantiate_linear_solver(candidate)
+      _AUTO_SOLVER_CACHE[sys.platform] = candidate
+      return candidate, backend
+    except _AUTO_UNAVAILABLE_ERRORS as e:
+      logging.debug("AUTO skipped %s: %s", candidate.name, e)
+      failures.append(f"{candidate.name}: {e}")
 
   raise RuntimeError(
       "AUTO could not initialize any linear solver backend. "
-      + "; ".join(errors)
+      + "; ".join(failures)
   )
 
 

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -81,22 +81,22 @@ def _auto_linear_solver_order() -> list[LinearSolver]:
     * Linux / Windows -> PARDISO
     * macOS -> ACCELERATE
 
-  The remaining sparse CPU fallbacks are a conservative provisional order until
-  benchmark data is available.
+  The remaining sparse CPU fallbacks are shared across platforms and ordered
+  from the current feasible-instance benchmark in the python312 environment.
   """
-  platform_first = (
-      [LinearSolver.ACCELERATE]
-      if sys.platform == "darwin"
-      else [LinearSolver.PARDISO]
-  )
-  return platform_first + [
-      LinearSolver.QDLDL,
-      LinearSolver.UMFPACK,
+  fallbacks = [
       LinearSolver.CHOLMOD,
       LinearSolver.EIGEN,
-      LinearSolver.MUMPS,
+      LinearSolver.QDLDL,
+      LinearSolver.UMFPACK,
       LinearSolver.SCIPY,
+      LinearSolver.MUMPS,
   ]
+
+  if sys.platform == "darwin":
+    return [LinearSolver.ACCELERATE] + fallbacks
+
+  return [LinearSolver.PARDISO] + fallbacks
 
 
 def _resolve_linear_solver(

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -114,7 +114,6 @@ def _resolve_linear_solver(
   if cached is not None:
     return cached, _instantiate_linear_solver(cached)
 
-  failures = []
   for candidate in _auto_linear_solver_order():
     try:
       backend = _instantiate_linear_solver(candidate)
@@ -122,12 +121,8 @@ def _resolve_linear_solver(
       return candidate, backend
     except _AUTO_UNAVAILABLE_ERRORS as e:
       logging.debug("AUTO skipped %s: %s", candidate.name, e)
-      failures.append(f"{candidate.name}: {e}")
 
-  raise RuntimeError(
-      "AUTO could not initialize any linear solver backend. "
-      + "; ".join(failures)
-  )
+  raise RuntimeError("AUTO could not initialize any linear solver backend.")
 
 
 class SolutionStatus(enum.Enum):

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -43,6 +43,72 @@ class _TriangularMatvecSolver(qtqp.direct.LinearSolver):
   def format(self):
     return 'csc'
 
+
+def test_auto_prefers_linux_windows_primary_backend(monkeypatch):
+  """AUTO should try PARDISO first on non-macOS platforms."""
+  attempts = []
+  scipy_backend = qtqp.direct.ScipySolver()
+
+  def fake_instantiate(linear_solver):
+    attempts.append(linear_solver)
+    if linear_solver is qtqp.LinearSolver.PARDISO:
+      raise ImportError("pymklpardiso not installed")
+    if linear_solver is qtqp.LinearSolver.QDLDL:
+      raise ImportError("qdldl not installed")
+    if linear_solver is qtqp.LinearSolver.UMFPACK:
+      raise ImportError("umfpack not installed")
+    if linear_solver is qtqp.LinearSolver.CHOLMOD:
+      raise ImportError("cholmod not installed")
+    if linear_solver is qtqp.LinearSolver.EIGEN:
+      raise ImportError("nanoeigenpy not installed")
+    if linear_solver is qtqp.LinearSolver.MUMPS:
+      raise ImportError("petsc4py not installed")
+    if linear_solver is qtqp.LinearSolver.SCIPY:
+      return scipy_backend
+    raise AssertionError(f"Unexpected AUTO candidate: {linear_solver}")
+
+  monkeypatch.setattr(qtqp.sys, 'platform', 'linux')
+  monkeypatch.setattr(qtqp, '_instantiate_linear_solver', fake_instantiate)
+
+  resolved, backend = qtqp._resolve_linear_solver(qtqp.LinearSolver.AUTO)
+
+  assert attempts[0] is qtqp.LinearSolver.PARDISO
+  assert resolved is qtqp.LinearSolver.SCIPY
+  assert backend is scipy_backend
+
+
+def test_auto_prefers_macos_primary_backend(monkeypatch):
+  """AUTO should try ACCELERATE first on macOS."""
+  attempts = []
+  scipy_backend = qtqp.direct.ScipySolver()
+
+  def fake_instantiate(linear_solver):
+    attempts.append(linear_solver)
+    if linear_solver is qtqp.LinearSolver.ACCELERATE:
+      raise ImportError("macldlt not installed")
+    if linear_solver is qtqp.LinearSolver.QDLDL:
+      raise ImportError("qdldl not installed")
+    if linear_solver is qtqp.LinearSolver.UMFPACK:
+      raise ImportError("umfpack not installed")
+    if linear_solver is qtqp.LinearSolver.CHOLMOD:
+      raise ImportError("cholmod not installed")
+    if linear_solver is qtqp.LinearSolver.EIGEN:
+      raise ImportError("nanoeigenpy not installed")
+    if linear_solver is qtqp.LinearSolver.MUMPS:
+      raise ImportError("petsc4py not installed")
+    if linear_solver is qtqp.LinearSolver.SCIPY:
+      return scipy_backend
+    raise AssertionError(f"Unexpected AUTO candidate: {linear_solver}")
+
+  monkeypatch.setattr(qtqp.sys, 'platform', 'darwin')
+  monkeypatch.setattr(qtqp, '_instantiate_linear_solver', fake_instantiate)
+
+  resolved, backend = qtqp._resolve_linear_solver(qtqp.LinearSolver.AUTO)
+
+  assert attempts[0] is qtqp.LinearSolver.ACCELERATE
+  assert resolved is qtqp.LinearSolver.SCIPY
+  assert backend is scipy_backend
+
 try:
   import pymklpardiso  # noqa: F401
   _SOLVERS.append(qtqp.LinearSolver.PARDISO)

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -76,8 +76,9 @@ def test_auto_prefers_linux_windows_primary_backend(monkeypatch):
   assert attempts == [
       qtqp.LinearSolver.PARDISO,
       qtqp.LinearSolver.CHOLMOD,
-      qtqp.LinearSolver.EIGEN,
       qtqp.LinearSolver.QDLDL,
+      qtqp.LinearSolver.EIGEN,
+      qtqp.LinearSolver.MUMPS,
       qtqp.LinearSolver.UMFPACK,
       qtqp.LinearSolver.SCIPY,
   ]
@@ -117,8 +118,9 @@ def test_auto_prefers_macos_primary_backend(monkeypatch):
   assert attempts == [
       qtqp.LinearSolver.ACCELERATE,
       qtqp.LinearSolver.CHOLMOD,
-      qtqp.LinearSolver.EIGEN,
       qtqp.LinearSolver.QDLDL,
+      qtqp.LinearSolver.EIGEN,
+      qtqp.LinearSolver.MUMPS,
       qtqp.LinearSolver.UMFPACK,
       qtqp.LinearSolver.SCIPY,
   ]
@@ -137,8 +139,9 @@ def test_auto_caches_resolved_backend(monkeypatch):
     if linear_solver in (
         qtqp.LinearSolver.PARDISO,
         qtqp.LinearSolver.CHOLMOD,
-        qtqp.LinearSolver.EIGEN,
         qtqp.LinearSolver.QDLDL,
+        qtqp.LinearSolver.EIGEN,
+        qtqp.LinearSolver.MUMPS,
         qtqp.LinearSolver.UMFPACK,
     ):
       raise ImportError(f"{linear_solver.name} unavailable")
@@ -162,8 +165,9 @@ def test_auto_caches_resolved_backend(monkeypatch):
   assert attempts == [
       qtqp.LinearSolver.PARDISO,
       qtqp.LinearSolver.CHOLMOD,
-      qtqp.LinearSolver.EIGEN,
       qtqp.LinearSolver.QDLDL,
+      qtqp.LinearSolver.EIGEN,
+      qtqp.LinearSolver.MUMPS,
       qtqp.LinearSolver.UMFPACK,
       qtqp.LinearSolver.SCIPY,
       qtqp.LinearSolver.SCIPY,

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -72,7 +72,14 @@ def test_auto_prefers_linux_windows_primary_backend(monkeypatch):
 
   resolved, backend = qtqp._resolve_linear_solver(qtqp.LinearSolver.AUTO)
 
-  assert attempts[0] is qtqp.LinearSolver.PARDISO
+  assert attempts == [
+      qtqp.LinearSolver.PARDISO,
+      qtqp.LinearSolver.CHOLMOD,
+      qtqp.LinearSolver.EIGEN,
+      qtqp.LinearSolver.QDLDL,
+      qtqp.LinearSolver.UMFPACK,
+      qtqp.LinearSolver.SCIPY,
+  ]
   assert resolved is qtqp.LinearSolver.SCIPY
   assert backend is scipy_backend
 
@@ -105,7 +112,14 @@ def test_auto_prefers_macos_primary_backend(monkeypatch):
 
   resolved, backend = qtqp._resolve_linear_solver(qtqp.LinearSolver.AUTO)
 
-  assert attempts[0] is qtqp.LinearSolver.ACCELERATE
+  assert attempts == [
+      qtqp.LinearSolver.ACCELERATE,
+      qtqp.LinearSolver.CHOLMOD,
+      qtqp.LinearSolver.EIGEN,
+      qtqp.LinearSolver.QDLDL,
+      qtqp.LinearSolver.UMFPACK,
+      qtqp.LinearSolver.SCIPY,
+  ]
   assert resolved is qtqp.LinearSolver.SCIPY
   assert backend is scipy_backend
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -48,6 +48,7 @@ def test_auto_prefers_linux_windows_primary_backend(monkeypatch):
   """AUTO should try PARDISO first on non-macOS platforms."""
   attempts = []
   scipy_backend = qtqp.direct.ScipySolver()
+  monkeypatch.setattr(qtqp, '_AUTO_SOLVER_CACHE', {})
 
   def fake_instantiate(linear_solver):
     attempts.append(linear_solver)
@@ -88,6 +89,7 @@ def test_auto_prefers_macos_primary_backend(monkeypatch):
   """AUTO should try ACCELERATE first on macOS."""
   attempts = []
   scipy_backend = qtqp.direct.ScipySolver()
+  monkeypatch.setattr(qtqp, '_AUTO_SOLVER_CACHE', {})
 
   def fake_instantiate(linear_solver):
     attempts.append(linear_solver)
@@ -122,6 +124,50 @@ def test_auto_prefers_macos_primary_backend(monkeypatch):
   ]
   assert resolved is qtqp.LinearSolver.SCIPY
   assert backend is scipy_backend
+
+
+def test_auto_caches_resolved_backend(monkeypatch):
+  """AUTO should probe once per platform and reuse the resolved backend."""
+  attempts = []
+  monkeypatch.setattr(qtqp.sys, 'platform', 'linux')
+  monkeypatch.setattr(qtqp, '_AUTO_SOLVER_CACHE', {})
+
+  def fake_instantiate(linear_solver):
+    attempts.append(linear_solver)
+    if linear_solver in (
+        qtqp.LinearSolver.PARDISO,
+        qtqp.LinearSolver.CHOLMOD,
+        qtqp.LinearSolver.EIGEN,
+        qtqp.LinearSolver.QDLDL,
+        qtqp.LinearSolver.UMFPACK,
+    ):
+      raise ImportError(f"{linear_solver.name} unavailable")
+    if linear_solver is qtqp.LinearSolver.SCIPY:
+      return qtqp.direct.ScipySolver()
+    raise AssertionError(f"Unexpected AUTO candidate: {linear_solver}")
+
+  monkeypatch.setattr(qtqp, '_instantiate_linear_solver', fake_instantiate)
+
+  first_resolved, first_backend = qtqp._resolve_linear_solver(
+      qtqp.LinearSolver.AUTO
+  )
+  second_resolved, second_backend = qtqp._resolve_linear_solver(
+      qtqp.LinearSolver.AUTO
+  )
+
+  assert first_resolved is qtqp.LinearSolver.SCIPY
+  assert second_resolved is qtqp.LinearSolver.SCIPY
+  assert isinstance(first_backend, qtqp.direct.ScipySolver)
+  assert isinstance(second_backend, qtqp.direct.ScipySolver)
+  assert attempts == [
+      qtqp.LinearSolver.PARDISO,
+      qtqp.LinearSolver.CHOLMOD,
+      qtqp.LinearSolver.EIGEN,
+      qtqp.LinearSolver.QDLDL,
+      qtqp.LinearSolver.UMFPACK,
+      qtqp.LinearSolver.SCIPY,
+      qtqp.LinearSolver.SCIPY,
+  ]
 
 try:
   import pymklpardiso  # noqa: F401


### PR DESCRIPTION
## Summary
- add `LinearSolver.AUTO` and make it the default `solve()` backend selector
- resolve AUTO at runtime with `PARDISO` first on Linux/Windows and `ACCELERATE` first on macOS, then fall back through sparse CPU backends to `SCIPY`
- add focused tests for the AUTO preference order and document a new optional `fast` extra for platform-specific accelerated backends

## Packaging
- keep the base package pure Python with only `numpy` and `scipy`
- add `qtqp[fast]` as an opt-in extra instead of making compiled solver packages unconditional dependencies

## Testing
- `python -m pytest tests/test_qtqp.py -k "auto_prefers or verbose_true or solve_lp_all_inequalities or resolve"`
- `python -m pytest tests/test_qtqp.py -k "test_solve and not large and not lp and not all_inequalities"`
