### PR TITLE
Install pip before CI pip commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
           channels: conda-forge
           channel-priority: strict
 
+      - name: Install pip
+        shell: bash -l {0}
+        run: conda install -y pip
+
       # MKL Pardiso is not available on macOS.
       - name: Install MKL Pardiso
         if: matrix.os != 'macos-latest'


### PR DESCRIPTION
## Summary
- install pip explicitly after creating the conda test environment
- fixes macOS CI jobs failing before pytest with: No module named pip

## Tests
- not run locally; workflow-only change