### PR TITLE
fixing init

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -221,11 +221,7 @@ class QTQP:
 
     self._presolve()
     if self.z == self.m:
-      raise ValueError(
-          "Equality-only problems are not currently supported "
-          "(effective z == m after presolve; some rows may have been dropped "
-          "during presolve)."
-      )
+      raise ValueError("z == m after presolve; some rows may have been dropped")
 
     if p is None:
       self.p = sp.csc_matrix((self.n, self.n))
@@ -425,7 +421,6 @@ class QTQP:
       stats_i = {}
       x, y, tau, s = self._normalize(x, y, tau, s)
 
-      # mu is a property of the current iterate (measures complementarity).
       mu = (y @ s) / (self.m - self.z)
 
       # --- Take an IPM step ---
@@ -477,9 +472,9 @@ class QTQP:
       # feed the predictor's cross-term d_y_p*d_s_p back into the corrector RHS
       # (divided by y because the KKT complementarity block is scaled by 1/y),
       # so the corrector step can incorporate it to land closer to the target.
-      correction = -d_s[self.z:] * d_y_p[self.z:] / y[self.z:]
-      xy[:self.n] = x_p
-      xy[self.n:] = y_p
+      correction = -d_s[self.z :] * d_y_p[self.z :] / y[self.z :]
+      xy[: self.n] = x_p
+      xy[self.n :] = y_p
       x_c, y_c, tau_c, corrector_lin_sys_stats = self._newton_step(
           p=p,
           mu=mu,
@@ -817,8 +812,8 @@ class QTQP:
 
   def _compute_step_size(self, y, s, d_y, d_s) -> float:
     """Computes the maximum standard primal-dual step size."""
-    alpha_s = self._max_step_size(s[self.z:], d_s[self.z:])
-    alpha_y = self._max_step_size(y[self.z:], d_y[self.z:])
+    alpha_s = self._max_step_size(s[self.z :], d_s[self.z :])
+    alpha_y = self._max_step_size(y[self.z :], d_y[self.z :])
     return min(alpha_s, alpha_y)
 
   def _check_termination(self, x, y, tau, s, alpha, mu, sigma, stats_i, collect_stats):

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -288,10 +288,15 @@ class QTQP:
     system, then shifts inequality (y, s) into the cone's strict interior.
     When z == m the solve is exact. Returns the KKT lin-sys stats.
     """
+    x = np.zeros(self.n)
     y = np.zeros(self.m)
     s = np.zeros(self.m)
     y[self.z :] = 1.0
     s[self.z :] = 1.0
+    if self.equilibrate:
+      x, y, s = self._equilibrate_iterates(x, y, s)
+    return x, y, s, 1.0, {}
+
     # This ensures that there is a -I in the bottom rght block of the KKT.
     self._linear_solver.update(mu=0.0, s=s, y=y)
     if self.p.nnz == 0:
@@ -333,7 +338,7 @@ class QTQP:
       max_iter: int = 100,
       step_size_scale: float = 0.99,
       min_static_regularization: float = 1e-8,
-      max_iterative_refinement_steps: int = 10,
+      max_iterative_refinement_steps: int = 50,
       linear_solver_atol: float = 1e-12,
       linear_solver_rtol: float = 1e-12,
       linear_solver: LinearSolver = LinearSolver.AUTO,
@@ -642,6 +647,9 @@ class QTQP:
 
   def _unequilibrate_iterates(self, x, y, s):
     return (self.e * x, self.d * y, s / self.d)
+ 
+  def _equilibrate_iterates(self, x, y, s):
+    return (x / self.e, y / self.d, s * self.d)
 
   def _max_step_size(self, y: np.ndarray, delta_y: np.ndarray) -> float:
     """Finds maximum step `alpha` in [0, 1] s.t. y + alpha * delta_y >= 0."""
@@ -710,28 +718,37 @@ class QTQP:
 
     # Tau solve: exact quadratic when KKT solve converged, linearized
     # fallback when noisy (avoids squaring O(eps) into O(eps^2)).
-    tau_plus = None
-    if lin_sys_stats["converged"]:
-      try:
-        r_tau = (mu - mu_target) * tau_anchor
-        tau_plus = self._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)
-        lin_sys_stats["tau_method"] = "quadratic"
-      except ValueError:
-        logging.debug("Primary tau solve failed; falling back to linearized.")
+    # tau_plus = None
+    # if lin_sys_stats["converged"]:
+    #   try:
+    #     r_tau = (mu - mu_target) * tau_anchor
+    #     tau_plus = self._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)
+    #     lin_sys_stats["tau_method"] = "quadratic"
+    #   except ValueError:
+    #     logging.debug("Primary tau solve failed; falling back to linearized.")
 
-    if tau_plus is None:
-      lin_sys_stats["tau_method"] = "linearized"
-      logging.debug("Using linearized tau fallback.")
-      tau_plus = self._solve_for_tau_linearized_fallback(
-          p, kinv_r, mu, mu_target, x, y, tau, tau_anchor,
-      )
+    # if tau_plus is None:
+    #   lin_sys_stats["tau_method"] = "linearized"
+    #   logging.debug("Using linearized tau fallback.")
+    #   tau_plus = self._solve_for_tau_linearized_fallback(
+    #       p, kinv_r, mu, mu_target, x, y, tau, tau_anchor,
+    #   )
+
+    try:
+      r_tau = (mu - mu_target) * tau_anchor
+      tau_plus = self._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)
+    except ValueError as e:
+      # Fallback if quadratic solve fails numerically (rare but possible)
+      logging.warning("Tau solve failed, using previous tau. Error: %s", e)
+      tau_plus = tau
+
 
     # Reconstruct [x+; y+] = kinv_r - kinv_q * tau+ (in-place on kinv_r).
     kinv_r -= self.kinv_q * tau_plus
     x_plus, y_plus = kinv_r[: self.n], kinv_r[self.n :]
     return x_plus, y_plus, tau_plus, lin_sys_stats
 
-  def _solve_for_tau(self, p, kinv_r, mu, mu_target, r_tau) -> float:
+  def _solve_for_tau(self, p, kinv_r, mu, mu_target, r_tau) -> np.ndarray:
     """Solves for tau+ using the homogeneous embedding's tau equation.
 
     The parametric KKT solution is:
@@ -741,14 +758,15 @@ class QTQP:
         t_a * tau+^2 + t_b * tau+ + t_c = 0
 
     The coefficients t_a, t_b, t_c are computed from inner products of kinv_r
-    and kinv_q with q and P. For LPs (P=0) the P terms drop out. The
-    coefficients are clamped to enforce structural signs (t_a > 0, t_c <= 0),
-    and Muller's stable quadratic formula avoids catastrophic cancellation.
+    and kinv_q with q and P. For LPs (P=0) the P terms drop out. We always take
+    the positive root since tau >= 0 is required for the embedding to represent
+    a feasible point (tau=0 corresponds to a certificate of infeasibility or
+    unboundedness, which is handled separately at termination).
     """
+    # Coefficients of the quadratic t_a * tau+^2 + t_b * tau+ + t_c = 0.
     n = self.n
     q, kinv_q = self.q, self.kinv_q
 
-    # Coefficients of the quadratic t_a * tau+^2 + t_b * tau+ + t_c = 0
     t_a = mu + kinv_q @ q
     t_b = -r_tau - kinv_r @ q
     t_c = -mu_target
@@ -760,27 +778,22 @@ class QTQP:
       t_a -= kinv_q[:n] @ p_kinv_q
       t_b += kinv_r[:n] @ p_kinv_q + kinv_q[:n] @ p_kinv_r
       t_c -= kinv_r[:n] @ p_kinv_r
+    logging.debug("t_a=%s, t_b=%s, t_c=%s", t_a, t_b, t_c)
 
-    # Enforce structural signs
-    t_a = max(t_a, mu)
-    t_c = min(t_c, -mu_target)
+    # Standard quadratic formula for the positive root
+    if abs(t_a) < _EPS:
+      raise ValueError(f"Near-zero t_a={t_a}, cannot solve for tau")
 
     discriminant = t_b**2 - 4 * t_a * t_c
-    if discriminant < 0.0:
-      discriminant = 0.0
+    if discriminant < -1e-9:
+      raise ValueError(f"Negative discriminant: {discriminant}")
 
-    # Stable Quadratic Formula (Muller)
-    if t_b > 0:
-      q_muller = -0.5 * (t_b + math.sqrt(discriminant))
-      tau_sol = t_c / q_muller
-    else:
-      q_muller = -0.5 * (t_b - math.sqrt(discriminant))
-      tau_sol = q_muller / t_a
+    tau_sol = (-t_b + np.sqrt(max(0.0, discriminant))) / (2 * t_a)
 
-    if not np.isfinite(tau_sol) or tau_sol < 0.0:
-      raise ValueError(f"Invalid tau solution: {tau_sol}")
+    if not np.isfinite(tau_sol) or tau_sol < -1e-10:
+      raise ValueError(f"Invalid tau solution found: {tau_sol}")
 
-    return tau_sol
+    return max(0.0, tau_sol)
 
   def _solve_for_tau_linearized_fallback(
       self, p, kinv_r, mu, mu_target, x, y, tau_curr, tau_anchor,
@@ -792,6 +805,7 @@ class QTQP:
     enters linearly rather than quadratically. A [0.1x, 10x] trust region
     prevents manifold drift from the first-order approximation.
     """
+    return tau_curr
     n = self.n
     q, kinv_q = self.q, self.kinv_q
 
@@ -971,7 +985,7 @@ class QTQP:
             "mean_s_over_y": np.mean(s_over_y),
             "std_s_over_y": np.std(s_over_y),
         })
