### PR TITLE
Stabilize tau solve in homogeneous embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ solve(
     max_iter: int = 100,
     step_size_scale: float = 0.99,
     min_static_regularization: float = 1e-8,
-    max_iterative_refinement_steps: int = 50,
+    max_iterative_refinement_steps: int = 10,
     linear_solver_atol: float = 1e-12,
     linear_solver_rtol: float = 1e-12,
     linear_solver: qtqp.LinearSolver = qtqp.LinearSolver.AUTO,
@@ -174,7 +174,8 @@ Key parameters:
     interior.
 -   `min_static_regularization`: Diagonal regularization on KKT for robustness.
 -   `max_iterative_refinement_steps`, `linear_solver_atol/rtol`: Control
-    iterative refinement of the linear solve.
+    iterative refinement of the linear solve. The default is 10 refinement
+    steps, counting the initial solve.
 -   `linear_solver`: (`qtqp.LinearSolver`) Choose the KKT solver backend (see
     below).
 -   `verbose`: Print per-iteration table with key metrics.

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -706,15 +706,8 @@ class QTQP:
 
     # Tau solve: exact quadratic when KKT solve converged, linearized
     # fallback when noisy (avoids squaring O(eps) into O(eps^2)).
-    # Exception: once mu drops below the static regularization floor, the
-    # linearized fallback is itself unstable -- the factored KKT uses the
-    # regularized diagonal, and the O(reg) gap iterative refinement must
-    # cancel becomes comparable to or larger than mu, so kinv_r carries
-    # reg-scale noise that the first-order linearization cannot reject.
-    # In that regime we trust the quadratic's structural clamps instead.
     tau_plus = None
-    reg = self._linear_solver.min_static_regularization
-    if lin_sys_stats["converged"] or mu < reg:
+    if lin_sys_stats["converged"]:
       try:
         r_tau = (mu - mu_target) * tau_anchor
         tau_plus = self._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -719,8 +719,7 @@ class QTQP:
       lin_sys_stats["tau_method"] = "linearized"
       logging.debug("Using linearized tau fallback.")
       tau_plus = self._solve_for_tau_linearized_fallback(
-          p, kinv_r, self.kinv_q, mu, mu_target,
-          np.concatenate([x, y]), tau, tau_anchor,
+          p, kinv_r, mu, mu_target, x, y, tau, tau_anchor,
       )
 
     # Reconstruct [x+; y+] = kinv_r - kinv_q * tau+ (in-place on kinv_r).
@@ -780,41 +779,44 @@ class QTQP:
     return tau_sol
 
   def _solve_for_tau_linearized_fallback(
-      self, p, kinv_r, kinv_q, mu, mu_target, z_curr, tau_curr, tau_anchor,
-      *, clamp_to_current_tau_range=True,
+      self, p, kinv_r, mu, mu_target, x, y, tau_curr, tau_anchor,
   ) -> float:
     """Linearized fallback for tau via first-order Taylor expansion of G(z,tau).
 
-    Replaces the exact quadratic with a linearization around (z_curr, tau_curr).
-    P only multiplies the safe current iterate x_curr, so KKT noise enters
-    linearly rather than quadratically. A [0.1x, 10x] trust region prevents
-    manifold drift from the first-order approximation.
+    Replaces the exact quadratic with a linearization around z_curr = [x; y]
+    and tau_curr. P only multiplies the safe current iterate x, so KKT noise
+    enters linearly rather than quadratically. A [0.1x, 10x] trust region
+    prevents manifold drift from the first-order approximation.
     """
     n = self.n
-    q = self.q
-    r_z = kinv_r - tau_curr * kinv_q - z_curr
-    px = p @ z_curr[:n] if p.nnz > 0 else np.zeros(n)
+    q, kinv_q = self.q, self.kinv_q
+
+    px = p @ x if p.nnz > 0 else np.zeros(n)
+
+    # Scalar inner products; avoids allocating z_curr = [x; y] or r_z.
+    q_z = q[:n] @ x + q[n:] @ y
+    x_px = x @ px
+    q_kinv_q = q @ kinv_q
+    px_kinv_q = px @ kinv_q[:n]
+    # r_z = kinv_r - tau_curr * kinv_q - z_curr, collapsed into scalar dots.
+    q_rz = q @ kinv_r - tau_curr * q_kinv_q - q_z
+    px_rz = px @ kinv_r[:n] - tau_curr * px_kinv_q - x_px
 
     # Base residual G(z_curr, tau_curr).
-    q_z = q @ z_curr
     g = (mu * tau_curr**2 + (mu_target - mu) * tau_anchor * tau_curr
-         - tau_curr * q_z - mu_target - z_curr[:n] @ px)
+         - tau_curr * q_z - mu_target - x_px)
 
     # Numerator: G + (dG/dz) @ r_z.  Denominator: dG/dtau - (dG/dz) @ kinv_q.
-    num = g - tau_curr * (q @ r_z) - 2.0 * (px @ r_z[:n])
+    num = g - tau_curr * q_rz - 2.0 * px_rz
     den = (2.0 * mu * tau_curr + (mu_target - mu) * tau_anchor - q_z
-           + tau_curr * (q @ kinv_q) + 2.0 * (px @ kinv_q[:n]))
+           + tau_curr * q_kinv_q + 2.0 * px_kinv_q)
 
     tau_sol = tau_curr + (0.0 if abs(den) < 1e-16 else -num / den)
 
     if not np.isfinite(tau_sol):
       logging.warning("Linearized tau fallback non-finite; using current tau.")
-      tau_sol = tau_curr
-    elif clamp_to_current_tau_range:
-      tau_sol = max(tau_sol, 0.1 * tau_curr)
-      tau_sol = min(tau_sol, 10.0 * tau_curr)
-
-    return tau_sol
+      return tau_curr
+    return min(max(tau_sol, 0.1 * tau_curr), 10.0 * tau_curr)
 
   def _normalize(self, x, y, tau, s):
     """Normalizes iterates to match the homogeneous embedding central path norm.

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -315,7 +315,7 @@ class QTQP:
       max_iter: int = 100,
       step_size_scale: float = 0.99,
       min_static_regularization: float = 1e-8,
-      max_iterative_refinement_steps: int = 50,
+      max_iterative_refinement_steps: int = 10,
       linear_solver_atol: float = 1e-12,
       linear_solver_rtol: float = 1e-12,
       linear_solver: LinearSolver = LinearSolver.AUTO,
@@ -394,9 +394,7 @@ class QTQP:
     y[self.z :] = 1.0
     s[self.z :] = 1.0
 
-    # tau is homogeneous embedding variable. Kept as 1-element array for
-    # consistent vector operations (e.g., @ operator).
-    tau = np.array([1.0])
+    tau = 1.0
 
     if self.equilibrate:
       a, p, b, c, self.d, self.e = self._equilibrate()
@@ -488,6 +486,7 @@ class QTQP:
           mu_target=0.0,
           r_anchor=xy,
           tau_anchor=tau,
+          x=x,
           y=y,
           s=s,
           tau=tau,
@@ -524,6 +523,7 @@ class QTQP:
           mu_target=sigma * mu,
           r_anchor=xy,
           tau_anchor=tau_p,
+          x=x,
           y=y,
           s=s,
           tau=tau,
@@ -550,7 +550,7 @@ class QTQP:
       # Ensure variables stay strictly in the cone to prevent numerical issues.
       y[self.z :] = np.maximum(y[self.z :], 1e-30)
       s[self.z :] = np.maximum(s[self.z :], 1e-30)
-      tau = np.maximum(tau, 1e-30)
+      tau = max(tau, 1e-30)
 
     # We have terminated for one reason or another.
     self._linear_solver.free()
@@ -664,7 +664,7 @@ class QTQP:
     # allocations. Equivalent to: normalize then compute (y @ s) / (m - z).
     # scale = sqrt(m-z+1) / max(_EPS, ||(x,y,tau)||), so scale^2 = (m-z+1) /
     # max(_EPS^2, ||(x,y,tau)||^2), giving mu_aff = scale^2 * (y_aff @ s_aff).
-    xyt_norm_sq = x_aff @ x_aff + y_aff @ y_aff + tau_aff @ tau_aff
+    xyt_norm_sq = x_aff @ x_aff + y_aff @ y_aff + tau_aff ** 2
     scale_sq = (self.m - self.z + 1) / max(_EPS**2, xyt_norm_sq)
     mu_aff = scale_sq * (y_aff @ s_aff) / (self.m - self.z)
 
@@ -676,7 +676,8 @@ class QTQP:
     return np.clip(sigma, 0.0, 1.0)
 
   def _newton_step(
-      self, *, p, mu, mu_target, r_anchor, tau_anchor, y, s, tau, correction
+      self, *, p, mu, mu_target, r_anchor, tau_anchor, x, y, s, tau,
+      correction,
   ):
     """Computes a Newton search direction by solving the augmented KKT system.
 
