### PR TITLE
Optimize Dense KKT Solvers (CPU & GPU) 

### DIFF
--- a/src/qtqp/solvers_dense.py
+++ b/src/qtqp/solvers_dense.py
@@ -70,7 +70,7 @@ class ScipyDenseSolver(LinearSolver):
     self._n = n
     self._m = m
     # Blocks extracted once from the KKT scaffold (populated in first set_kkt).
-    self._A: np.ndarray | None = None         # (m, n) dense, C-order
+    self._A: np.ndarray | None = None         # (m, n) dense, Fortran-order
     self._P_offdiag: np.ndarray | None = None  # (n, n) P with diagonal zeroed, F-order
 
     # Pre-allocate all per-iteration buffers.
@@ -121,6 +121,7 @@ class ScipyDenseSolver(LinearSolver):
       raise np.linalg.LinAlgError(f"Cholesky failed (dpotrf info={info})")
 
   def __matmul__(self, x: np.ndarray) -> np.ndarray:
+    """Note: `x` must not alias the returned buffer."""
     n = self._n
     x_x, x_y = x[:n], x[n:]
     result = self._result
@@ -135,13 +136,14 @@ class ScipyDenseSolver(LinearSolver):
     return result
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
+    """Note: `rhs` must not alias the returned buffer."""
     n = self._n
     inv_R_y = self._inv_R_y
     # Reduced RHS: g = rhs_x + A' (R_y^{-1} rhs_y)
     g = self._g
     np.copyto(g, rhs[:n])
-    tmp = inv_R_y * rhs[n:]
-    self._dgemv(1.0, self._A, tmp, 1.0, g, trans=1, overwrite_y=1)
+    np.multiply(inv_R_y, rhs[n:], out=self._result[n:])
+    self._dgemv(1.0, self._A, self._result[n:], 1.0, g, trans=1, overwrite_y=1)
     x, _ = self._dpotrs(self._chol, g, lower=True)
     # Back-substitute: y = R_y^{-1} (A x - rhs_y)
     result = self._result

--- a/src/qtqp/solvers_dense.py
+++ b/src/qtqp/solvers_dense.py
@@ -62,6 +62,7 @@ class ScipyDenseSolver(LinearSolver):
     self._dpotrs = lapack.dpotrs
     self._dsyrk = blas.dsyrk
     self._dsymv = blas.dsymv
+    self._dgemv = blas.dgemv
     self._n = 0
     self._m = 0
 
@@ -75,6 +76,8 @@ class ScipyDenseSolver(LinearSolver):
     # Pre-allocate all per-iteration buffers.
     self._R_x = np.empty(n, dtype=np.float64)
     self._R_y = np.empty(m, dtype=np.float64)
+    self._inv_R_y = np.empty(m, dtype=np.float64)
+    self._inv_sqrt_R_y = np.empty(m, dtype=np.float64)
     self._G = np.empty((n, n), dtype=np.float64, order="F")
     self._chol = np.empty((n, n), dtype=np.float64, order="F")
     self._A_scaled = np.empty((m, n), dtype=np.float64, order="F")
@@ -86,7 +89,7 @@ class ScipyDenseSolver(LinearSolver):
     super().set_kkt(kkt)
     n = self._n
     kkt_dense = kkt.toarray()
-    self._A = np.ascontiguousarray(kkt_dense[:n, n:].T, dtype=np.float64)
+    self._A = np.asfortranarray(kkt_dense[:n, n:].T, dtype=np.float64)
     P_block = kkt_dense[:n, :n]
     P_block = P_block + P_block.T - np.diag(np.diag(P_block))
     np.fill_diagonal(P_block, 0.0)
@@ -95,12 +98,14 @@ class ScipyDenseSolver(LinearSolver):
   def update_diag(self, diag: np.ndarray) -> None:
     np.copyto(self._R_x, diag[:self._n])
     np.negative(diag[self._n:], out=self._R_y)
+    np.divide(1.0, self._R_y, out=self._inv_R_y)
+    np.sqrt(self._inv_R_y, out=self._inv_sqrt_R_y)
 
   def factorize(self) -> None:
     # G = P_offdiag + diag(R_x) + A' diag(1/R_y) A
     np.copyto(self._G, self._P_offdiag)
     self._G[self._diag_idx] += self._R_x
