### PR TITLE
Report mu of the current iterate instead of the prior step

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -440,9 +440,9 @@ class QTQP:
     xy = np.empty(self.n + self.m)   # Combined primal-dual vector [x; y]
     d_s = np.zeros(self.m)           # Slack step direction; d_s[:z] is always 0
 
-    # mu/alpha/sigma describe the IPM step that produced the current iterate;
-    # at iter 0 (init point) there is no prior step, so all three are 0.
-    alpha = sigma = mu = 0.0
+    # alpha/sigma describe the IPM step that produced the current iterate
+    # and are therefore 0 at init.
+    alpha = sigma = 0.0
     q_lin_sys_stats = init_stats
     predictor_lin_sys_stats = {}
     corrector_lin_sys_stats = {}
@@ -452,6 +452,12 @@ class QTQP:
     # already taken (0 = init). When z == m iter 0 terminates (no central path).
     for self.it in range(max_iter + 1):
       x, y, tau, s = self._normalize(x, y, tau, s)
+
+      # mu is a property of the current iterate (measures complementarity);
+      # equality-only problems (z == m) have no complementarity block, and
+      # the loop terminates at iter 0 before taking a step, so mu is defined
+      # as 0 there for logging purposes.
+      mu = (y @ s) / (self.m - self.z) if self.z < self.m else 0.0
 
       stats_i = {
           "q_lin_sys_stats": q_lin_sys_stats,
@@ -469,7 +475,6 @@ class QTQP:
         break
 
       # --- Take an IPM step ---
-      mu = (y @ s) / (self.m - self.z)
       self._linear_solver.update(mu=mu, s=s, y=y)
 
       # --- Step 1: Precompute kinv_q = K^{-1} @ q ---

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1802,11 +1802,10 @@ def test_stats_monotonicity():
   times = [s['time'] for s in solution.stats]
   alphas = [s['alpha'] for s in solution.stats]
 
-  # At iter 0 no step has been taken, so mu is reported as 0. From iter 1
-  # onward mu is the complementarity that was used to compute the step
-  # which produced the current iterate, and it should be strictly decreasing.
-  assert mus[0] == 0.0
-  for i in range(2, len(mus)):
+  # mu is the complementarity of the current iterate and should decrease
+  # strictly as the IPM drives iterates toward the central path.
+  assert mus[0] > 0.0
+  for i in range(1, len(mus)):
     assert mus[i] < mus[i - 1], (
         f"mu not decreasing: mu[{i}]={mus[i]} >= mu[{i-1}]={mus[i-1]}"
     )


### PR DESCRIPTION
## Summary

- `mu = (y @ s) / (m - z)` is a property of the current iterate (its complementarity), not a step parameter, so report it that way.
- Previously mu was initialized to 0 at iter 0 and reset each iteration alongside `alpha`/`sigma`, printing a misleading \`mu=0\` row in the verbose trace.
- Computing mu at the top of the loop (post-normalize, pre-log) makes iter 0 show the complementarity of the initial point; iter k>0 shows the current iterate's complementarity; \`alpha\`/\`sigma\` remain genuinely 0 at init as step parameters.
- IPM trajectory is unchanged — the linear-solver update and newton step use exactly the same mu, just computed a few lines earlier.
- For equality-only problems (z == m) we break at iter 0 before stepping and the complementarity block is empty, so mu is defined as 0 in that case.

## Test plan
- [x] \`pytest tests/\` — 2335 passed
- [x] \`test_stats_monotonicity\` updated: iter 0 mu > 0 and mu strictly decreases from iter 1 onward