-    print(stats_i)
+    # print(stats_i)
     return status
 
   def _log_header(self):

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -309,7 +309,7 @@ class QTQP:
       max_iter: int = 100,
       step_size_scale: float = 0.99,
       min_static_regularization: float = 1e-8,
-      max_iterative_refinement_steps: int = 50,
+      max_iterative_refinement_steps: int = 10,
       linear_solver_atol: float = 1e-12,
       linear_solver_rtol: float = 1e-12,
       linear_solver: LinearSolver = LinearSolver.AUTO,

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -676,7 +676,7 @@ class QTQP:
     # allocations. Equivalent to: normalize then compute (y @ s) / (m - z).
     # scale = sqrt(m-z+1) / max(_EPS, ||(x,y,tau)||), so scale^2 = (m-z+1) /
     # max(_EPS^2, ||(x,y,tau)||^2), giving mu_aff = scale^2 * (y_aff @ s_aff).
-    xyt_norm_sq = x_aff @ x_aff + y_aff @ y_aff + tau_aff ** 2
+    xyt_norm_sq = x_aff @ x_aff + y_aff @ y_aff + tau_aff * tau_aff
     scale_sq = (self.m - self.z + 1) / max(_EPS**2, xyt_norm_sq)
     mu_aff = scale_sq * (y_aff @ s_aff) / (self.m - self.z)
 

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -608,7 +608,7 @@ class QTQP:
 
   def _unequilibrate_iterates(self, x, y, s):
     return (self.e * x, self.d * y, s / self.d)
- 
+
   def _equilibrate_iterates(self, x, y, s):
     return (x / self.e, y / self.d, s * self.d)
 
@@ -699,7 +699,7 @@ class QTQP:
     x_plus, y_plus = kinv_r[: self.n], kinv_r[self.n :]
     return x_plus, y_plus, tau_plus, lin_sys_stats
 