@@ -686,19 +687,9 @@ class QTQP:
     tau+ is then pinned by substituting this back into the tau equation of the
     homogeneous embedding (see _solve_for_tau).
 
-    Args:
-      p: The quadratic cost matrix.
-      mu: Current barrier parameter.
-      mu_target: Complementarity target for this step (0 for predictor,
-        sigma*mu for corrector).
-      r_anchor: The current [x; y] iterate (as a single vector), used to
-        form the Newton RHS via r = (mu - mu_target) * r_anchor + ...
-      tau_anchor: The current tau iterate.
-      y: Current dual variables.
-      s: Current slack variables.
-      tau: Current homogeneous variable (used as fallback if tau solve fails).
-      correction: Optional Mehrotra second-order correction added to the
-        complementarity block of the RHS.
+    Uses the exact quadratic tau solve when the KKT solve is accurate, and a
+    linearized fallback (avoids squaring solver noise) when it's noisy or the
+    quadratic residual check fails.
     """
     # Prepare RHS for the linear system.
     r = (mu - mu_target) * r_anchor
@@ -713,23 +704,31 @@ class QTQP:
         warm_start=r_anchor,
     )
 
-    # Solve the 1D quadratic equation for the homogeneous tau component
-    try:
-      r_tau = (mu - mu_target) * tau_anchor
-      tau_plus = self._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)
-    except ValueError as e:
-      # Fallback if quadratic solve fails numerically (rare but possible)
-      logging.warning("Tau solve failed, using previous tau. Error: %s", e)
-      tau_plus = tau
+    # Tau solve: exact quadratic when KKT solve converged, linearized
+    # fallback when noisy (avoids squaring O(eps) into O(eps^2)).
+    tau_plus = None
+    if lin_sys_stats["converged"]:
+      try:
+        r_tau = (mu - mu_target) * tau_anchor
+        tau_plus = self._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)
+        lin_sys_stats["tau_method"] = "quadratic"
+      except ValueError:
+        logging.debug("Primary tau solve failed; falling back to linearized.")
 
-    # Reconstruct full (x, y) solution by combining the parametric KKT components:
-    #   [x+; y+] = kinv_r - kinv_q * tau+
-    # Perform this in-place on kinv_r to avoid another large allocation.
+    if tau_plus is None:
+      lin_sys_stats["tau_method"] = "linearized"
+      logging.debug("Using linearized tau fallback.")
+      tau_plus = self._solve_for_tau_linearized_fallback(
+          p, kinv_r, self.kinv_q, mu, mu_target,
+          np.concatenate([x, y]), tau, tau_anchor,
+      )
+
+    # Reconstruct [x+; y+] = kinv_r - kinv_q * tau+ (in-place on kinv_r).
     kinv_r -= self.kinv_q * tau_plus
     x_plus, y_plus = kinv_r[: self.n], kinv_r[self.n :]
     return x_plus, y_plus, tau_plus, lin_sys_stats
 
-  def _solve_for_tau(self, p, kinv_r, mu, mu_target, r_tau) -> np.ndarray:
+  def _solve_for_tau(self, p, kinv_r, mu, mu_target, r_tau) -> float:
     """Solves for tau+ using the homogeneous embedding's tau equation.
 
     The parametric KKT solution is:
@@ -739,17 +738,16 @@ class QTQP:
         t_a * tau+^2 + t_b * tau+ + t_c = 0
 
     The coefficients t_a, t_b, t_c are computed from inner products of kinv_r
