### PR TITLE
Validate quadratic matrix symmetry

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -229,34 +229,21 @@ class QTQP:
     if p is None:
       self.p = sp.csc_matrix((self.n, self.n))
     else:
-      self.p = self._validate_and_canonicalize_p(p)
-
-  def _validate_and_canonicalize_p(self, p: sp.csc_matrix) -> sp.csc_matrix:
-    """Validates and returns a symmetric CSC copy of the quadratic matrix."""
-    if not sp.isspmatrix_csc(p):
-      raise TypeError("QP matrix 'p' must be in CSC format.")
-    if p.shape != (self.n, self.n):
-      raise ValueError(
-          f"p must have shape ({self.n}, {self.n}), got {p.shape}"
-      )
-
-    p = p.copy().tocsc()
-    p.sum_duplicates()
-    p.eliminate_zeros()
-    if not np.all(np.isfinite(p.data)):
-      raise ValueError("QP matrix 'p' must contain only finite values.")
-
-    asymmetry = (p - p.T).tocsc()
-    asymmetry.eliminate_zeros()
-    if asymmetry.nnz:
-      scale = max(1.0, np.max(np.abs(p.data), initial=0.0))
-      if np.max(np.abs(asymmetry.data)) > 1e-12 * scale:
+      if not sp.isspmatrix_csc(p):
+        raise TypeError("QP matrix 'p' must be in CSC format.")
+      if p.shape != (self.n, self.n):
+        raise ValueError(
+            f"p must have shape ({self.n}, {self.n}), got {p.shape}"
+        )
+      if not np.all(np.isfinite(p.data)):
+        raise ValueError("QP matrix 'p' must contain only finite values.")
+      asymmetry = p - p.T
+      if (
+          asymmetry.nnz
+          and np.max(np.abs(asymmetry.data), initial=0.0) > 1e-12
+      ):
         raise ValueError("QP matrix 'p' must be symmetric.")
-
-    p = ((p + p.T) * 0.5).tocsc()
-    p.sum_duplicates()
-    p.eliminate_zeros()
-    return p
+      self.p = p
 
   def _presolve(self, inf_bound: float = 1e20):
     """Drop inequality rows with trivially-satisfied RHS (b[i] >= inf_bound

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -229,13 +229,34 @@ class QTQP:
     if p is None:
       self.p = sp.csc_matrix((self.n, self.n))
     else:
-      if not sp.isspmatrix_csc(p):
-        raise TypeError("QP matrix 'p' must be in CSC format.")
-      if p.shape != (self.n, self.n):
-        raise ValueError(
-            f"p must have shape ({self.n}, {self.n}, got {p.shape})"
-        )
-      self.p = p
+      self.p = self._validate_and_canonicalize_p(p)
+
+  def _validate_and_canonicalize_p(self, p: sp.csc_matrix) -> sp.csc_matrix:
+    """Validates and returns a symmetric CSC copy of the quadratic matrix."""
+    if not sp.isspmatrix_csc(p):
+      raise TypeError("QP matrix 'p' must be in CSC format.")
+    if p.shape != (self.n, self.n):
+      raise ValueError(
+          f"p must have shape ({self.n}, {self.n}), got {p.shape}"
+      )
+
+    p = p.copy().tocsc()
+    p.sum_duplicates()
+    p.eliminate_zeros()
+    if not np.all(np.isfinite(p.data)):
+      raise ValueError("QP matrix 'p' must contain only finite values.")
+
+    asymmetry = (p - p.T).tocsc()
+    asymmetry.eliminate_zeros()
+    if asymmetry.nnz:
+      scale = max(1.0, np.max(np.abs(p.data), initial=0.0))
+      if np.max(np.abs(asymmetry.data)) > 1e-12 * scale:
+        raise ValueError("QP matrix 'p' must be symmetric.")
+
+    p = ((p + p.T) * 0.5).tocsc()
+    p.sum_duplicates()
+    p.eliminate_zeros()
+    return p
 
   def _presolve(self, inf_bound: float = 1e20):
     """Drop inequality rows with trivially-satisfied RHS (b[i] >= inf_bound

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -2155,26 +2155,23 @@ def test_linear_solver_tolerances():
 # Non-symmetric P handling
 # =============================================================================
 
-def test_nonsymmetric_p():
-  """Test solver behavior with a non-symmetric P (upper triangle only).
+def test_nonsymmetric_p_rejected():
+  """Non-symmetric P is ambiguous and should be rejected."""
+  a = sparse.eye(2, format='csc')
+  b = np.ones(2)
+  c = np.zeros(2)
+  p = sparse.csc_matrix([[1.0, 2.0], [0.0, 1.0]])
 
-  Users are expected to provide symmetric P, but verify the solver doesn't
-  crash with the upper triangle alone.
-  """
-  rng = np.random.default_rng(42)
-  m, n, z = 20, 10, 3
-  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  with pytest.raises(ValueError, match='symmetric'):
+    qtqp.QTQP(a=a, b=b, c=c, z=0, p=p)
 
-  p_triu = sparse.triu(p, format='csc')
 
-  sol_sym = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
-  sol_triu = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p_triu).solve(verbose=True)
+def test_nonfinite_p_rejected():
+  """Non-finite entries in P should fail during input validation."""
+  a = sparse.eye(2, format='csc')
+  b = np.ones(2)
+  c = np.zeros(2)
+  p = sparse.csc_matrix([[1.0, np.nan], [np.nan, 1.0]])
 
-  assert sol_sym.status == qtqp.SolutionStatus.SOLVED
-  # Upper-triangle-only P may or may not converge to the same optimum
-  # (it defines a different KKT). Just verify it doesn't crash.
-  assert sol_triu.status in (
-      qtqp.SolutionStatus.SOLVED,
-      qtqp.SolutionStatus.HIT_MAX_ITER,
-      qtqp.SolutionStatus.FAILED,
-  )
+  with pytest.raises(ValueError, match='finite'):
+    qtqp.QTQP(a=a, b=b, c=c, z=0, p=p)


### PR DESCRIPTION
## Summary
- validate that P is CSC, correctly shaped, finite, and symmetric
- store a canonical symmetric CSC copy for downstream KKT and termination logic
- update nonsymmetric/non-finite P tests to expect validation errors

## Tests
- PYTHONPATH=src pytest -q tests/test_qtqp.py::test_nonsymmetric_p_rejected tests/test_qtqp.py::test_nonfinite_p_rejected tests/test_qtqp.py::test_raise_error_negative_invalid_shapes tests/test_qtqp.py::test_p_none_equivalent_to_zero_matrix