-    np.multiply(self._A, (1.0 / np.sqrt(self._R_y))[:, None], out=self._A_scaled)
+    np.multiply(self._A, self._inv_sqrt_R_y[:, None], out=self._A_scaled)
     # Symmetric rank-k update: G += A_scaled.T @ A_scaled via BLAS dsyrk.
     self._dsyrk(1.0, self._A_scaled, beta=1.0, c=self._G, trans=1,
                 lower=1, overwrite_c=True)
@@ -123,22 +128,27 @@ class ScipyDenseSolver(LinearSolver):
     self._dsymv(1.0, self._P_offdiag, x_x, 0.0, result[:n], lower=1,
                 overwrite_y=1)
     result[:n] += self._R_x * x_x
-    result[:n] += self._A.T @ x_y
-    result[n:] = self._A @ x_x - self._R_y * x_y
+    self._dgemv(1.0, self._A, x_y, 1.0, result[:n], trans=1, overwrite_y=1)
+    np.multiply(self._R_y, x_y, out=result[n:])
+    np.negative(result[n:], out=result[n:])
+    self._dgemv(1.0, self._A, x_x, 1.0, result[n:], trans=0, overwrite_y=1)
     return result
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     n = self._n
-    inv_R_y = 1.0 / self._R_y
+    inv_R_y = self._inv_R_y
     # Reduced RHS: g = rhs_x + A' (R_y^{-1} rhs_y)
     g = self._g
     np.copyto(g, rhs[:n])
-    g += self._A.T @ (inv_R_y * rhs[n:])
+    tmp = inv_R_y * rhs[n:]
+    self._dgemv(1.0, self._A, tmp, 1.0, g, trans=1, overwrite_y=1)
     x, _ = self._dpotrs(self._chol, g, lower=True)
     # Back-substitute: y = R_y^{-1} (A x - rhs_y)
     result = self._result
     result[:n] = x
-    np.multiply(inv_R_y, self._A @ x - rhs[n:], out=result[n:])
+    self._dgemv(1.0, self._A, x, 0.0, result[n:], trans=0, overwrite_y=1)
+    result[n:] -= rhs[n:]
+    result[n:] *= inv_R_y
     return result
 
   def format(self) -> Literal["csr"]:

--- a/src/qtqp/solvers_gpu.py
+++ b/src/qtqp/solvers_gpu.py
@@ -179,19 +179,23 @@ class CupyDenseSolver(LinearSolver):
     self._L = cp.linalg.cholesky(self._G_gpu)
 
   def __matmul__(self, x: np.ndarray) -> np.ndarray:
+    """Note: `x` must not alias the returned buffer."""
     cp = self._cp
     n = self._n
     self._x_gpu.set(x)
     x_x, x_y = self._x_gpu[:n], self._x_gpu[n:]
     result = self._result_gpu
     cp.dot(self._P_offdiag_gpu, x_x, out=result[:n])
-    result[:n] += self._R_x_gpu * x_x
-    result[:n] += cp.dot(self._A_gpu.T, x_y)
+    cp.multiply(self._R_x_gpu, x_x, out=self._g_gpu)
+    result[:n] += self._g_gpu
+    cp.dot(self._A_gpu.T, x_y, out=self._g_gpu)
+    result[:n] += self._g_gpu
     cp.dot(self._A_gpu, x_x, out=result[n:])
     result[n:] -= self._R_y_gpu * x_y
     return cp.asnumpy(result)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
+    """Note: `rhs` must not alias the returned buffer."""
     cp = self._cp
     n = self._n
     self._rhs_gpu.set(rhs)

--- a/src/qtqp/solvers_gpu.py
+++ b/src/qtqp/solvers_gpu.py
@@ -140,9 +140,14 @@ class CupyDenseSolver(LinearSolver):
     self._P_offdiag_gpu = None
     self._R_x_gpu = cp.empty(n, dtype=cp.float64)
     self._R_y_gpu = cp.empty(m, dtype=cp.float64)