-    and kinv_q with q and P. For LPs (P=0) the P terms drop out. We always take
-    the positive root since tau >= 0 is required for the embedding to represent
-    a feasible point (tau=0 corresponds to a certificate of infeasibility or
-    unboundedness, which is handled separately at termination).
+    and kinv_q with q and P. For LPs (P=0) the P terms drop out. The
+    coefficients are clamped to enforce structural signs (t_a > 0, t_c <= 0),
+    and Muller's stable quadratic formula avoids catastrophic cancellation.
     """
-    # Coefficients of the quadratic t_a * tau+^2 + t_b * tau+ + t_c = 0.
     n = self.n
     q, kinv_q = self.q, self.kinv_q
 
+    # Coefficients of the quadratic t_a * tau+^2 + t_b * tau+ + t_c = 0
     t_a = mu + kinv_q @ q
-    t_b = -r_tau[0] - kinv_r @ q
+    t_b = -r_tau - kinv_r @ q
     t_c = -mu_target
     if p.nnz > 0:
       # Memory access for the sparse matrix P is the bottleneck here.
@@ -759,22 +757,64 @@ class QTQP:
       t_a -= kinv_q[:n] @ p_kinv_q
       t_b += kinv_r[:n] @ p_kinv_q + kinv_q[:n] @ p_kinv_r
       t_c -= kinv_r[:n] @ p_kinv_r
-    logging.debug("t_a=%s, t_b=%s, t_c=%s", t_a, t_b, t_c)
 
-    # Standard quadratic formula for the positive root
-    if abs(t_a) < _EPS:
-      raise ValueError(f"Near-zero t_a={t_a}, cannot solve for tau")
+    # Enforce structural signs
+    t_a = max(t_a, mu)
+    t_c = min(t_c, -mu_target)
 
     discriminant = t_b**2 - 4 * t_a * t_c
-    if discriminant < -1e-9:
-      raise ValueError(f"Negative discriminant: {discriminant}")
+    if discriminant < 0.0:
+      discriminant = 0.0
 
-    tau_sol = (-t_b + math.sqrt(max(0.0, discriminant))) / (2 * t_a)
+    # Stable Quadratic Formula (Muller)
+    if t_b > 0:
+      q_muller = -0.5 * (t_b + math.sqrt(discriminant))
+      tau_sol = t_c / q_muller
+    else:
+      q_muller = -0.5 * (t_b - math.sqrt(discriminant))
+      tau_sol = q_muller / t_a
 
-    if not np.isfinite(tau_sol) or tau_sol < -1e-10:
-      raise ValueError(f"Invalid tau solution found: {tau_sol}")
+    if not np.isfinite(tau_sol) or tau_sol < 0.0:
+      raise ValueError(f"Invalid tau solution: {tau_sol}")
 
-    return np.array([max(0.0, tau_sol)])
+    return tau_sol
+
+  def _solve_for_tau_linearized_fallback(
+      self, p, kinv_r, kinv_q, mu, mu_target, z_curr, tau_curr, tau_anchor,
+      *, clamp_to_current_tau_range=True,
+  ) -> float:
+    """Linearized fallback for tau via first-order Taylor expansion of G(z,tau).
+
+    Replaces the exact quadratic with a linearization around (z_curr, tau_curr).
+    P only multiplies the safe current iterate x_curr, so KKT noise enters
+    linearly rather than quadratically. A [0.1x, 10x] trust region prevents
+    manifold drift from the first-order approximation.
+    """
+    n = self.n
+    q = self.q
+    r_z = kinv_r - tau_curr * kinv_q - z_curr
+    px = p @ z_curr[:n] if p.nnz > 0 else np.zeros(n)
+
+    # Base residual G(z_curr, tau_curr).
+    q_z = q @ z_curr
+    g = (mu * tau_curr**2 + (mu_target - mu) * tau_anchor * tau_curr
+         - tau_curr * q_z - mu_target - z_curr[:n] @ px)
+
+    # Numerator: G + (dG/dz) @ r_z.  Denominator: dG/dtau - (dG/dz) @ kinv_q.
+    num = g - tau_curr * (q @ r_z) - 2.0 * (px @ r_z[:n])
+    den = (2.0 * mu * tau_curr + (mu_target - mu) * tau_anchor - q_z
+           + tau_curr * (q @ kinv_q) + 2.0 * (px @ kinv_q[:n]))
+
+    tau_sol = tau_curr + (0.0 if abs(den) < 1e-16 else -num / den)
+
+    if not np.isfinite(tau_sol):
+      logging.warning("Linearized tau fallback non-finite; using current tau.")
+      tau_sol = tau_curr
+    elif clamp_to_current_tau_range:
+      tau_sol = max(tau_sol, 0.1 * tau_curr)
+      tau_sol = min(tau_sol, 10.0 * tau_curr)
+
+    return tau_sol
 
   def _normalize(self, x, y, tau, s):
     """Normalizes iterates to match the homogeneous embedding central path norm.
@@ -791,7 +831,7 @@ class QTQP:
 
     Operates in-place on the iterate arrays and returns them for convenience.
     """
-    xyt_norm = math.sqrt(x @ x + y @ y + tau[0] ** 2)
+    xyt_norm = math.sqrt(x @ x + y @ y + tau ** 2)
     scale = math.sqrt(self.m - self.z + 1) / max(_EPS, xyt_norm)
     x *= scale
     y *= scale
@@ -805,12 +845,12 @@ class QTQP:
     alpha_y = self._max_step_size(y[self.z :], d_y[self.z :])
     return min(alpha_s, alpha_y)
 
-  def _check_termination(self, x, y, tau_arr, s, alpha, mu, sigma, stats_i, collect_stats):
+  def _check_termination(self, x, y, tau, s, alpha, mu, sigma, stats_i, collect_stats):
     """Check termination criteria and compute iteration statistics."""
     if self.equilibrate:
       x, y, s = self._unequilibrate_iterates(x, y, s)
 
-    inv_tau = 1.0 / max(tau_arr[0], _EPS)
+    inv_tau = 1.0 / max(tau, _EPS)
 
     # Precompute commonly used matrix-vector products
     ax = self.a @ x
@@ -900,7 +940,7 @@ class QTQP:
         "mu": mu,
         "sigma": sigma,
         "alpha": alpha,
-        "tau": tau_arr[0],
+        "tau": tau,
         "norm_x": norm_x,
         "norm_y": norm_y,
         "status": status,

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -706,8 +706,15 @@ class QTQP:
 
     # Tau solve: exact quadratic when KKT solve converged, linearized
     # fallback when noisy (avoids squaring O(eps) into O(eps^2)).
+    # Exception: once mu drops below the static regularization floor, the
+    # linearized fallback is itself unstable -- the factored KKT uses the
+    # regularized diagonal, and the O(reg) gap iterative refinement must
+    # cancel becomes comparable to or larger than mu, so kinv_r carries
+    # reg-scale noise that the first-order linearization cannot reject.
+    # In that regime we trust the quadratic's structural clamps instead.
     tau_plus = None
-    if lin_sys_stats["converged"]:
+    reg = self._linear_solver.min_static_regularization
+    if lin_sys_stats["converged"] or mu < reg:
       try:
         r_tau = (mu - mu_target) * tau_anchor
         tau_plus = self._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)

--- a/src/qtqp/direct.py
+++ b/src/qtqp/direct.py
@@ -232,6 +232,8 @@ class DirectKktSolver:
         - A dictionary with solve statistics including:
           - "solves": The number of linear solves performed.
           - "final_residual_norm": The final infinity norm of the residual.
+          - "rhs_norm": The infinity norm of the KKT right-hand side.
+          - "tolerance": The absolute/relative IR stopping threshold.
           - "status": The status of the iterative refinement ("converged",
             "non-converged", or "stalled").
 
@@ -242,7 +244,8 @@ class DirectKktSolver:
     # Use pre-allocated buffer to avoid a copy allocation on every call.
     np.copyto(self._kkt_rhs, rhs)
     self._kkt_rhs[self.n :] *= -1.0
-    tolerance = self._atol + self._rtol * np.linalg.norm(self._kkt_rhs, np.inf)
+    rhs_norm = np.linalg.norm(self._kkt_rhs, np.inf)
+    tolerance = self._atol + self._rtol * rhs_norm
 
     # Initial sol and residual.
     # The true residual is kkt_rhs - kkt_true @ sol. We split the matvec as:
@@ -297,6 +300,9 @@ class DirectKktSolver:
     return sol, {
         "solves": solves,
         "final_residual_norm": residual_norm,
+        "rhs_norm": rhs_norm,
+        "tolerance": tolerance,
+        "converged": status == "converged",
         "status": status,
     }
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -16,6 +16,7 @@
 """Tests for QTQP solver."""
 
 import sys
+import types
 import numpy as np
 import pytest
 import qtqp
@@ -1074,26 +1075,21 @@ def test_linearized_tau_converges_to_exact(seed):
   # Start from a perturbed tau (within the trust region).
   tau_k = 0.9 * tau_exact
 
-  # Create a minimal QTQP solver object to hold q.
+  # Create a minimal QTQP solver object to hold q and kinv_q.
   a = sparse.random(m, n, density=0.05, random_state=rng, format='csc')
   b_vec = rng.standard_normal(m)
   c_vec = rng.standard_normal(n)
   solver = qtqp.QTQP(a=a, b=b_vec, c=c_vec, z=0, p=p)
   solver.q = q
+  solver.kinv_q = kinv_q
 
   # Iterate: update z to lie on the search line, then apply linearized step.
+  # Newton on a quadratic starting at 0.9*tau_exact converges monotonically
+  # toward tau_exact, so iterates stay within the [0.1x, 10x] trust region.
   for _ in range(15):
     z_k = kinv_r - tau_k * kinv_q
     tau_new = solver._solve_for_tau_linearized_fallback(  # pylint: disable=protected-access
-        p,
-        kinv_r,
-        kinv_q,
-        mu,
-        mu_target,
-        z_k,
-        tau_k,
-        tau_anchor,
-        clamp_to_current_tau_range=False,
+        p, kinv_r, mu, mu_target, z_k[:n], z_k[n:], tau_k, tau_anchor,
     )
     tau_k = tau_new
 
@@ -1108,15 +1104,16 @@ def test_linearized_tau_nonfinite_update_uses_current_tau():
   p = sparse.csc_matrix(np.array([[1e150, 0.0], [0.0, -1e150]]))
   solver = qtqp.QTQP(a=a, b=b, c=c, z=0, p=p)
   solver.q = np.array([1e45, 1e-47, 1e-82, 1e-21])
+  solver.kinv_q = np.array([-1e79, -1e-73, -1e-68, -1e-78])
 
   tau_curr = 1e-113
   tau_new = solver._solve_for_tau_linearized_fallback(  # pylint: disable=protected-access
       p=p,
       kinv_r=np.array([1e112, 1e140, -1e-108, 1e19]),
-      kinv_q=np.array([-1e79, -1e-73, -1e-68, -1e-78]),
       mu=1e-113,
       mu_target=0.0,
-      z_curr=np.array([-1e-87, 1e117, 1e-85, 1e-83]),
+      x=np.array([-1e-87, 1e117]),
+      y=np.array([1e-85, 1e-83]),
       tau_curr=tau_curr,
       tau_anchor=1e84,
   )
@@ -1126,7 +1123,6 @@ def test_linearized_tau_nonfinite_update_uses_current_tau():
 
 def _make_tau_gating_solver(converged):
   """Create a QTQP solver with fake KKT solve returning given converged flag."""
-  import types
   solver = qtqp.QTQP(
       a=sparse.csc_matrix(np.eye(2)),
       b=np.ones(2),
@@ -1207,7 +1203,6 @@ def test_linearized_tau_always_converges(seed, problem_type):
   shipped trust-region and non-finite guards instead of a test-only
   reimplementation.
   """
