### PR TITLE
Tighten test_p_none_equivalent_to_zero_matrix to exact equality

### DIFF
--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1187,8 +1187,8 @@ def test_p_none_equivalent_to_zero_matrix():
 
   assert sol_none.status == qtqp.SolutionStatus.SOLVED
   assert sol_zero.status == qtqp.SolutionStatus.SOLVED
-  np.testing.assert_allclose(sol_none.x, sol_zero.x, atol=1e-8, rtol=1e-8)
-  np.testing.assert_allclose(sol_none.y, sol_zero.y, atol=1e-8, rtol=1e-8)
+  np.testing.assert_array_equal(sol_none.x, sol_zero.x)
+  np.testing.assert_array_equal(sol_none.y, sol_zero.y)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Follow-up to #61. When `p=None`, `QTQP.__init__` constructs `sp.csc_matrix((n, n))` — bit-identical to what the test builds as `p_zero`. Both paths feed the solver equivalent inputs, so the outputs should match exactly, not within `1e-8`.

## Test plan

- [x] `test_p_none_equivalent_to_zero_matrix` passes with `assert_array_equal`