+    self._inv_R_y_gpu = cp.empty(m, dtype=cp.float64)
+    self._inv_sqrt_R_y_gpu = cp.empty(m, dtype=cp.float64)
     self._G_gpu = cp.empty((n, n), dtype=cp.float64)
     self._diag_idx = cp.arange(n)
     self._result_gpu = cp.empty(n + m, dtype=cp.float64)
+    self._x_gpu = cp.empty(n + m, dtype=cp.float64)
+    self._rhs_gpu = cp.empty(n + m, dtype=cp.float64)
+    self._g_gpu = cp.empty(n, dtype=cp.float64)
     self._L = None  # Lower-triangular Cholesky factor
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
@@ -159,13 +164,15 @@ class CupyDenseSolver(LinearSolver):
   def update_diag(self, diag: np.ndarray) -> None:
     self._R_x_gpu.set(diag[:self._n])
     self._R_y_gpu.set(-diag[self._n:])
+    cp.divide(1.0, self._R_y_gpu, out=self._inv_R_y_gpu)
+    cp.sqrt(self._inv_R_y_gpu, out=self._inv_sqrt_R_y_gpu)
 
   def factorize(self) -> None:
     cp = self._cp
     idx = self._diag_idx
     cp.copyto(self._G_gpu, self._P_offdiag_gpu)
     self._G_gpu[idx, idx] += self._R_x_gpu
-    A_scaled = self._A_gpu * (1.0 / cp.sqrt(self._R_y_gpu))[:, None]
+    A_scaled = self._A_gpu * self._inv_sqrt_R_y_gpu[:, None]
     self._G_gpu += A_scaled.T @ A_scaled
     # Same numerical perturbation as ScipyDenseSolver.factorize.
     self._G_gpu[idx, idx] += 1e-14 * cp.max(self._G_gpu[idx, idx])
@@ -174,25 +181,32 @@ class CupyDenseSolver(LinearSolver):
   def __matmul__(self, x: np.ndarray) -> np.ndarray:
     cp = self._cp
     n = self._n
-    x_gpu = cp.asarray(x)
-    x_x, x_y = x_gpu[:n], x_gpu[n:]
+    self._x_gpu.set(x)
+    x_x, x_y = self._x_gpu[:n], self._x_gpu[n:]
     result = self._result_gpu
-    result[:n] = self._P_offdiag_gpu @ x_x + self._R_x_gpu * x_x + self._A_gpu.T @ x_y
-    result[n:] = self._A_gpu @ x_x - self._R_y_gpu * x_y
+    cp.dot(self._P_offdiag_gpu, x_x, out=result[:n])
+    result[:n] += self._R_x_gpu * x_x
+    result[:n] += cp.dot(self._A_gpu.T, x_y)
+    cp.dot(self._A_gpu, x_x, out=result[n:])
+    result[n:] -= self._R_y_gpu * x_y
     return cp.asnumpy(result)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     cp = self._cp
     n = self._n
-    rhs_gpu = cp.asarray(rhs)
-    inv_R_y = 1.0 / self._R_y_gpu
-    g = rhs_gpu[:n] + self._A_gpu.T @ (inv_R_y * rhs_gpu[n:])
+    self._rhs_gpu.set(rhs)
+    inv_R_y = self._inv_R_y_gpu
+    cp.multiply(inv_R_y, self._rhs_gpu[n:], out=self._result_gpu[n:])
+    cp.dot(self._A_gpu.T, self._result_gpu[n:], out=self._g_gpu)
+    self._g_gpu += self._rhs_gpu[:n]
     # Solve L L' x = g via triangular solves.
-    x = self._cupyx_linalg.solve_triangular(self._L, g, lower=True)
+    x = self._cupyx_linalg.solve_triangular(self._L, self._g_gpu, lower=True)
     x = self._cupyx_linalg.solve_triangular(self._L, x, lower=True, trans='C')
     result = self._result_gpu
     result[:n] = x
-    cp.multiply(inv_R_y, self._A_gpu @ x - rhs_gpu[n:], out=result[n:])
+    cp.dot(self._A_gpu, x, out=result[n:])
+    result[n:] -= self._rhs_gpu[n:]
+    result[n:] *= inv_R_y
     return cp.asnumpy(result)
 
   def format(self) -> Literal["csr"]:


### PR DESCRIPTION
 This PR significantly accelerates the CPU (`ScipyDenseSolver`) and GPU (`CupyDenseSolver`) backends by aggressively minimizing intermediate memory allocations within the iterative refinement loops.                           
                                                                                                                                                                      
- Hoisted Invariants: Moved heavy mathematical operations (like inverse square roots and diagonal scaling factors) out of the  `__matmul__`  and  solve  loops into the one-time `update_diag`  phase.                                           
- Zero-Allocation BLAS: Replaced implicit NumPy and CuPy allocations (like standard  `@`  operators) with in-place operations (`scipy.linalg.blas.dgemv`  on CPU, and  `cp.dot(..., out=...)`  on GPU) mapping to pre-allocated buffers.        
- Fortran-Contiguity: Configured the Gram matrix extraction to guarantee Fortran-contiguous arrays so SciPy BLAS runs with zero-copy overhead. 

Benchmarking script:

<details>
<summary>Script</summary>

```python
import platform
import time
import numpy as np
from scipy import sparse
import qtqp

def _gen_feasible(m, n, z, random_state=None):
    """Generate a feasible QP."""
    rng = np.random.default_rng(random_state)
    w = rng.normal(size=m)
    x = rng.normal(size=n)
    y = w.copy()
    y[z:] = 0.5 * (w[z:] + np.abs(w[z:]))  # y = s - z;
    s = y - w

    a = sparse.random(
        m,
        n,
        density=0.1,
        format='csc',
        rng=rng,
        data_rvs=lambda x: rng.normal(size=x),
    )
    p = sparse.random(
        n,
        n,
        density=0.01,
        format='csc',
        rng=rng,
        data_rvs=lambda x: rng.normal(size=x),
    )

    c = -a.T @ y
    b = a @ x + s
    p = p.T @ p * 0.01
    return sparse.csc_matrix(a), b, c, sparse.csc_matrix(p)

def print_system_info():
    print("=" * 60)
    print("System Information")
    print("=" * 60)
    print(f"OS: {platform.system()} {platform.release()} ({platform.version()})")
    print(f"Machine: {platform.machine()}")
    print(f"Processor: {platform.processor()}")
    print(f"Python: {platform.python_version()}")
    print("=" * 60)

def benchmark():
    print_system_info()
    print("\nGenerating large feasible QP instance...")
    rng = np.random.default_rng(42)
    m, n, z = 1000, 600, 60
    a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
    
    print(f"Problem size: m={m}, n={n}, z={z}")
    print("\nRunning warm-up solve...")
    solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
    solver.solve(linear_solver=qtqp.LinearSolver.SCIPY_DENSE, collect_stats=False)
    
    print("Running benchmark (10 iterations)...")
    times = []
    iters = []
    
    for _ in range(10):
        t0 = time.time()
        solution = solver.solve(linear_solver=qtqp.LinearSolver.SCIPY_DENSE, collect_stats=True)
        t1 = time.time()
        times.append(t1 - t0)
        iters.append(solution.stats[-1]['iter'])

    times = np.array(times)
    print("\n" + "=" * 60)
    print("Benchmark Results (SCIPY_DENSE)")
    print("=" * 60)
    print(f"Avg Iterations: {np.mean(iters):.1f}")
    print(f"Avg Time: {np.mean(times)*1000:.2f} ms")
    print(f"Min Time: {np.min(times)*1000:.2f} ms")
    print(f"Max Time: {np.max(times)*1000:.2f} ms")
    print("=" * 60)

if __name__ == "__main__":
    benchmark()
```
</details>

Main branch output:
```
Avg Time: 263.85 ms
Min Time: 237.81 ms
Max Time: 311.54 ms
```

This PR:
```
Avg Time: 238.83 ms
Min Time: 212.67 ms
Max Time: 356.37 ms
```

Machine info:
```
System Information
============================================================
OS: Darwin 25.5.0 (Darwin Kernel Version 25.5.0: Mon Apr 27 20:38:56 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6000)
Machine: arm64
Processor: arm
Python: 3.14.6
```