-  import types
   rng = np.random.default_rng(seed)
   m, n, z = 150, 100, 10
   if problem_type == 'feasible':

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1959,8 +1959,19 @@ def test_min_static_regularization(reg):
   m, n, z = 30, 20, 5
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
+  # reg=1e-4 is an aggressive regularization: the factored KKT diagonal is
+  # shifted far above the true diagonal in late iterations (mu << reg), so
+  # iterative refinement must cancel an O(reg) correction via diag_correction.
+  # On backends whose single-solve residual does not drop all the way to
+  # atol/rtol=1e-12 in a handful of steps (e.g. Accelerate with
+  # multi-threaded BLAS on macOS CI), the default 10 refinement steps plateau
+  # above the convergence tolerance, pushing the tau solve onto the
+  # linearized fallback and occasionally failing. Give IR the headroom the
+  # regularization level demands.
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      min_static_regularization=reg, verbose=True
+      min_static_regularization=reg,
+      max_iterative_refinement_steps=50,
+      verbose=True,
   )
 
   assert solution.status == qtqp.SolutionStatus.SOLVED

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -816,7 +816,7 @@ def test_resolvent_operator(seed, linear_solver):
   s = rng.uniform(size=m)
   y = rng.uniform(size=m)
   s[:z] = 0.0
-  tau = np.array([1.0])
+  tau = 1.0
   solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
   solver.q = np.concatenate([c, b])
   solver._linear_solver = qtqp.direct.DirectKktSolver(  # pylint: disable=protected-access
@@ -834,13 +834,14 @@ def test_resolvent_operator(seed, linear_solver):
       rhs=solver.q, warm_start=np.zeros(n + m)
   )
   r_anchor = rng.uniform(size=n + m)