-  def _solve_for_tau(self, p, kinv_r, mu, mu_target, r_tau) -> np.ndarray:
+  def _solve_for_tau(self, p, kinv_r, mu, mu_target, r_tau) -> float:
     """Solves for tau+ using the homogeneous embedding's tau equation.
 
     The parametric KKT solution is:
@@ -739,7 +739,13 @@ class QTQP:
     if discriminant < -1e-9:
       raise ValueError(f"Negative discriminant: {discriminant}")
 
-    tau_sol = (-t_b + np.sqrt(max(0.0, discriminant))) / (2 * t_a)
+    # Stable Quadratic Formula (Muller)
+    if t_b > 0:
+      q_muller = -0.5 * (t_b + math.sqrt(discriminant))
+      tau_sol = t_c / q_muller
+    else:
+      q_muller = -0.5 * (t_b - math.sqrt(discriminant))
+      tau_sol = q_muller / t_a
 
     if not np.isfinite(tau_sol) or tau_sol < -1e-10:
       raise ValueError(f"Invalid tau solution found: {tau_sol}")
@@ -935,7 +941,6 @@ class QTQP:
             "mean_s_over_y": np.mean(s_over_y),
             "std_s_over_y": np.std(s_over_y),
         })
-    # print(stats_i)
     return status
 
   def _log_header(self):

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -687,7 +687,8 @@ class QTQP:
       lin_sys_stats["tau_method"] = "linearized"
       logging.debug("Using linearized tau fallback.")
       tau_plus = self._solve_for_tau_linearized_fallback(
-          p, kinv_r, mu, mu_target, x, y, tau, tau_anchor)
+          p, kinv_r, mu, mu_target, x, y, tau, tau_anchor
+      )
 
     # Reconstruct [x+; y+] = kinv_r - kinv_q * tau+ (in-place on kinv_r).
     kinv_r -= self.kinv_q * tau_plus
@@ -733,6 +734,7 @@ class QTQP:
     discriminant = t_b * t_b - 4 * t_a * t_c
     if discriminant < -1e-9:
       raise ValueError(f"Negative discriminant: {discriminant}")
+    discriminant = max(0.0, discriminant)
 
     # Stable Quadratic Formula (Muller)
     if t_b > 0:

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -220,6 +220,12 @@ class QTQP:
       )
 
     self._presolve()
+    if self.z == self.m:
+      raise ValueError(
+          "Equality-only problems are not currently supported "
+          "(effective z == m after presolve; some rows may have been dropped "
+          "during presolve)."
+      )
 
     if p is None:
       self.p = sp.csc_matrix((self.n, self.n))
@@ -403,7 +409,7 @@ class QTQP:
 
     stats = []
     self.kinv_q = np.zeros_like(self.q)  # K^{-1}q, warm-started across iterations.
-    x, y, s, tau, q_lin_sys_stats = self._init_variables()
+    x, y, s, tau, _ = self._init_variables()
     status = SolutionStatus.UNFINISHED
     self._log_header()
 
@@ -411,38 +417,16 @@ class QTQP:
     xy = np.empty(self.n + self.m)   # Combined primal-dual vector [x; y]
     d_s = np.zeros(self.m)           # Slack step direction; d_s[:z] is always 0
 
-    # alpha/sigma describe the IPM step that produced the current iterate
-    # and are therefore 0 at init.
     alpha = sigma = 0.0
-    predictor_lin_sys_stats = {}
-    corrector_lin_sys_stats = {}
 
     # --- Main Iteration Loop ---
-    # Evaluate iterate, log/terminate, then take a step. self.it counts steps
-    # already taken (0 = init). When z == m iter 0 terminates (no central path).
-    for self.it in range(max_iter + 1):
+    # self.it counts IPM steps already taken.
+    for self.it in range(max_iter):
+      stats_i = {}
       x, y, tau, s = self._normalize(x, y, tau, s)
 
-      # mu is a property of the current iterate (measures complementarity);
-      # equality-only problems (z == m) have no complementarity block, and
-      # the loop terminates at iter 0 before taking a step, so mu is defined
-      # as 0 there for logging purposes.
-      mu = (y @ s) / (self.m - self.z) if self.z < self.m else 0.0
-
-      stats_i = {
-          "q_lin_sys_stats": q_lin_sys_stats,
-          "predictor_lin_sys_stats": predictor_lin_sys_stats,
-          "corrector_lin_sys_stats": corrector_lin_sys_stats,
-      }
-      status = self._check_termination(
-          x, y, tau, s, alpha, mu, sigma, stats_i, collect_stats
-      )
-      self._log_iteration(stats_i)
-      if collect_stats:
-        stats.append(stats_i)
-      if (status != SolutionStatus.UNFINISHED
-          or self.it == max_iter or self.z == self.m):
-        break
+      # mu is a property of the current iterate (measures complementarity).
+      mu = (y @ s) / (self.m - self.z)
 
       # --- Take an IPM step ---
       self._linear_solver.update(mu=mu, s=s, y=y)
@@ -452,6 +436,7 @@ class QTQP:
       self.kinv_q, q_lin_sys_stats = self._linear_solver.solve(
           rhs=self.q, warm_start=self.kinv_q
       )
+      stats_i["q_lin_sys_stats"] = q_lin_sys_stats
 
       # --- Step 2: Predictor (Affine) Step ---
       # Solve KKT with mu_target = 0 to find pure Newton direction.
@@ -469,6 +454,7 @@ class QTQP:
           tau=tau,
           correction=None,
       )
+      stats_i["predictor_lin_sys_stats"] = predictor_lin_sys_stats
 
       d_x_p, d_y_p, d_tau_p = x_p - x, y_p - y, tau_p - tau
       # Predictor slack step from the linearized complementarity condition with
@@ -506,6 +492,7 @@ class QTQP:
           tau=tau,
           correction=correction,
       )
+      stats_i["corrector_lin_sys_stats"] = corrector_lin_sys_stats
 
       # --- Step 4: Update Iterates ---
       d_x, d_y, d_tau = x_c - x, y_c - y, tau_c - tau
@@ -528,6 +515,15 @@ class QTQP:
       y[self.z :] = np.maximum(y[self.z :], 1e-30)
       s[self.z :] = np.maximum(s[self.z :], 1e-30)
       tau = max(tau, 1e-30)
+
+      status = self._check_termination(
+          x, y, tau, s, alpha, mu, sigma, stats_i, collect_stats
+      )
+      self._log_iteration(stats_i)
+      if collect_stats:
+        stats.append(stats_i)
+      if status != SolutionStatus.UNFINISHED:
+        break
 
     # We have terminated for one reason or another.
     self._linear_solver.free()

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -283,27 +283,45 @@ class QTQP:
       return 0.0
     return ps.b_dropped - ps.a_dropped @ x
 
-  def _init_variables(self, x, y, s, a, b):
+  def _init_variables(self):
     """KKT-based starting point (modified in-place). Solves the mu=0 KKT
     system, then shifts inequality (y, s) into the cone's strict interior.
     When z == m the solve is exact. Returns the KKT lin-sys stats.
     """
+    y = np.zeros(self.m)
+    s = np.zeros(self.m)
+    y[self.z :] = 1.0
+    s[self.z :] = 1.0
+    # This ensures that there is a -I in the bottom rght block of the KKT.
     self._linear_solver.update(mu=0.0, s=s, y=y)
-    sol, init_stats = self._linear_solver.solve(
-        rhs=-self.q, warm_start=np.zeros_like(self.q),
-    )
-    x[:] = sol[: self.n]
-    y[:] = sol[self.n :]
-    s[:] = b - a @ x
+    if self.p.nnz == 0:
+      # Handle the LP case slightly differently.
+      xs, _ = self._linear_solver.solve(
+        rhs=np.concatenate([np.zeros(self.n), self.b]), warm_start=self.kinv_q,
+      )
+      xy, init_stats = self._linear_solver.solve(
+        rhs=np.concatenate([self.c, np.zeros(self.m)]), warm_start=self.kinv_q,
+      )
+      x = -xs[: self.n]
+      y = -xy[self.n :]
+      s = xs[self.n :]
+    else:
+      xy, init_stats = self._linear_solver.solve(
+          rhs=self.q, warm_start=self.kinv_q,
+      )
+      x = -xy[: self.n]
+      y = -xy[self.n :]
+      s = -y
+    
     s[: self.z] = 0.0
     # No-op when z == m (no inequality indices).
-    alpha_p = -np.min(s[self.z :], initial=np.inf)
-    alpha_d = -np.min(y[self.z :], initial=np.inf)
-    if alpha_p >= -1.0:
-      s[self.z :] += 1.0 + alpha_p
-    if alpha_d >= -1.0:
-      y[self.z :] += 1.0 + alpha_d
-    return init_stats
+    alpha_s = np.min(s[self.z :], initial=np.inf)
+    alpha_y = np.min(y[self.z :], initial=np.inf)
+    if alpha_s <= 1.0:
+      s[self.z :] += 1.0 - alpha_s
+    if alpha_y <= 1.0:
+      y[self.z :] += 1.0 - alpha_y
+    return x, y, s, 1.0, init_stats
 
   def solve(
       self,
@@ -383,22 +401,8 @@ class QTQP:
           f" nnz(P)={self.p.nnz}, linear_solver={resolved_linear_solver.name}"
       )
 
-    # --- Initialization ---
-    x = np.zeros(self.n)
-    y = np.zeros(self.m)
-    s = np.zeros(self.m)
-
-    # Initialize inequality duals and slacks to 1.0. This places the starting
-    # point strictly inside the cone (required for the IPM) and sets the
-    # initial barrier parameter mu = (y @ s) / (m - z) = 1.0.
-    y[self.z :] = 1.0
-    s[self.z :] = 1.0
-
-    tau = 1.0
-
     if self.equilibrate:
       a, p, b, c, self.d, self.e = self._equilibrate()
-      x, y, s = self._equilibrate_iterates(x, y, s)
     else:
       a, p, b, c, self.d, self.e = self.a, self.p, self.b, self.c, None, None
 
@@ -427,10 +431,9 @@ class QTQP:
         solver=linear_solver_backend,
     )
 
-    init_stats = self._init_variables(x, y, s, a, b)
-
     stats = []
     self.kinv_q = np.zeros_like(self.q)  # K^{-1}q, warm-started across iterations.
+    x, y, s, tau, q_lin_sys_stats = self._init_variables()
     status = SolutionStatus.UNFINISHED
     self._log_header()
 
@@ -441,7 +444,6 @@ class QTQP:
     # alpha/sigma describe the IPM step that produced the current iterate
     # and are therefore 0 at init.
     alpha = sigma = 0.0
-    q_lin_sys_stats = init_stats
     predictor_lin_sys_stats = {}
     corrector_lin_sys_stats = {}
 
@@ -582,7 +584,7 @@ class QTQP:
         y, s = self._postsolve(y, s, y_dropped=np.nan)
         return Solution(x, y, s, stats, status)
       case SolutionStatus.UNFINISHED:
-        self._log_footer(f"Failed to converge in {max_iter} iterations")
+        self._log_footer(f"Failed to converge")
         x, y, s = x / tau, y / tau, s / tau
         y, s = self._postsolve(y, s, s_dropped=self._dropped_slack(x))
         return Solution(x, y, s, stats, SolutionStatus.FAILED)
@@ -640,9 +642,6 @@ class QTQP:
 
   def _unequilibrate_iterates(self, x, y, s):
     return (self.e * x, self.d * y, s / self.d)
-
-  def _equilibrate_iterates(self, x, y, s):
-    return (x / self.e, y / self.d, s * self.d)
 
   def _max_step_size(self, y: np.ndarray, delta_y: np.ndarray) -> float:
     """Finds maximum step `alpha` in [0, 1] s.t. y + alpha * delta_y >= 0."""
@@ -972,7 +971,7 @@ class QTQP:
             "mean_s_over_y": np.mean(s_over_y),
             "std_s_over_y": np.std(s_over_y),
         })
-
+    print(stats_i)
     return status
 
   def _log_header(self):

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -284,10 +284,6 @@ class QTQP:
     return ps.b_dropped - ps.a_dropped @ x
 
   def _init_variables(self):
-    """KKT-based starting point (modified in-place). Solves the mu=0 KKT
-    system, then shifts inequality (y, s) into the cone's strict interior.
-    When z == m the solve is exact. Returns the KKT lin-sys stats.
-    """
     x = np.zeros(self.n)
     y = np.zeros(self.m)
     s = np.zeros(self.m)
@@ -296,37 +292,6 @@ class QTQP:
     if self.equilibrate:
       x, y, s = self._equilibrate_iterates(x, y, s)
     return x, y, s, 1.0, {}
-
-    # This ensures that there is a -I in the bottom rght block of the KKT.
-    self._linear_solver.update(mu=0.0, s=s, y=y)
-    if self.p.nnz == 0:
-      # Handle the LP case slightly differently.
-      xs, _ = self._linear_solver.solve(
-        rhs=np.concatenate([np.zeros(self.n), self.b]), warm_start=self.kinv_q,
-      )
-      xy, init_stats = self._linear_solver.solve(
-        rhs=np.concatenate([self.c, np.zeros(self.m)]), warm_start=self.kinv_q,
-      )
-      x = -xs[: self.n]
-      y = -xy[self.n :]
-      s = xs[self.n :]
-    else:
-      xy, init_stats = self._linear_solver.solve(
-          rhs=self.q, warm_start=self.kinv_q,
-      )
-      x = -xy[: self.n]
-      y = -xy[self.n :]
-      s = -y
-    
-    s[: self.z] = 0.0
-    # No-op when z == m (no inequality indices).
-    alpha_s = np.min(s[self.z :], initial=np.inf)
-    alpha_y = np.min(y[self.z :], initial=np.inf)
-    if alpha_s <= 1.0:
-      s[self.z :] += 1.0 - alpha_s
-    if alpha_y <= 1.0:
-      y[self.z :] += 1.0 - alpha_y
-    return x, y, s, 1.0, init_stats
 
   def solve(
       self,
@@ -526,9 +491,9 @@ class QTQP:
       # feed the predictor's cross-term d_y_p*d_s_p back into the corrector RHS
       # (divided by y because the KKT complementarity block is scaled by 1/y),
       # so the corrector step can incorporate it to land closer to the target.
-      correction = -d_s[self.z :] * d_y_p[self.z :] / y[self.z :]
-      xy[: self.n] = x_p
-      xy[self.n :] = y_p
+      correction = -d_s[self.z:] * d_y_p[self.z:] / y[self.z:]
+      xy[:self.n] = x_p
+      xy[self.n:] = y_p
       x_c, y_c, tau_c, corrector_lin_sys_stats = self._newton_step(
           p=p,
           mu=mu,
@@ -629,7 +594,7 @@ class QTQP:
       col_scale_a = np.repeat(e_i, np.diff(a.indptr))
       a.data *= d_i[a.indices] * col_scale_a
       if p.nnz > 0:
-      	# E @ P @ E: scale non-zero at row r, col c by e_i[r] * e_i[c].
+        # E @ P @ E: scale non-zero at row r, col c by e_i[r] * e_i[c].
         col_scale_p = np.repeat(e_i, np.diff(p.indptr))
         p.data *= e_i[p.indices] * col_scale_p
 
@@ -677,19 +642,19 @@ class QTQP:
     # scale = sqrt(m-z+1) / max(_EPS, ||(x,y,tau)||), so scale^2 = (m-z+1) /
     # max(_EPS^2, ||(x,y,tau)||^2), giving mu_aff = scale^2 * (y_aff @ s_aff).
     xyt_norm_sq = x_aff @ x_aff + y_aff @ y_aff + tau_aff * tau_aff
-    scale_sq = (self.m - self.z + 1) / max(_EPS**2, xyt_norm_sq)
+    scale_sq = (self.m - self.z + 1) / max(_EPS * _EPS, xyt_norm_sq)
     mu_aff = scale_sq * (y_aff @ s_aff) / (self.m - self.z)
 
     # sigma = (mu_aff / mu)^3: Mehrotra's heuristic. If the affine step already
     # drives mu close to zero, sigma is small (aggressive, little centering).
     # If mu_aff ≈ mu (affine step didn't help much), sigma ≈ 1 (full centering).
     # The cubic exponent amplifies the contrast, pushing sigma toward 0 or 1.
-    sigma = (mu_aff / max(_EPS, mu_curr)) ** 3
+    sigma_base = mu_aff / max(_EPS, mu_curr)
+    sigma = sigma_base * sigma_base * sigma_base  # More stable than **3.
     return np.clip(sigma, 0.0, 1.0)
 
   def _newton_step(
-      self, *, p, mu, mu_target, r_anchor, tau_anchor, x, y, s, tau,
-      correction,
+      self, *, p, mu, mu_target, r_anchor, tau_anchor, x, y, s, tau, correction,
   ):
     """Computes a Newton search direction by solving the augmented KKT system.
 
