### PR TITLE
Free linear solver on solve errors

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -316,6 +316,48 @@ class QTQP:
       equilibrate: bool = True,
       collect_stats: bool = False,
   ) -> Solution:
+    """Solves the QP using a primal-dual interior-point method."""
+    self._linear_solver = None
+    try:
+      return self._solve_impl(
+          atol=atol,
+          rtol=rtol,
+          atol_infeas=atol_infeas,
+          rtol_infeas=rtol_infeas,
+          max_iter=max_iter,
+          step_size_scale=step_size_scale,
+          min_static_regularization=min_static_regularization,
+          max_iterative_refinement_steps=max_iterative_refinement_steps,
+          linear_solver_atol=linear_solver_atol,
+          linear_solver_rtol=linear_solver_rtol,
+          linear_solver=linear_solver,
+          verbose=verbose,
+          equilibrate=equilibrate,
+          collect_stats=collect_stats,
+      )
+    finally:
+      if self._linear_solver is not None:
+        self._linear_solver.free()
+        self._linear_solver = None
+
+  def _solve_impl(
+      self,
+      *,
+      atol: float = 1e-7,
+      rtol: float = 1e-8,
+      atol_infeas: float = 1e-8,
+      rtol_infeas: float = 1e-9,
+      max_iter: int = 100,
+      step_size_scale: float = 0.99,
+      min_static_regularization: float = 1e-8,
+      max_iterative_refinement_steps: int = 20,
+      linear_solver_atol: float = 1e-12,
+      linear_solver_rtol: float = 1e-12,
+      linear_solver: LinearSolver = LinearSolver.AUTO,
+      verbose: bool = True,
+      equilibrate: bool = True,
+      collect_stats: bool = False,
+  ) -> Solution:
     """Solves the QP using a primal-dual interior-point method.
 
     Args:
@@ -528,7 +570,6 @@ class QTQP:
         stats[-1]["status"] = status
 
     # We have terminated for one reason or another.
-    self._linear_solver.free()
     if self.equilibrate:
       x, y, s = self._unequilibrate_iterates(x, y, s)
     match status:

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -697,6 +697,46 @@ def test_raise_error_negative_invalid_shapes():
     _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p_invalid).solve()
 
 
+def test_solve_frees_linear_solver_on_exception(monkeypatch):
+  """Linear solver resources should be freed when an IPM step raises."""
+
+  class FailingSolver(qtqp.direct.LinearSolver):
+
+    def __init__(self):
+      self.freed = False
+
+    def factorize(self):
+      raise RuntimeError("forced factorization failure")
+
+    def solve(self, rhs):
+      del rhs
+      raise AssertionError("factorization should fail before solve")
+
+    def format(self):
+      return 'csc'
+
+    def free(self):
+      self.freed = True
+
+  backend = FailingSolver()
+  monkeypatch.setattr(
+      qtqp,
+      '_resolve_linear_solver',
+      lambda linear_solver: (linear_solver, backend),
+  )
+
+  rng = np.random.default_rng(842)
+  m, n, z = 20, 10, 3
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
+
+  with pytest.raises(RuntimeError, match='forced factorization failure'):
+    solver.solve(verbose=False, linear_solver=qtqp.LinearSolver.SCIPY)
+
+  assert backend.freed
+  assert solver._linear_solver is None  # pylint: disable=protected-access
+
+
 @pytest.mark.parametrize('seed', 842 + np.arange(10))
 @pytest.mark.parametrize('linear_solver', _SOLVERS)
 def test_direct_linear_solver(seed, linear_solver):


### PR DESCRIPTION
## Summary
- split solve into a public cleanup wrapper and private implementation
- remove the normal-path-only explicit free call
- add a regression test that verifies backend free is called after a factorization exception

## Tests
- PYTHONPATH=src pytest -q tests/test_qtqp.py::test_solve_frees_linear_solver_on_exception tests/test_qtqp.py::test_p_none_equivalent_to_zero_matrix tests/test_qtqp.py::test_hit_max_iter_status