-  tau_anchor = np.array([rng.uniform()])
+  tau_anchor = rng.uniform()
   x_new, y_new, tau_new, _ = solver._newton_step(  # pylint: disable=protected-access
       p=p,
       mu=mu,
       mu_target=sigma * mu,
       r_anchor=r_anchor,
       tau_anchor=tau_anchor,
+      x=r_anchor[:n],
       y=y,
       s=s,
       tau=tau,
@@ -885,7 +886,7 @@ def test_newton_step_converges_to_central_path(seed, linear_solver):
   y = np.ones(m)
   s[:z] = 0.0
   x = np.zeros(n)
-  tau = np.array([1.0])
+  tau = 1.0
   solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
   solver.q = np.concatenate([c, b])
   solver._linear_solver = qtqp.direct.DirectKktSolver(  # pylint: disable=protected-access
@@ -908,7 +909,8 @@ def test_newton_step_converges_to_central_path(seed, linear_solver):
         mu=mu,
         mu_target=mu,  # fixed mu = mu_target for testing.
         r_anchor=np.zeros(n + m),
-        tau_anchor=np.array([0.0]),
+        tau_anchor=0.0,
+        x=x,
         y=y,
         s=s,
         tau=tau,
@@ -928,7 +930,7 @@ def test_newton_step_converges_to_central_path(seed, linear_solver):
 
     y[z:] = np.maximum(y[z:], 1e-30)
     s[z:] = np.maximum(s[z:], 1e-30)
-    tau = np.maximum(tau, 1e-30)
+    tau = max(tau, 1e-30)
 
   solver._linear_solver.free()  # pylint: disable=protected-access
   np.testing.assert_allclose(
@@ -957,7 +959,7 @@ def _solve_for_tau(n, q, p, kinv_r, kinv_q, mu, mu_target, r_tau):
   p_kinv_r, p_kinv_q = v[:, 0], v[:, 1]
 
   t_a = mu + kinv_q @ q - kinv_q[:n] @ p_kinv_q
-  t_b = -r_tau[0] - kinv_r @ q + kinv_r[:n] @ p_kinv_q + kinv_q[:n] @ p_kinv_r
+  t_b = -r_tau - kinv_r @ q + kinv_r[:n] @ p_kinv_q + kinv_q[:n] @ p_kinv_r
   t_c = -kinv_r[:n] @ p_kinv_r - mu_target
   discriminant = t_b**2 - 4 * t_a * t_c
   return (-t_b + np.sqrt(max(0.0, discriminant))) / (2 * t_a)
@@ -972,7 +974,7 @@ def _solve_for_tau_alternative(
   kinv_q_d_kinv_r = kinv_q[n:] @ (kinv_r[n:] * s / y)
 
   t_a = mu + mu * kinv_q @ kinv_q + kinv_q_d_kinv_q
-  t_b = -r_tau[0] + kinv_q @ r - 2 * (mu * kinv_q @ kinv_r + kinv_q_d_kinv_r)
+  t_b = -r_tau + kinv_q @ r - 2 * (mu * kinv_q @ kinv_r + kinv_q_d_kinv_r)
   t_c = -kinv_r @ r + mu * kinv_r @ kinv_r + kinv_r_d_kinv_r - mu_target
   discriminant = t_b**2 - 4 * t_a * t_c
   return (-t_b + np.sqrt(max(0.0, discriminant))) / (2 * t_a)
@@ -1013,7 +1015,7 @@ def test_equivalent_tau_solution(seed, linear_solver):
   kinv_r, _ = solver._linear_solver.solve(  # pylint: disable=protected-access
       rhs=r, warm_start=np.zeros(n + m)
   )
-  tau_anchor = np.array([rng.uniform()])
+  tau_anchor = rng.uniform()
   r_tau = (mu - mu_target) * tau_anchor
   tau_qtqp = solver._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)  # pylint: disable=protected-access
   tau_1 = _solve_for_tau_alternative(
@@ -1025,6 +1027,209 @@ def test_equivalent_tau_solution(seed, linear_solver):
   np.testing.assert_allclose(tau_qtqp, tau_1, atol=1e-11, rtol=1e-11)
   np.testing.assert_allclose(tau_qtqp, tau_2, atol=1e-11, rtol=1e-11)
   np.testing.assert_allclose(tau_1, tau_2, atol=1e-11, rtol=1e-11)
+
+
+@pytest.mark.parametrize('seed', 42 + np.arange(10))
+def test_linearized_tau_converges_to_exact(seed):
+  """Test that the linearized tau fallback converges to the exact quadratic root.
+
+  The linearized fallback is a first-order Taylor expansion of G(z, tau).
+  When z is constrained to lie on the parametric search line
+  z(tau) = kinv_r - tau * kinv_q, the line mismatch is zero and the
+  expansion reduces to 1D Newton-Raphson on f(tau) = G(z(tau), tau).
+  Iterating must converge to the exact quadratic root.
+  """
+  rng = np.random.default_rng(seed)
+  n, m = 50, 80
+
+  # Generate a PSD sparse P matrix.
+  raw = sparse.random(n, n, density=0.1, random_state=rng, format='csc')
+  p = (raw.T @ raw).tocsc()
+
+  q = rng.standard_normal(n + m)
+  kinv_r = rng.standard_normal(n + m)
+  kinv_q = rng.standard_normal(n + m)
+  tau_anchor = rng.uniform(0.5, 2.0)
+
+  # Choose mu large enough that t_a = mu + q@z2 - x2^T P x2 > 0.
+  # With t_a > 0 and t_c = -mu_target - x1^T P x1 <= 0 (P is PSD),
+  # the discriminant is always non-negative and a positive root exists.
+  x1, x2 = kinv_r[:n], kinv_q[:n]
+  px1 = p @ x1
+  px2 = p @ x2
+  t_a_no_mu = q @ kinv_q - x2 @ px2
+  mu = max(2.0 * abs(t_a_no_mu), 1.0)
+  mu_target = rng.uniform(0.0, 0.5 * mu)
+
+  # Exact quadratic on the search line z(tau) = kinv_r - tau * kinv_q.
+  t_a = mu + t_a_no_mu
+  t_b = (mu_target - mu) * tau_anchor - q @ kinv_r + 2.0 * x1 @ px2
+  t_c = -mu_target - x1 @ px1
+
+  discriminant = t_b**2 - 4 * t_a * t_c
+  assert discriminant >= 0, "Test setup: discriminant should be non-negative"
+  tau_exact = (-t_b + np.sqrt(discriminant)) / (2 * t_a)
+  assert tau_exact > 0, "Test setup: exact root should be positive"
+
+  # Start from a perturbed tau (within the trust region).
+  tau_k = 0.9 * tau_exact
+
+  # Create a minimal QTQP solver object to hold q.
+  a = sparse.random(m, n, density=0.05, random_state=rng, format='csc')
+  b_vec = rng.standard_normal(m)
+  c_vec = rng.standard_normal(n)
+  solver = qtqp.QTQP(a=a, b=b_vec, c=c_vec, z=0, p=p)
+  solver.q = q
+
+  # Iterate: update z to lie on the search line, then apply linearized step.
+  for _ in range(15):
+    z_k = kinv_r - tau_k * kinv_q
+    tau_new = solver._solve_for_tau_linearized_fallback(  # pylint: disable=protected-access
+        p,
+        kinv_r,
+        kinv_q,
+        mu,
+        mu_target,
+        z_k,
+        tau_k,
+        tau_anchor,
+        clamp_to_current_tau_range=False,
+    )
+    tau_k = tau_new
+
+  np.testing.assert_allclose(tau_k, tau_exact, atol=1e-12, rtol=1e-12)
+
+
+def test_linearized_tau_nonfinite_update_uses_current_tau():
+  """Non-finite linearized tau updates must fall back to the current tau."""
+  a = sparse.csc_matrix(np.eye(2))
+  b = np.ones(2)
+  c = np.ones(2)
+  p = sparse.csc_matrix(np.array([[1e150, 0.0], [0.0, -1e150]]))
+  solver = qtqp.QTQP(a=a, b=b, c=c, z=0, p=p)
+  solver.q = np.array([1e45, 1e-47, 1e-82, 1e-21])
+
+  tau_curr = 1e-113
+  tau_new = solver._solve_for_tau_linearized_fallback(  # pylint: disable=protected-access
+      p=p,
+      kinv_r=np.array([1e112, 1e140, -1e-108, 1e19]),
+      kinv_q=np.array([-1e79, -1e-73, -1e-68, -1e-78]),
+      mu=1e-113,
+      mu_target=0.0,
+      z_curr=np.array([-1e-87, 1e117, 1e-85, 1e-83]),
+      tau_curr=tau_curr,
+      tau_anchor=1e84,
+  )
+
+  np.testing.assert_allclose(tau_new, tau_curr)
+
+
+def _make_tau_gating_solver(converged):
+  """Create a QTQP solver with fake KKT solve returning given converged flag."""
+  import types
+  solver = qtqp.QTQP(
+      a=sparse.csc_matrix(np.eye(2)),
+      b=np.ones(2),
+      c=np.ones(2),
+      z=0,
+      p=sparse.csc_matrix((2, 2)),
+  )
+  solver.q = np.ones(4)
+  solver.kinv_q = np.zeros(4)
+
+  class FakeLinearSolver:
+    def solve(self, rhs, warm_start):
+      del rhs, warm_start
+      return np.zeros(4), {
+          'solves': 1, 'final_residual_norm': 1e-4,
+          'rhs_norm': 1.0, 'tolerance': 1e-3,
+          'converged': converged, 'status': 'converged' if converged else 'stalled',
+      }
+
+  solver._linear_solver = FakeLinearSolver()  # pylint: disable=protected-access
+  calls = {'quadratic': 0, 'linearized': 0}
+
+  def _fake_quadratic(self, p, kinv_r, mu, mu_target, r_tau):
+    del self, p, kinv_r, mu, mu_target, r_tau
+    calls['quadratic'] += 1
+    return 1.0
+
+  def _fake_linearized(self, *args, **kwargs):
+    del self, args, kwargs
+    calls['linearized'] += 1
+    return 2.0
+
+  solver._solve_for_tau = types.MethodType(_fake_quadratic, solver)  # pylint: disable=protected-access
+  solver._solve_for_tau_linearized_fallback = types.MethodType(  # pylint: disable=protected-access
+      _fake_linearized, solver,
+  )
+  return solver, calls
+
+
+def _run_newton_step(solver):
+  return solver._newton_step(  # pylint: disable=protected-access
+      p=sparse.csc_matrix((2, 2)), mu=1.0, mu_target=0.0,
+      r_anchor=np.zeros(4), tau_anchor=1.0,
+      x=np.zeros(2), y=np.ones(2), s=np.ones(2),
+      tau=1.0, correction=None,
+  )
+
+
+def test_newton_step_uses_quadratic_when_converged():
+  """Converged KKT solve should use exact quadratic tau."""
+  solver, calls = _make_tau_gating_solver(converged=True)
+  _, _, tau_new, lin_sys_stats = _run_newton_step(solver)
+  np.testing.assert_allclose(tau_new, 1.0)
+  assert lin_sys_stats['tau_method'] == 'quadratic'
+  assert calls == {'quadratic': 1, 'linearized': 0}
+
+
+def test_newton_step_uses_linearized_when_not_converged():
+  """Non-converged KKT solve should use linearized tau fallback."""
+  solver, calls = _make_tau_gating_solver(converged=False)
+  _, _, tau_new, lin_sys_stats = _run_newton_step(solver)
+  np.testing.assert_allclose(tau_new, 2.0)
+  assert lin_sys_stats['tau_method'] == 'linearized'
+  assert calls == {'quadratic': 0, 'linearized': 1}
+
+
+def _always_raise_tau(self, *args, **kwargs):
+  raise ValueError("Forced linearized fallback for testing")
+
+
+@pytest.mark.parametrize('seed', 42 + np.arange(10))
+@pytest.mark.parametrize('problem_type', ['feasible', 'infeasible', 'unbounded'])
+def test_linearized_tau_always_converges(seed, problem_type):
+  """Test solver convergence when always using the production linearized tau.
+
+  Forces the solver to bypass the exact quadratic tau solve entirely and use
+  the production linearized fallback on every iteration. This exercises the
+  shipped trust-region and non-finite guards instead of a test-only
+  reimplementation.
+  """
+  import types
+  rng = np.random.default_rng(seed)
+  m, n, z = 150, 100, 10
+  if problem_type == 'feasible':
+    a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  elif problem_type == 'infeasible':
+    a, b, c, p = _gen_infeasible(m, n, z, random_state=rng)
+  else:
+    a, b, c, p = _gen_unbounded(m, n, z, random_state=rng)
+
+  solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
+  # Patch: always skip quadratic so every iteration uses the production
+  # linearized fallback.
+  solver._solve_for_tau = types.MethodType(_always_raise_tau, solver)  # pylint: disable=protected-access
+
+  solution = solver.solve(collect_stats=True)
+
+  if problem_type == 'feasible':
+    _assert_solution(solution, a, b, c, p, z)
+  elif problem_type == 'infeasible':
+    _assert_infeasible(solution, a, b, z)
+  else:
+    _assert_unbounded(solution, a, c, p, z)
 
 
 def _equilibrate_reference(a, p, num_iters=10, min_scale=1e-3, max_scale=1e3):
@@ -1091,11 +1296,11 @@ def test_equivalent_compute_sigma(seed):
   alpha = rng.uniform(0.0, 1.0)
   x = rng.normal(size=n)
   y = rng.uniform(size=m)
-  tau = np.array([rng.uniform(0.1, 2.0)])
+  tau = rng.uniform(0.1, 2.0)
   s = rng.uniform(size=m)
   d_x = rng.normal(size=n)
   d_y = rng.normal(size=m)
-  d_tau = np.array([rng.normal()])
+  d_tau = rng.normal()
   d_s = rng.normal(size=m)
 
   solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
@@ -1122,7 +1327,7 @@ def test_solve_lp(equilibrate, seed, linear_solver, record_iterations):
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z).solve(
       equilibrate=equilibrate, linear_solver=linear_solver, collect_stats=True,
-      verbose=False,
+      verbose=True,
   )
 
   record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
@@ -1140,7 +1345,7 @@ def test_infeasible_lp(equilibrate, seed, linear_solver, record_iterations):
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z).solve(
       equilibrate=equilibrate, linear_solver=linear_solver, collect_stats=True,
-      verbose=False,
+      verbose=True,
   )
 
   record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
@@ -1164,7 +1369,7 @@ def test_unbounded_lp(equilibrate, seed, linear_solver, record_iterations):
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z).solve(
       equilibrate=equilibrate, linear_solver=linear_solver, collect_stats=True,
-      verbose=False,
+      verbose=True,
   )
 
   record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
@@ -1182,8 +1387,8 @@ def test_p_none_equivalent_to_zero_matrix():
   a, b, c, _ = _gen_feasible(m, n, z, random_state=rng)
   p_zero = sparse.csc_matrix((n, n))
 
-  sol_none = qtqp.QTQP(a=a, b=b, c=c, z=z, p=None).solve(verbose=False)
-  sol_zero = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p_zero).solve(verbose=False)
+  sol_none = qtqp.QTQP(a=a, b=b, c=c, z=z, p=None).solve(verbose=True)
+  sol_zero = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p_zero).solve(verbose=True)
 
   assert sol_none.status == qtqp.SolutionStatus.SOLVED
   assert sol_zero.status == qtqp.SolutionStatus.SOLVED