@@ -718,30 +683,20 @@ class QTQP:
 
     # Tau solve: exact quadratic when KKT solve converged, linearized
     # fallback when noisy (avoids squaring O(eps) into O(eps^2)).
-    # tau_plus = None
-    # if lin_sys_stats["converged"]:
-    #   try:
-    #     r_tau = (mu - mu_target) * tau_anchor
-    #     tau_plus = self._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)
-    #     lin_sys_stats["tau_method"] = "quadratic"
-    #   except ValueError:
-    #     logging.debug("Primary tau solve failed; falling back to linearized.")
+    tau_plus = None
+    if lin_sys_stats["converged"] or lin_sys_stats["final_residual_norm"] < 1e-7:
+      try:
+        r_tau = (mu - mu_target) * tau_anchor
+        tau_plus = self._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)
+        lin_sys_stats["tau_method"] = "quadratic"
+      except ValueError:
+        logging.debug("Primary tau solve failed; falling back to linearized.")
 
-    # if tau_plus is None:
-    #   lin_sys_stats["tau_method"] = "linearized"
-    #   logging.debug("Using linearized tau fallback.")
-    #   tau_plus = self._solve_for_tau_linearized_fallback(
-    #       p, kinv_r, mu, mu_target, x, y, tau, tau_anchor,
-    #   )
-
-    try:
-      r_tau = (mu - mu_target) * tau_anchor
-      tau_plus = self._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)
-    except ValueError as e:
-      # Fallback if quadratic solve fails numerically (rare but possible)
-      logging.warning("Tau solve failed, using previous tau. Error: %s", e)
-      tau_plus = tau
-
+    if tau_plus is None:
+      lin_sys_stats["tau_method"] = "linearized"
+      logging.debug("Using linearized tau fallback.")
+      tau_plus = self._solve_for_tau_linearized_fallback(
+          p, kinv_r, mu, mu_target, x, y, tau, tau_anchor)
 
     # Reconstruct [x+; y+] = kinv_r - kinv_q * tau+ (in-place on kinv_r).
     kinv_r -= self.kinv_q * tau_plus
