### PR TITLE
Clarify equilibration sparse formats

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -568,7 +568,7 @@ class QTQP:
     """Ruiz equilibration to improve numerical conditioning."""
     # Work on copies so self.a / self.p are not modified in-place; they are
     # used unequilibrated later (e.g. in _check_termination).
-    a, p = self.a.copy(), self.p.copy()
+    a, p = self.a.copy().tocsc(), self.p.copy().tocsc()
     b, c = self.b, self.c
     # Initialize the equilibration matrices.
     d, e = (np.ones(self.m), np.ones(self.n))


### PR DESCRIPTION
## Summary
- copy A and P as CSC matrices before in-place Ruiz equilibration scaling
- keep the existing sparse norm implementation and equilibration math unchanged

## Tests
- PYTHONPATH=src pytest -q tests/test_qtqp.py::test_equivalent_equilibration