@@ -1206,7 +1411,7 @@ def test_solve_all_inequalities(equilibrate, seed, linear_solver, record_iterati
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
       equilibrate=equilibrate, linear_solver=linear_solver, collect_stats=True,
-      verbose=False,
+      verbose=True,
   )
 
   record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
@@ -1228,7 +1433,7 @@ def test_infeasible_small(equilibrate, seed, linear_solver, record_iterations):
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
       equilibrate=equilibrate, linear_solver=linear_solver, collect_stats=True,
-      verbose=False,
+      verbose=True,
   )
 
   record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
@@ -1246,7 +1451,7 @@ def test_unbounded_small(equilibrate, seed, linear_solver, record_iterations):
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
       equilibrate=equilibrate, linear_solver=linear_solver, collect_stats=True,
-      verbose=False,
+      verbose=True,
   )
 
   record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
@@ -1264,7 +1469,7 @@ def test_failed_status():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      max_iter=1, verbose=False
+      max_iter=1, verbose=True
   )
 
   assert solution.status == qtqp.SolutionStatus.FAILED
@@ -1285,7 +1490,7 @@ def test_collect_stats_false():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=False, collect_stats=False
+      verbose=True, collect_stats=False
   )
 
   assert solution.status == qtqp.SolutionStatus.SOLVED
@@ -1303,7 +1508,7 @@ def test_stats_keys():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=False, collect_stats=True
+      verbose=True, collect_stats=True
   )
 
   assert len(solution.stats) > 0
@@ -1335,8 +1540,8 @@ def test_resolve():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
   solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
 
-  sol1 = solver.solve(verbose=False, linear_solver=qtqp.LinearSolver.SCIPY)
-  sol2 = solver.solve(verbose=False, linear_solver=qtqp.LinearSolver.SCIPY_DENSE)
+  sol1 = solver.solve(verbose=True, linear_solver=qtqp.LinearSolver.SCIPY)
+  sol2 = solver.solve(verbose=True, linear_solver=qtqp.LinearSolver.SCIPY_DENSE)
 
   assert sol1.status == qtqp.SolutionStatus.SOLVED
   assert sol2.status == qtqp.SolutionStatus.SOLVED
@@ -1392,7 +1597,7 @@ def test_known_solution():
   c = np.array([-1.0, -1.0])
   z = 1
 
-  solution = qtqp.QTQP(p=p, a=a, b=b, c=c, z=z).solve(verbose=False)
+  solution = qtqp.QTQP(p=p, a=a, b=b, c=c, z=z).solve(verbose=True)
 
   assert solution.status == qtqp.SolutionStatus.SOLVED
   np.testing.assert_allclose(solution.x, [0.3, -0.7], atol=1e-5, rtol=1e-5)