@@ -784,7 +739,7 @@ class QTQP:
     if abs(t_a) < _EPS:
       raise ValueError(f"Near-zero t_a={t_a}, cannot solve for tau")
 
-    discriminant = t_b**2 - 4 * t_a * t_c
+    discriminant = t_b * t_b - 4 * t_a * t_c
     if discriminant < -1e-9:
       raise ValueError(f"Negative discriminant: {discriminant}")
 
@@ -805,7 +760,6 @@ class QTQP:
     enters linearly rather than quadratically. A [0.1x, 10x] trust region
     prevents manifold drift from the first-order approximation.
     """
-    return tau_curr
     n = self.n
     q, kinv_q = self.q, self.kinv_q
 
@@ -821,13 +775,13 @@ class QTQP:
     px_rz = px @ kinv_r[:n] - tau_curr * px_kinv_q - x_px
 
     # Base residual G(z_curr, tau_curr).
-    g = (mu * tau_curr**2 + (mu_target - mu) * tau_anchor * tau_curr
-         - tau_curr * q_z - mu_target - x_px)
+    g = (mu * tau_curr * tau_curr + (mu_target - mu) * tau_anchor * tau_curr -
+         tau_curr * q_z - mu_target - x_px)
 
     # Numerator: G + (dG/dz) @ r_z.  Denominator: dG/dtau - (dG/dz) @ kinv_q.
     num = g - tau_curr * q_rz - 2.0 * px_rz
-    den = (2.0 * mu * tau_curr + (mu_target - mu) * tau_anchor - q_z
-           + tau_curr * q_kinv_q + 2.0 * px_kinv_q)
+    den = (2.0 * mu * tau_curr + (mu_target - mu) * tau_anchor - q_z +
+           tau_curr * q_kinv_q + 2.0 * px_kinv_q)
 
     tau_sol = tau_curr + (0.0 if abs(den) < 1e-16 else -num / den)
 
@@ -851,7 +805,7 @@ class QTQP:
 
     Operates in-place on the iterate arrays and returns them for convenience.
     """
