### PR TITLE
[codex] Use eigh for unbounded test generator

### DIFF
--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -270,7 +270,7 @@ def _gen_unbounded(m, n, z, random_state=None):
   p = rng.normal(size=(n, n))
 
   p = p.T @ p * 0.01
-  e, v = np.linalg.eig(p)
+  e, v = np.linalg.eigh(p)
   e[-1] = 0.0
   x = v[:, -1]
   p = v @ np.diag(e) @ v.T


### PR DESCRIPTION
## Summary

Use `np.linalg.eigh` in `_gen_unbounded` when decomposing the symmetric positive semidefinite test matrix.

## Root Cause

The unbounded test generator builds `p = p.T @ p * 0.01`, so the matrix is symmetric. It then used `np.linalg.eig`, which can return complex-typed eigenvectors under NumPy 2.5 even when the imaginary parts are zero. That complex dtype leaked into the reconstructed sparse `p` matrix and caused the solver to fail during float in-place Newton updates with:

```text
Cannot cast ufunc subtract output from dtype complex128 to dtype float64
```

`np.linalg.eigh` is the symmetric/Hermitian routine and keeps the generated matrix real for this case.

## Validation

- `/tmp/qtqp-np25-repro/bin/python -m pytest -q tests/test_qtqp.py::test_unbounded_small[LinearSolver.SCIPY-seed0-EquilibrationStrategy.RUIZ]`
- `PYTHONPATH=src python -m pytest -q tests/test_qtqp.py::test_unbounded_small[LinearSolver.SCIPY-seed0-EquilibrationStrategy.RUIZ]`

## Note

I opened this against `main` because this repository does not currently have an `origin/master` branch.