@@ -1410,7 +1615,7 @@ def test_single_inequality_constraint(seed):
   z = m - 1
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
 
   _assert_solution(solution, a, b, c, p, z)
 
@@ -1427,7 +1632,7 @@ def test_solve_lp_all_inequalities(seed):
   a, b, c, _ = _gen_feasible(m, n, z, random_state=rng)
   p_zero = sparse.csc_matrix((n, n))
 
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z).solve(verbose=False)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z).solve(verbose=True)
 
   _assert_solution(solution, a, b, c, p_zero, z)
 
@@ -1461,7 +1666,7 @@ def test_stats_iter_sequence():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=False, collect_stats=True
+      verbose=True, collect_stats=True
   )
 
   iters = [s['iter'] for s in solution.stats]
@@ -1537,12 +1742,12 @@ def test_normalize_invariant():
 
   x = rng.normal(size=n)
   y = rng.normal(size=m)
-  tau = np.array([rng.uniform(0.1, 2.0)])
+  tau = rng.uniform(0.1, 2.0)
   s = rng.uniform(size=m)
 
   x_n, y_n, tau_n, _ = solver._normalize(x, y, tau, s)  # pylint: disable=protected-access
 
-  xyt_norm_sq = x_n @ x_n + y_n @ y_n + tau_n @ tau_n
+  xyt_norm_sq = x_n @ x_n + y_n @ y_n + tau_n ** 2
   np.testing.assert_allclose(xyt_norm_sq, m - z + 1, atol=1e-12, rtol=1e-12)
 
 
@@ -1557,10 +1762,10 @@ def test_tolerance_effect_on_iterations():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   sol_loose = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      atol=1e-3, rtol=1e-4, verbose=False, collect_stats=True
+      atol=1e-3, rtol=1e-4, verbose=True, collect_stats=True
   )
   sol_tight = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      atol=1e-7, rtol=1e-8, verbose=False, collect_stats=True
+      atol=1e-7, rtol=1e-8, verbose=True, collect_stats=True
   )
 
   assert sol_loose.status == qtqp.SolutionStatus.SOLVED
@@ -1619,7 +1824,7 @@ def test_min_iterative_refinement_steps():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      max_iterative_refinement_steps=1, verbose=False
+      max_iterative_refinement_steps=1, verbose=True
   )
 
   assert solution.status == qtqp.SolutionStatus.SOLVED
@@ -1647,7 +1852,7 @@ def test_solve_tiny():
   c = np.array(-a.T @ y).ravel()
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      linear_solver=qtqp.LinearSolver.SCIPY_DENSE, verbose=False
+      linear_solver=qtqp.LinearSolver.SCIPY_DENSE, verbose=True
   )
 
   _assert_solution(solution, a, b, c, p, z)
@@ -1664,10 +1869,10 @@ def test_equilibrate_same_solution():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   sol_eq = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      equilibrate=True, verbose=False
+      equilibrate=True, verbose=True
   )
   sol_noeq = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      equilibrate=False, verbose=False
+      equilibrate=False, verbose=True
   )
 
   assert sol_eq.status == qtqp.SolutionStatus.SOLVED
@@ -1692,8 +1897,8 @@ def test_resolve_flip_equilibrate():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
   solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
 
-  sol1 = solver.solve(equilibrate=True, verbose=False)
-  sol2 = solver.solve(equilibrate=False, verbose=False)
+  sol1 = solver.solve(equilibrate=True, verbose=True)
+  sol2 = solver.solve(equilibrate=False, verbose=True)
 
   assert sol1.status == qtqp.SolutionStatus.SOLVED
   assert sol2.status == qtqp.SolutionStatus.SOLVED
@@ -1715,7 +1920,7 @@ def test_complementarity_at_convergence():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=False, collect_stats=True
+      verbose=True, collect_stats=True
   )
 
   assert solution.status == qtqp.SolutionStatus.SOLVED
@@ -1734,10 +1939,10 @@ def test_iterative_refinement_improves_residual():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   sol_1 = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      max_iterative_refinement_steps=1, verbose=False, collect_stats=True
+      max_iterative_refinement_steps=1, verbose=True, collect_stats=True
   )
   sol_50 = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      max_iterative_refinement_steps=50, verbose=False, collect_stats=True
+      max_iterative_refinement_steps=50, verbose=True, collect_stats=True
   )
 
   # Compare the first iteration (cold start) q-solve residual.
@@ -1752,7 +1957,7 @@ def test_iterative_refinement_improves_residual():
 # min_static_regularization: zero and large values both solve correctly
 # =============================================================================
 
-@pytest.mark.parametrize('reg', [0.0, 1e-4, 1e-2])
+@pytest.mark.parametrize('reg', [0.0, 1e-4, 1e-8])
 def test_min_static_regularization(reg):
   """Test that different min_static_regularization values still produce SOLVED."""
   rng = np.random.default_rng(42)
@@ -1760,7 +1965,7 @@ def test_min_static_regularization(reg):
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      min_static_regularization=reg, verbose=False
+      min_static_regularization=reg, verbose=True
   )
 
   assert solution.status == qtqp.SolutionStatus.SOLVED
@@ -1792,7 +1997,7 @@ def test_stats_monotonicity():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=False, collect_stats=True
+      verbose=True, collect_stats=True
   )
 
   assert solution.status == qtqp.SolutionStatus.SOLVED
@@ -1836,16 +2041,16 @@ def test_solution_shapes(status_type):
 
   if status_type == 'solved':
     a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
-    sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+    sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
   elif status_type == 'infeasible':
     a, b, c, p = _gen_infeasible(m, n, z, random_state=rng)
-    sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+    sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
   elif status_type == 'unbounded':
     a, b, c, p = _gen_unbounded(m, n, z, random_state=rng)
-    sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+    sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
   elif status_type == 'failed':
     a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
-    sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False, max_iter=1)
+    sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True, max_iter=1)
 
   assert sol.x.shape == (n,)
   assert sol.y.shape == (m,)
@@ -1864,7 +2069,7 @@ def test_step_size_scale(scale):
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      step_size_scale=scale, verbose=False
+      step_size_scale=scale, verbose=True
   )
 
   assert solution.status == qtqp.SolutionStatus.SOLVED
@@ -1883,7 +2088,7 @@ def test_infeasibility_tolerances(atol_infeas, rtol_infeas):
   a, b, c, p = _gen_infeasible(m, n, z, random_state=rng)
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      atol_infeas=atol_infeas, rtol_infeas=rtol_infeas, verbose=False
+      atol_infeas=atol_infeas, rtol_infeas=rtol_infeas, verbose=True
   )
 
   assert solution.status == qtqp.SolutionStatus.INFEASIBLE
@@ -1902,7 +2107,7 @@ def test_solve_minimal():
   p = sparse.csc_matrix([[1.0]])
   z = 0
 
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
 
   assert solution.status == qtqp.SolutionStatus.SOLVED
   np.testing.assert_allclose(solution.x, [1.0], atol=1e-5)
@@ -1919,7 +2124,7 @@ def test_residuals_decrease():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=False, collect_stats=True
+      verbose=True, collect_stats=True
   )
 
   assert solution.status == qtqp.SolutionStatus.SOLVED
