### PR TITLE
Return Python floats for gap and complementarity stats

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -34,6 +34,7 @@
 import dataclasses
 import enum
 import logging
+import math
 import sys
 import timeit
 from typing import Any, Dict, List
@@ -768,7 +769,7 @@ class QTQP:
     if discriminant < -1e-9:
       raise ValueError(f"Negative discriminant: {discriminant}")
 
-    tau_sol = (-t_b + np.sqrt(max(0.0, discriminant))) / (2 * t_a)
+    tau_sol = (-t_b + math.sqrt(max(0.0, discriminant))) / (2 * t_a)
 
     if not np.isfinite(tau_sol) or tau_sol < -1e-10:
       raise ValueError(f"Invalid tau solution found: {tau_sol}")
@@ -790,8 +791,8 @@ class QTQP:
 
     Operates in-place on the iterate arrays and returns them for convenience.
     """
-    xyt_norm = np.sqrt(x @ x + y @ y + tau[0] ** 2)
-    scale = np.sqrt(self.m - self.z + 1) / max(_EPS, xyt_norm)
+    xyt_norm = math.sqrt(x @ x + y @ y + tau[0] ** 2)
+    scale = math.sqrt(self.m - self.z + 1) / max(_EPS, xyt_norm)
     x *= scale
     y *= scale
     tau *= scale

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -830,7 +830,7 @@ class QTQP:
     # Residuals
     pres = _norm((ax + s) * inv_tau - self.b, np.inf)
     dres = _norm((px + aty) * inv_tau + self.c, np.inf)
-    gap = np.abs((ctx + bty + xpx * inv_tau) * inv_tau)
+    gap = abs((ctx + bty + xpx * inv_tau) * inv_tau)
 
     # Infeasibility certificates (Farkas-type, from the embedding structure).
     # If the primal is unbounded (dual infeasible) this produces a ray x with
@@ -909,7 +909,7 @@ class QTQP:
     })
 
     if collect_stats:
-      stats_i["complementarity"] = np.abs((y @ s) * inv_tau * inv_tau)
+      stats_i["complementarity"] = abs((y @ s) * inv_tau * inv_tau)
       stats_i["norm_s"] = _norm(s, np.inf)
       # Per-inequality stats only meaningful when inequalities exist.
       if self.z < self.m:


### PR DESCRIPTION
## Summary

Clean up a handful of callers that invoked NumPy functions on already-scalar inputs, producing 0-d arrays where a Python float is cleaner:

- `_solve_for_tau`: `np.sqrt(discriminant)` → `math.sqrt(...)` (scalar discriminant).
- `_normalize`: `np.sqrt(x @ x + y @ y + tau[0]**2)` and `np.sqrt(m - z + 1)` → `math.sqrt(...)`.
- `_check_termination`: `gap = np.abs(...)` → `abs(...)`. This one leaks a 0-d array into `stats_i["gap"]`.
- `_check_termination`: `stats_i["complementarity"] = np.abs(...)` → `abs(...)`. Same.
- Added `import math` to support the above.

No test-side cleanups on this branch: on `main`, `tau` and `tau_anchor` are still 1-element arrays in production code (`tau[0]` is indexed, `r_tau[0]` is indexed), so the `np.array([val])` wrappings in tests reflect production and must stay. Those test tightenings belong on PR #60 where `tau`/`tau_anchor` become scalars.

## Test plan

- [x] Full test suite: `pytest tests/` — 2335 passed