-    xyt_norm = math.sqrt(x @ x + y @ y + tau ** 2)
+    xyt_norm = math.sqrt(x @ x + y @ y + tau * tau)
     scale = math.sqrt(self.m - self.z + 1) / max(_EPS, xyt_norm)
     x *= scale
     y *= scale
@@ -861,8 +815,8 @@ class QTQP:
 
   def _compute_step_size(self, y, s, d_y, d_s) -> float:
     """Computes the maximum standard primal-dual step size."""
-    alpha_s = self._max_step_size(s[self.z :], d_s[self.z :])
-    alpha_y = self._max_step_size(y[self.z :], d_y[self.z :])
+    alpha_s = self._max_step_size(s[self.z:], d_s[self.z:])
+    alpha_y = self._max_step_size(y[self.z:], d_y[self.z:])
     return min(alpha_s, alpha_y)
 
   def _check_termination(self, x, y, tau, s, alpha, mu, sigma, stats_i, collect_stats):

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -305,7 +305,7 @@ class AccelerateSolver(LinearSolver):
   def factorize(self):
     if self._solver is None:
       self._solver = self._macldlt.LDLTSolver(
-        self._kkt, triangle="upper", factorization="ldlt_sbk")
+        self._kkt, triangle="upper", factorization="ldlt_tpp", ordering="metis")
     else:
       self._solver.refactor(self._kkt.data)
 

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -304,7 +304,8 @@ class AccelerateSolver(LinearSolver):
 
   def factorize(self):
     if self._solver is None:
-      self._solver = self._macldlt.LDLTSolver(self._kkt, triangle="upper")
+      self._solver = self._macldlt.LDLTSolver(
+        self._kkt, triangle="upper", factorization="ldlt_sbk")
     else:
       self._solver.refactor(self._kkt.data)
 

--- a/src/qtqp/solvers_sparse.py
+++ b/src/qtqp/solvers_sparse.py
@@ -305,7 +305,7 @@ class AccelerateSolver(LinearSolver):
   def factorize(self):
     if self._solver is None:
       self._solver = self._macldlt.LDLTSolver(
-        self._kkt, triangle="upper", factorization="ldlt_tpp", ordering="metis")
+        self._kkt, triangle="upper", factorization="ldlt_sbk", ordering="metis")
     else:
       self._solver.refactor(self._kkt.data)
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -500,21 +500,20 @@ def _append_dropped_inequalities(a, b, n_extra, random_state, rhs_value):
 @pytest.mark.parametrize('seed', 1542 + np.arange(10))
 @pytest.mark.parametrize('mn', ((5, 10), (30, 50), (80, 100)))
 def test_equality_only_solve(equilibrate, seed, mn):
-  """Test equality-only QP (z == m) solved via direct KKT system."""
+  """Equality-only QP (z == m) is currently rejected."""
   rng = np.random.default_rng(seed)
   m, n = mn
   z = m
   a, b, c, p = _gen_equality_only(m, n, random_state=rng)
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=True, equilibrate=equilibrate,
-  )
-  _assert_solution(solution, a, b, c, p, z)
-  assert solution.stats == []
+  with pytest.raises(ValueError, match='effective z == m'):
+    _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+        verbose=True, equilibrate=equilibrate,
+    )
 
 
 @pytest.mark.parametrize('seed', 2042 + np.arange(5))
 def test_equality_only_lp(seed):