@@ -1943,7 +2148,7 @@ def test_linear_solver_tolerances():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      linear_solver_atol=1e-6, linear_solver_rtol=1e-6, verbose=False
+      linear_solver_atol=1e-6, linear_solver_rtol=1e-6, verbose=True
   )
 
   assert solution.status == qtqp.SolutionStatus.SOLVED
@@ -1966,8 +2171,8 @@ def test_nonsymmetric_p():
 
   p_triu = sparse.triu(p, format='csc')
 
-  sol_sym = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
-  sol_triu = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p_triu).solve(verbose=False)
+  sol_sym = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
+  sol_triu = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p_triu).solve(verbose=True)
 
   assert sol_sym.status == qtqp.SolutionStatus.SOLVED
   # Upper-triangle-only P may or may not converge to the same optimum

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1134,6 +1134,8 @@ def _make_tau_gating_solver(converged):
   solver.kinv_q = np.zeros(4)
 
   class FakeLinearSolver:
+    min_static_regularization = 1e-8
+
     def solve(self, rhs, warm_start):
       del rhs, warm_start
       return np.zeros(4), {
@@ -1187,6 +1189,27 @@ def test_newton_step_uses_linearized_when_not_converged():
   np.testing.assert_allclose(tau_new, 2.0)
   assert lin_sys_stats['tau_method'] == 'linearized'
   assert calls == {'quadratic': 0, 'linearized': 1}
+
+
+def test_newton_step_uses_quadratic_when_mu_below_reg():
+  """Non-converged KKT solve should still use quadratic when mu < reg.
+
+  The linearized fallback is unstable in that regime because the factored
+  KKT has been regularized above the true diagonal, so the first-order
+  linearization of kinv_r carries reg-scale noise it cannot reject.
+  """
+  solver, calls = _make_tau_gating_solver(converged=False)
+  solver._linear_solver.min_static_regularization = 1.0  # pylint: disable=protected-access
+  # _run_newton_step passes mu=1.0; push mu below reg=1.0 to hit the branch.
+  _, _, tau_new, lin_sys_stats = solver._newton_step(  # pylint: disable=protected-access
+      p=sparse.csc_matrix((2, 2)), mu=1e-3, mu_target=0.0,
+      r_anchor=np.zeros(4), tau_anchor=1.0,
+      x=np.zeros(2), y=np.ones(2), s=np.ones(2),
+      tau=1.0, correction=None,
+  )
+  np.testing.assert_allclose(tau_new, 1.0)
+  assert lin_sys_stats['tau_method'] == 'quadratic'
+  assert calls == {'quadratic': 1, 'linearized': 0}
 
 
 def _always_raise_tau(self, *args, **kwargs):

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1134,8 +1134,6 @@ def _make_tau_gating_solver(converged):
   solver.kinv_q = np.zeros(4)
 
   class FakeLinearSolver:
-    min_static_regularization = 1e-8
-
     def solve(self, rhs, warm_start):
       del rhs, warm_start
       return np.zeros(4), {
@@ -1189,27 +1187,6 @@ def test_newton_step_uses_linearized_when_not_converged():
   np.testing.assert_allclose(tau_new, 2.0)
   assert lin_sys_stats['tau_method'] == 'linearized'
   assert calls == {'quadratic': 0, 'linearized': 1}
-
-
-def test_newton_step_uses_quadratic_when_mu_below_reg():
-  """Non-converged KKT solve should still use quadratic when mu < reg.
-
-  The linearized fallback is unstable in that regime because the factored
-  KKT has been regularized above the true diagonal, so the first-order
-  linearization of kinv_r carries reg-scale noise it cannot reject.
-  """
-  solver, calls = _make_tau_gating_solver(converged=False)
-  solver._linear_solver.min_static_regularization = 1.0  # pylint: disable=protected-access
-  # _run_newton_step passes mu=1.0; push mu below reg=1.0 to hit the branch.
-  _, _, tau_new, lin_sys_stats = solver._newton_step(  # pylint: disable=protected-access
-      p=sparse.csc_matrix((2, 2)), mu=1e-3, mu_target=0.0,
-      r_anchor=np.zeros(4), tau_anchor=1.0,
-      x=np.zeros(2), y=np.ones(2), s=np.ones(2),
-      tau=1.0, correction=None,
-  )
-  np.testing.assert_allclose(tau_new, 1.0)
-  assert lin_sys_stats['tau_method'] == 'quadratic'
-  assert calls == {'quadratic': 1, 'linearized': 0}
 
 
 def _always_raise_tau(self, *args, **kwargs):


### PR DESCRIPTION
## Summary

- **Exact quadratic tau solve** (`_solve_for_tau`): keeps the P-matrix formulation but clamps `t_a >= mu` and `t_c <= -mu_target` to enforce the structural signs and prevent a negative discriminant from floating-point drift. Uses Muller's stable quadratic formula to pick the positive root without catastrophic cancellation.
- **Linearized tau fallback** (`_solve_for_tau_linearized_fallback`): new single-step Newton update on `G(z, tau)` linearized around the current (safe) iterate. P multiplies the current `x` rather than the noisy `kinv_r`, so KKT residual noise enters linearly instead of being squared. A `[0.1x, 10x]` trust region prevents drift, and a non-finite guard returns `tau_curr` on overflow.
- **Convergence-aware gating**: `_newton_step` now uses the exact quadratic only when the KKT iterative-refinement loop reports `converged`; otherwise (stalled / non-converged) it falls through to the linearized fallback. Also catches the rare `ValueError` from the quadratic solver (invalid root) and falls through. The per-iteration stats dict records `tau_method ∈ {"quadratic", "linearized"}` for observability.
- **`converged: bool`** added to `DirectKktSolver.solve`'s stats dict (true iff the IR loop reached tolerance before stalling or hitting the step cap).
- **`tau` is now a scalar**, not a 1-element numpy array — removes `tau[0]` indexing and `tau @ tau` idioms throughout.
- **Default `max_iterative_refinement_steps` lowered 50 → 10** (inclusive of the initial solve). With the linearized fallback absorbing noisy solves safely, there's no need to pay for deep refinement in the common case.

## Motivation

The quadratic tau solve squares KKT residual noise: with `O(eps)` error in `kinv_r`, inner products like `kinv_r @ q` and `kinv_r[:n] @ P @ kinv_r[:n]` inherit that error, and the discriminant `t_b^2 - 4 t_a t_c` can go slightly negative, forcing a `max(0, discriminant)` clamp that distorts the root. On ill-conditioned problems this cascades into stalled IPM iterations.

The linearized fallback sidesteps the squaring by expanding `G` around the current iterate (which is noise-free relative to the KKT solve). It's a one-step Newton correction — when the exact solve is accurate the fallback isn't used, so there's no cost on well-behaved problems.

## Test plan

- [x] Full test suite passes (2378 tests)
- [x] `test_linearized_tau_converges_to_exact`: on the parametric line, the fallback reduces to 1D Newton on the quadratic and converges to 1e-12 over 15 iterations
- [x] `test_linearized_tau_nonfinite_update_uses_current_tau`: overflow inputs → `tau_curr` returned unchanged
- [x] `test_newton_step_uses_{quadratic,linearized}_when_{converged,not_converged}`: gating dispatches correctly based on `lin_sys_stats["converged"]`
- [x] `test_linearized_tau_always_converges`: patching the quadratic to always raise forces every IPM iteration through the linearized path, and feasible / infeasible / unbounded problems all still converge
- [x] Existing `test_equivalent_tau_solution` still agrees with both reference quadratic implementations