-  """Test equality-only LP (P=0, z=m) solved via direct KKT system.
+  """Equality-only LP (P=0, z=m) is currently rejected.
 
   Uses n == m (square A) so the KKT system is non-singular with P=0.
   """
@@ -527,19 +526,12 @@ def test_equality_only_lp(seed):
   b = a @ x_star
   c = -(a.T @ y_star)
   p = sparse.csc_matrix((n, n))
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z).solve(verbose=True)
-  _assert_solution(solution, a, b, c, p, z)
-  assert solution.stats == []
+  with pytest.raises(ValueError, match='effective z == m'):
+    _ = qtqp.QTQP(a=a, b=b, c=c, z=z).solve(verbose=True)
 
 
 def test_equality_only_inconsistent():
-  """Inconsistent equality constraints do not get reported as SOLVED.
-
-  Depending on the linear-solver backend, a rank-deficient KKT system
-  may return either INFEASIBLE (Farkas-type certificate detected) or
-  FAILED (residuals nonzero, no certificate detected). Either outcome
-  is acceptable; SOLVED is not.
-  """
+  """Inconsistent equality-only problems are rejected before solve."""
   n, m, z = 5, 3, 3
   # All rows of A are identical -> Ax = b can only be satisfied if all b_i
   # are equal. Since they are not, the problem is primal infeasible.
@@ -547,15 +539,12 @@ def test_equality_only_inconsistent():
   b = np.array([1.0, 2.0, 3.0])
   c = np.ones(n)
   p = sparse.csc_matrix((n, n))
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
-  assert solution.status in (
-      qtqp.SolutionStatus.INFEASIBLE,
-      qtqp.SolutionStatus.FAILED,
-  )
+  with pytest.raises(ValueError, match='effective z == m'):
+    _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
 
 
 def test_presolve_drops_all_inequalities():
-  """Test presolve dropping all inequalities triggers direct solve."""
+  """Dropping all inequalities in presolve yields an unsupported equality-only problem."""
   rng = np.random.default_rng(842)
   m_eq, n = 5, 20
   m_ineq = 5
@@ -565,10 +554,8 @@ def test_presolve_drops_all_inequalities():
   a, b = _append_dropped_inequalities(
       a, b, n_extra=m_ineq, random_state=rng, rhs_value=1e21,
   )
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
-  _assert_solution(solution, a, b, c, p, z)
-  assert solution.y.shape == (m,)
-  assert solution.s.shape == (m,)
+  with pytest.raises(ValueError, match='effective z == m'):
+    _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
 
 
 def test_presolve_restores_infeasible_certificate():
@@ -609,21 +596,17 @@ def test_presolve_restores_unbounded_certificate():
 
 
 def test_presolve_accepts_posinf_inequalities():
-  """Literal +inf inequality RHS should be dropped without entering the KKT."""
+  """Literal +inf inequality RHS may reduce the problem to unsupported equality-only."""
   rng = np.random.default_rng(2042)
   m_eq, n, z = 5, 20, 5
   a, b, c, p = _gen_equality_only(m_eq, n, random_state=rng)
-  baseline = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
+  with pytest.raises(ValueError, match='effective z == m'):
+    _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
   a_full, b_full = _append_dropped_inequalities(
       a, b, n_extra=3, random_state=rng, rhs_value=np.inf,
   )
-  solution = qtqp.QTQP(a=a_full, b=b_full, c=c, z=z, p=p).solve(verbose=True)
-  assert solution.status == qtqp.SolutionStatus.SOLVED
-  np.testing.assert_allclose(solution.x, baseline.x, atol=1e-8, rtol=1e-8)
-  np.testing.assert_allclose(solution.y[:z], baseline.y, atol=1e-8, rtol=1e-8)
-  np.testing.assert_allclose(solution.s[:z], baseline.s, atol=1e-8, rtol=1e-8)
-  np.testing.assert_allclose(solution.y[z:], 0.0, atol=0.0, rtol=0.0)
-  assert np.all(np.isposinf(solution.s[z:]))
+  with pytest.raises(ValueError, match='effective z == m'):
+    _ = qtqp.QTQP(a=a_full, b=b_full, c=c, z=z, p=p).solve(verbose=True)
 
 
 def test_raise_error_nonfinite_equality_rhs():
@@ -638,19 +621,18 @@ def test_raise_error_nonfinite_equality_rhs():
 @pytest.mark.parametrize('linear_solver', _SOLVERS)
 @pytest.mark.parametrize('seed', 3042 + np.arange(5))
 def test_equality_only_all_backends(linear_solver, seed):
-  """Test equality-only QP with every linear solver backend."""
+  """Equality-only QP is rejected before choosing a backend-specific path."""
   rng = np.random.default_rng(seed)
   m, n, z = 20, 40, 20
   a, b, c, p = _gen_equality_only(m, n, random_state=rng)
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=True, linear_solver=linear_solver,
-  )
-  _assert_solution(solution, a, b, c, p, z)
-  assert solution.stats == []
+  with pytest.raises(ValueError, match='effective z == m'):
+    _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+        verbose=True, linear_solver=linear_solver,
+    )
 
 
 def test_equality_only_recovers_known_solution():
-  """Test that the direct solve recovers the ground-truth (x*, y*)."""
+  """Equality-only QP with known solution is currently rejected."""
   rng = np.random.default_rng(7742)
   m, n, z = 10, 20, 10
   x_star = rng.normal(size=n)
@@ -661,32 +643,25 @@ def test_equality_only_recovers_known_solution():
   p = sparse.csc_matrix(q.T @ q * 0.01)
   b = a @ x_star
   c = -(p @ x_star + a.T @ y_star)
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
-  assert solution.status == qtqp.SolutionStatus.SOLVED
-  np.testing.assert_allclose(solution.x, x_star, atol=1e-6)
-  np.testing.assert_allclose(solution.y, y_star, atol=1e-6)
-  np.testing.assert_allclose(solution.s, np.zeros(m), atol=1e-10)
+  with pytest.raises(ValueError, match='effective z == m'):
+    _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
 
 
 def test_equality_only_verbose(capsys):
-  """Test that equality-only path prints header and footer and terminates at iter 0."""
+  """Equality-only QP is rejected before any iteration logging."""
   rng = np.random.default_rng(8842)
   m, n, z = 5, 10, 5
   a, b, c, p = _gen_equality_only(m, n, random_state=rng)
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=True, collect_stats=True
-  )
-  assert solution.status == qtqp.SolutionStatus.SOLVED
-  # Init KKT solve is exact, so iter 0 terminates immediately.
-  assert len(solution.stats) == 1
+  with pytest.raises(ValueError, match='effective z == m'):
+    _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+        verbose=True, collect_stats=True
+    )
   captured = capsys.readouterr().out
-  assert 'QTQP v' in captured
-  assert 'z=5' in captured
-  assert 'Solved' in captured
+  assert captured == ''
 
 
 def test_equality_only_sparse_p():
-  """Test equality-only QP where P is sparse (not dense-generated)."""
+  """Equality-only QP with sparse P is currently rejected."""
   rng = np.random.default_rng(9942)
   m, n, z = 15, 30, 15
   x_star = rng.normal(size=n)
@@ -702,11 +677,10 @@ def test_equality_only_sparse_p():
   p = (p.T @ p) * 0.01  # Make PSD.
   b = a @ x_star
   c = -(p @ x_star + a.T @ y_star)
-  solution = qtqp.QTQP(
-      a=sparse.csc_matrix(a), b=b, c=c, z=z, p=sparse.csc_matrix(p),
-  ).solve(verbose=True)
-  _assert_solution(solution, sparse.csc_matrix(a), b, c, sparse.csc_matrix(p), z)
-  assert solution.stats == []
+  with pytest.raises(ValueError, match='effective z == m'):
+    _ = qtqp.QTQP(
+        a=sparse.csc_matrix(a), b=b, c=c, z=z, p=sparse.csc_matrix(p),
+    ).solve(verbose=True)
 
 
 def test_raise_error_negative_invalid_shapes():
@@ -1474,6 +1448,22 @@ def test_failed_status():
   assert np.all(np.isfinite(solution.s))
 
 
+def test_failed_status_collect_stats_counts_post_step_iterates():
+  """With end-of-loop logging, max_iter bounds the number of recorded IPM steps."""
+  rng = np.random.default_rng(42)
+  m, n, z = 150, 100, 10
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      max_iter=1, verbose=True, collect_stats=True
+  )
+
+  assert solution.status == qtqp.SolutionStatus.FAILED
+  assert len(solution.stats) == 1
+  assert solution.stats[0]['iter'] == 0
+  assert solution.stats[0]['status'] == qtqp.SolutionStatus.UNFINISHED
+
+
 # =============================================================================
 # collect_stats=False (default)
 # =============================================================================
@@ -1655,7 +1645,7 @@ def test_verbose_true(capsys):
 # =============================================================================
 
 def test_stats_iter_sequence():
-  """Test that iter counts 0,1,2,... and final status matches solution status."""
+  """Recorded stats index post-step iterates as 0,1,2,..."""
   rng = np.random.default_rng(42)
   m, n, z = 10, 5, 3
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
@@ -2027,10 +2017,9 @@ def test_stats_monotonicity():
         f"time not increasing: time[{i}]={times[i]} < time[{i-1}]={times[i-1]}"
     )
 
-  # alpha should be in (0, 1] at every IPM step. Iteration 0 is the
-  # initialization point before any step, so alpha=0 there by convention.
-  assert alphas[0] == 0.0
-  for i, a_val in enumerate(alphas[1:], start=1):
+  # alpha should be in (0, 1] at every recorded iterate because stats are now
+  # logged after each IPM step, not at the initialization point.
+  for i, a_val in enumerate(alphas):
     assert 0 < a_val <= 1.0, f"alpha[{i}]={a_val} not in (0, 1]"
 
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1538,16 +1538,16 @@ def test_resolve():
 
 
 # =============================================================================
-# verbose=True produces no output
+# verbose=False produces no output
 # =============================================================================
 
 def test_verbose_false(capsys):
-  """Test that verbose=True suppresses all printed output."""
+  """Test that verbose=False suppresses all printed output."""
   rng = np.random.default_rng(42)
   m, n, z = 10, 5, 3
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
-  qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
+  qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
 
   captured = capsys.readouterr()
   assert captured.out == ""

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -506,7 +506,7 @@ def test_equality_only_solve(equilibrate, seed, mn):
   z = m
   a, b, c, p = _gen_equality_only(m, n, random_state=rng)
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=False, equilibrate=equilibrate,
+      verbose=True, equilibrate=equilibrate,
   )
   _assert_solution(solution, a, b, c, p, z)
   assert solution.stats == []
@@ -527,7 +527,7 @@ def test_equality_only_lp(seed):
   b = a @ x_star
   c = -(a.T @ y_star)
   p = sparse.csc_matrix((n, n))
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z).solve(verbose=False)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z).solve(verbose=True)
   _assert_solution(solution, a, b, c, p, z)
   assert solution.stats == []
 
@@ -547,7 +547,7 @@ def test_equality_only_inconsistent():
   b = np.array([1.0, 2.0, 3.0])
   c = np.ones(n)
   p = sparse.csc_matrix((n, n))
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
   assert solution.status in (
       qtqp.SolutionStatus.INFEASIBLE,
       qtqp.SolutionStatus.FAILED,
@@ -565,7 +565,7 @@ def test_presolve_drops_all_inequalities():
   a, b = _append_dropped_inequalities(
       a, b, n_extra=m_ineq, random_state=rng, rhs_value=1e21,
   )
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
   _assert_solution(solution, a, b, c, p, z)
   assert solution.y.shape == (m,)
   assert solution.s.shape == (m,)
@@ -579,7 +579,7 @@ def test_presolve_restores_infeasible_certificate():
   a, b = _append_dropped_inequalities(
       a, b, n_extra=3, random_state=rng, rhs_value=1e21,
   )
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
   _assert_infeasible(solution, a, b, z)
 
 
@@ -592,7 +592,7 @@ def test_presolve_restores_unbounded_certificate():
   a, b = _append_dropped_inequalities(
       a, b, n_extra=3, random_state=rng, rhs_value=1e21,
   )
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
   assert solution.status == qtqp.SolutionStatus.UNBOUNDED
   np.testing.assert_array_equal(np.isnan(solution.y), True)
   np.testing.assert_array_equal(np.isnan(solution.s[-3:]), True)
@@ -613,11 +613,11 @@ def test_presolve_accepts_posinf_inequalities():
   rng = np.random.default_rng(2042)
   m_eq, n, z = 5, 20, 5
   a, b, c, p = _gen_equality_only(m_eq, n, random_state=rng)
-  baseline = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  baseline = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
   a_full, b_full = _append_dropped_inequalities(
       a, b, n_extra=3, random_state=rng, rhs_value=np.inf,
   )
-  solution = qtqp.QTQP(a=a_full, b=b_full, c=c, z=z, p=p).solve(verbose=False)
+  solution = qtqp.QTQP(a=a_full, b=b_full, c=c, z=z, p=p).solve(verbose=True)
   assert solution.status == qtqp.SolutionStatus.SOLVED
   np.testing.assert_allclose(solution.x, baseline.x, atol=1e-8, rtol=1e-8)
   np.testing.assert_allclose(solution.y[:z], baseline.y, atol=1e-8, rtol=1e-8)
@@ -643,7 +643,7 @@ def test_equality_only_all_backends(linear_solver, seed):
   m, n, z = 20, 40, 20
   a, b, c, p = _gen_equality_only(m, n, random_state=rng)
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=False, linear_solver=linear_solver,
+      verbose=True, linear_solver=linear_solver,
   )
   _assert_solution(solution, a, b, c, p, z)
   assert solution.stats == []
@@ -661,7 +661,7 @@ def test_equality_only_recovers_known_solution():
   p = sparse.csc_matrix(q.T @ q * 0.01)
   b = a @ x_star
   c = -(p @ x_star + a.T @ y_star)
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
   assert solution.status == qtqp.SolutionStatus.SOLVED
   np.testing.assert_allclose(solution.x, x_star, atol=1e-6)
   np.testing.assert_allclose(solution.y, y_star, atol=1e-6)
@@ -704,7 +704,7 @@ def test_equality_only_sparse_p():
   c = -(p @ x_star + a.T @ y_star)
   solution = qtqp.QTQP(
       a=sparse.csc_matrix(a), b=b, c=c, z=z, p=sparse.csc_matrix(p),
-  ).solve(verbose=False)
+  ).solve(verbose=True)
   _assert_solution(solution, sparse.csc_matrix(a), b, c, sparse.csc_matrix(p), z)
   assert solution.stats == []
 
@@ -1548,16 +1548,16 @@ def test_resolve():
 
 
 # =============================================================================
-# verbose=False produces no output
+# verbose=True produces no output
 # =============================================================================
 
 def test_verbose_false(capsys):
-  """Test that verbose=False suppresses all printed output."""
+  """Test that verbose=True suppresses all printed output."""
   rng = np.random.default_rng(42)
   m, n, z = 10, 5, 3
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
-  qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
 
   captured = capsys.readouterr()
   assert captured.out == ""


### PR DESCRIPTION
## Summary
- reject equality-only effective problems with a `ValueError` after presolve, with an error message that notes presolve may have dropped rows and left `z == m`
- restore residual checking and iteration logging at the end of each IPM loop so recorded stats describe post-step iterates rather than the initializer
- update the equality-only and iteration-stat tests to match the current solver contract

## Validation
- `PYTHONPATH=src python -m pytest tests/test_qtqp.py -k 'equality_only or presolve_drops_all_inequalities or presolve_accepts_posinf_inequalities' -q`
- `PYTHONPATH=src python -m pytest tests/test_qtqp.py::test_failed_status_collect_stats_counts_post_step_iterates tests/test_qtqp.py::test_stats_iter_sequence tests/test_qtqp.py::test_residuals_decrease tests/test_qtqp.py::test_failed_status tests/test_qtqp.py::test_verbose_failed -q`
- `PYTHONPATH=src python -m pytest 'tests/test_qtqp.py::test_solve[mnz1-LinearSolver.ACCELERATE-seed0-True]' -q`
