### PR TITLE
Judge infeasibility/unboundedness certificates by data-scaled backward error

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -570,10 +570,17 @@ class QTQP:
       atol (float): Absolute tolerance for convergence criteria.
       rtol (float): Relative tolerance for convergence criteria, scaled by
         problem data norms.
-      atol_infeas (float): Absolute tolerance for detecting primal or dual
-        infeasibility.
-      rtol_infeas (float): Relative tolerance for detecting primal or dual
-        infeasibility.
+      atol_infeas (float): Certificate-quality tolerance for infeasibility
+        and unboundedness detection. A candidate ray u must be good in two
+        complementary senses: its relative backward error (violations over
+        ||operator|| * ||u||) must be below atol_infeas, AND its violations
+        must be below atol_infeas * |objective slope| + rtol_infeas * ||u||.
+        The first rejects large-slope pseudo-rays, the second rejects
+        huge-norm near-solutions; each guards the other's blind spot.
+      rtol_infeas (float): Ray-relative slack in the slope-scaled
+        certificate test, and the margin by which the certificate's
+        objective slope (c'x or b'y) must be negative relative to the data
+        and ray norms.
       max_iter (int): Maximum number of iterations before stopping.
       step_size_scale (float): A factor in (0, 1) to scale the step size,
         ensuring iterates remain strictly interior.
@@ -673,6 +680,14 @@ class QTQP:
     # so we use self.b and self.c here (not the equilibrated local b, c).
     self._norm_b = _norm(self.b, np.inf)
     self._norm_c = _norm(self.c, np.inf)
+
+    # Data operator norms (original scale) for the certificate-quality tests:
+    # ||A||_inf (rows, acts on x), ||A||_1 (columns, = ||A'||_inf, acts on y),
+    # and ||P||_inf.
+    abs_a = abs(self.a)
+    self._norm_a_inf = float(abs_a.sum(axis=1).max()) if self.a.nnz else 0.0
+    self._norm_a_one = float(abs_a.sum(axis=0).max()) if self.a.nnz else 0.0
+    self._norm_p_inf = float(abs(self.p).sum(axis=1).max()) if self.p.nnz else 0.0
 
     self._linear_solver = direct.DirectKktSolver(
         a=a,
@@ -1297,22 +1312,24 @@ class QTQP:
     dres = _norm(px_plus_aty * inv_tau + self.c, np.inf)
     gap = abs((ctx + bty + xpx * inv_tau) * inv_tau)
 
-    # Infeasibility certificates (Farkas-type, from the embedding structure).
-    # If the primal is unbounded (dual infeasible) this produces a ray x with
-    # c'x < 0 that satisfies the homogeneous primal conditions Ax + s ≈ 0 and Px
-    # ≈ 0.  dinfeas measures how well x/|c'x| certifies dual infeasibility.
+    # Certificate-quality measures (Farkas-type, from the embedding
+    # structure). A candidate ray is judged by the smallest relative data
+    # perturbation that would make it an exact certificate (Rigal-Gaches
+    # normwise backward error): e.g. dinfeas_a = ||Ax + s|| / (||A|| ||x||)
+    # is the relative perturbation of A under which x is an exact unbounded
+    # ray. Normalizing by the objective slope |c'x| instead (the common
+    # convention) hands out slack proportional to a quantity degenerate
+    # problems can inflate — near-null directions with enormous c-slope pass
+    # such tests while violating the constraints badly (e.g. NETLIB dfl001).
     norm_aty = _norm(aty, np.inf)
     norm_px = _norm(px, np.inf)
-    dinfeas_a = _norm(ax_plus_s, np.inf) / (abs(ctx) + _EPS)
-    dinfeas_p = norm_px / (abs(ctx) + _EPS)
-    dinfeas = max(dinfeas_a, dinfeas_p)
-    # If the primal is infeasible (dual unbounded) this produces a ray y
-    # with b'y < 0 that satisfies the homogeneous dual condition A'y ≈ 0.
-    # pinfeas measures how well y/|b'y| certifies primal infeasibility.
-    pinfeas = norm_aty / (abs(bty) + _EPS)
-
+    norm_ax_plus_s = _norm(ax_plus_s, np.inf)
     norm_x = _norm(x, np.inf)
     norm_y = _norm(y, np.inf)
+    dinfeas_a = norm_ax_plus_s / (self._norm_a_inf * norm_x + _EPS)
+    dinfeas_p = norm_px / (self._norm_p_inf * norm_x + _EPS)
+    dinfeas = max(dinfeas_a, dinfeas_p)
+    pinfeas = norm_aty / (self._norm_a_one * norm_y + _EPS)
 
     # Residual tolerance relative scales. Each is the max of two families:
     # the summand norms (the floor below which the residual cannot even be
@@ -1351,14 +1368,31 @@ class QTQP:
         and dres < self.atol + self.rtol * drelrhs
     ):
       status = SolutionStatus.SOLVED
-    # Unbounded: x is a dual infeasibility certificate (primal unbounded ray).
-    elif ctx < -_EPS and (
-        dinfeas < self.atol_infeas + self.rtol_infeas * norm_x / abs(ctx)
+    # Certificate acceptance requires BOTH quality senses, because each
+    # guards the other's blind spot:
+    #   - data-scaled (violations / (||operator|| ||ray||) < atol_infeas):
+    #     rejects large-slope pseudo-rays whose |c'x| buys unbounded slack
+    #     in the slope-scaled test (e.g. NETLIB dfl001, where a direction
+    #     violating the constraints at 5-9% of ||A|| ||x|| was certified);
+    #   - slope-scaled (violations < atol_infeas * |slope| + rtol_infeas *
+    #     ||ray||): rejects huge-norm near-solutions, whose data-scaled
+    #     quality becomes small automatically (A'y ~ -c*tau with enormous
+    #     ||y|| makes ||A'y|| / (||A||_1 ||y||) tiny while y is nothing
+    #     like a ray; e.g. NETLIB fit1p, tuff, vtp.base, fffff800).
+    # The quality measures need no zero-ray guard: as ||x|| -> 0 the
+    # data-scaled denominator vanishes while the numerator retains the
+    # O(1) slack s, so dinfeas diverges and nothing is certified.
+    elif (
+        ctx < -(self.rtol_infeas * self._norm_c * norm_x + _EPS)
+        and dinfeas < self.atol_infeas
+        and max(norm_ax_plus_s, norm_px)
+        < self.atol_infeas * abs(ctx) + self.rtol_infeas * norm_x
     ):
       status = SolutionStatus.UNBOUNDED
-    # Infeasible: y is a primal infeasibility certificate (dual unbounded ray).
-    elif bty < -_EPS and (
-        pinfeas < self.atol_infeas + self.rtol_infeas * norm_y / abs(bty)
+    elif (
+        bty < -(self.rtol_infeas * self._norm_b * norm_y + _EPS)
+        and pinfeas < self.atol_infeas
+        and norm_aty < self.atol_infeas * abs(bty) + self.rtol_infeas * norm_y
     ):
       status = SolutionStatus.INFEASIBLE
     else:

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -323,14 +323,19 @@ def _assert_infeasible(solution, a, b, z, atol=1e-8, rtol=1e-9):
   y = solution.y
   s = solution.s
 
-  pinfeas = np.linalg.norm(a.T @ y, np.inf)
+  # Certificate quality is judged as relative backward error, mirroring the
+  # solver's detection contract: violations over ||A||_1 * ||y||.
+  norm_a_one = float(abs(a).sum(axis=0).max())
+  pinfeas = np.linalg.norm(a.T @ y, np.inf) / (
+      norm_a_one * np.linalg.norm(y, np.inf) + 1e-300
+  )
 
   assert solution.status == qtqp.SolutionStatus.INFEASIBLE
   np.testing.assert_array_equal(np.isnan(x), True)
   np.testing.assert_array_equal(np.isnan(s), True)
   np.testing.assert_allclose(b @ y, -1.0, atol=atol, rtol=rtol)
   np.testing.assert_array_less(-1e-9, np.min(y[z:], initial=0.0))
-  np.testing.assert_array_less(pinfeas, atol + rtol * np.linalg.norm(y, np.inf))
+  np.testing.assert_array_less(pinfeas, atol)
 
 
 def _assert_unbounded(solution, a, c, p, z, atol=1e-8, rtol=1e-9):
@@ -339,19 +344,21 @@ def _assert_unbounded(solution, a, c, p, z, atol=1e-8, rtol=1e-9):
   y = solution.y
   s = solution.s
 
-  dinfeas_a = np.linalg.norm(a @ x + s, np.inf)
-  dinfeas_p = np.linalg.norm(p @ x, np.inf)
+  # Certificate quality is judged as relative backward error, mirroring the
+  # solver's detection contract: violations over ||A||_inf * ||x|| (and
+  # ||P||_inf * ||x|| for the quadratic part).
+  norm_x = np.linalg.norm(x, np.inf)
+  norm_a_inf = float(abs(a).sum(axis=1).max())
+  norm_p_inf = float(abs(p).sum(axis=1).max()) if p.nnz else 0.0
+  dinfeas_a = np.linalg.norm(a @ x + s, np.inf) / (norm_a_inf * norm_x + 1e-300)
+  dinfeas_p = np.linalg.norm(p @ x, np.inf) / (norm_p_inf * norm_x + 1e-300)
 
   assert solution.status == qtqp.SolutionStatus.UNBOUNDED
   np.testing.assert_array_equal(np.isnan(y), True)
   np.testing.assert_allclose(c @ x, -1.0, atol=atol, rtol=rtol)
   np.testing.assert_array_less(-1e-9, np.min(s[z:], initial=0.0))
-  np.testing.assert_array_less(
-      dinfeas_a, atol + rtol * np.linalg.norm(x, np.inf)
-  )
-  np.testing.assert_array_less(
-      dinfeas_p, atol + rtol * np.linalg.norm(x, np.inf)
-  )
+  np.testing.assert_array_less(dinfeas_a, atol)
+  np.testing.assert_array_less(dinfeas_p, atol)
 
 
 @pytest.mark.parametrize('equilibration', [qtqp.EquilibrationStrategy.RUIZ, qtqp.EquilibrationStrategy.NONE])
@@ -533,7 +540,6 @@ def test_equality_only_lp(seed):
   y_star = rng.normal(size=m)
   b = a @ x_star
   c = -(a.T @ y_star)
-  p = sparse.csc_matrix((n, n))
   with pytest.raises(ValueError, match='effective z == m'):
     _ = qtqp.QTQP(a=a, b=b, c=c, z=z).solve(verbose=True)
 
@@ -556,7 +562,6 @@ def test_presolve_drops_all_inequalities():
   rng = np.random.default_rng(842)
   m_eq, n = 5, 20
   m_ineq = 5
-  m = m_eq + m_ineq
   z = m_eq
   a, b, c, p = _gen_equality_only(m_eq, n, random_state=rng)
   a, b = _append_dropped_inequalities(
@@ -2870,6 +2875,76 @@ def test_gmres_rollback_on_stalled_refinement():
   # Either we converged immediately, or the returned residual is no worse
   # than what one direct factor-solve from warm_start would give.
   assert stats['final_residual_norm'] < 1e-6
+
+
+# =============================================================================
+# Certificate quality: pseudo-rays must not be certified
+# =============================================================================
+
+def test_certificate_rejects_large_slope_pseudo_ray():
+  """A direction with enormous |c'x| but non-trivial constraint violations
+  must not be accepted as an unboundedness certificate.
+
+  This is the mechanism behind false certificates on degenerate LPs (e.g.
+  NETLIB dfl001): tests that normalize violations by |c'x| hand out slack
+  proportional to the objective slope, which a near-null direction of A with
+  a large c-component can inflate arbitrarily. The certificate test must
+  judge violations against ||A|| ||x|| instead.
+  """
+  rng = np.random.default_rng(7)
+  m, n, z = 12, 8, 3
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+
+  # Direction v: right singular vector of A with the smallest singular value
+  # (near-null for A but not null), and a cost vector with a huge component
+  # along v so that c'v is enormously negative.
+  u_svd, s_svd, vt_svd = np.linalg.svd(a.toarray())
+  mid = len(s_svd) // 2
+  v = vt_svd[mid]
+  sigma_v = s_svd[mid]  # clearly nonzero: v is NOT a feasible ray
+  norm_a = np.max(np.abs(a.toarray()).sum(axis=1))
+  big = 1e12
+  c_adv = -big * v
+
+  solver = qtqp.QTQP(a=a, b=b, c=c_adv, z=z, p=p)
+  # Prime the state that solve() would normally set before termination checks.
+  solver.atol, solver.rtol = 1e-7, 1e-8
+  solver.atol_infeas, solver.rtol_infeas = 1e-8, 1e-9
+  solver.equilibration_strategy = qtqp.EquilibrationStrategy.NONE
+  solver._norm_b = np.linalg.norm(solver.b, np.inf)
+  solver._norm_c = np.linalg.norm(solver.c, np.inf)
+  abs_a = abs(solver.a)
+  solver._norm_a_inf = float(abs_a.sum(axis=1).max())
+  solver._norm_a_one = float(abs_a.sum(axis=0).max())
+  solver._norm_p_inf = (
+      float(abs(solver.p).sum(axis=1).max()) if solver.p.nnz else 0.0
+  )
+  solver.it = 0
+  solver.start_time = 0.0
+
+  x = v.copy()
+  y = np.zeros(m)
+  y[z:] = 1e-6
+  s = np.zeros(m)
+  s[z:] = 1e-6
+  tau = 1e-8  # deep in the certificate regime
+
+  ctx = c_adv @ x
+  assert ctx < 0
+
+  # The legacy |c'x|-normalized test would have accepted this pseudo-ray:
+  legacy_dinfeas = np.linalg.norm(a @ x + s, np.inf) / abs(ctx)
+  assert legacy_dinfeas < 1e-8 + 1e-9 * np.linalg.norm(x, np.inf) / abs(ctx)
+
+  # The data-scaled test must reject it: the violations are a sigma_v /
+  # ||A|| fraction of ||A|| ||x||, far above any certificate tolerance.
+  assert sigma_v / norm_a > 1e-3
+  status = solver._check_termination(  # pylint: disable=protected-access
+      x, y, tau, s, alpha=0.5, mu=1.0, sigma=0.5, stats_i={},
+      collect_stats=False,
+  )
+  assert status != qtqp.SolutionStatus.UNBOUNDED
+  assert status != qtqp.SolutionStatus.INFEASIBLE
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes false infeasibility/unboundedness certificates. The investigation surfaced **two dual failure modes**, and the final test requires a candidate ray to be good in both of two complementary senses — each guards the other's blind spot.

**Failure mode 1: slope-normalized tests are gameable by large-slope pseudo-rays.** The legacy test accepted a ray when `||Ax + s|| < atol_infeas * |c'x| + rtol_infeas * ||x||` — slack proportional to the objective slope, which degenerate problems can inflate. On NETLIB `dfl001` (feasible; optimum 1.1266e7 confirmed by HiGHS on the identical converted model) the solver returned UNBOUNDED at iteration 9 with a "certificate" violating the constraints at 5–9% of `||A|| ||x||` but carrying slope −5.4e7 per unit norm. Clarabel 0.11.1 mis-certifies the same model the same way.

**Failure mode 2: data-scaled tests are fooled by huge-norm near-solutions.** A pure relative-backward-error test (`||A'y|| / (||A||_1 ||y||) < tol`) becomes small *automatically* on feasible problems with large dual iterates: `A'y ≈ -c·tau` while `||y||` is enormous, so the ratio shrinks although y is nothing like a ray. An intermediate version of this PR shipped exactly that test and false-certified four feasible NETLIB instances (fffff800, fit1p, tuff, vtp.base). Measured slope ratios `|b'y| / (||b|| ||y||)` do **not** separate the populations (genuine certificates span 5e-9..1.0, overlapping the false positives), so a slope-margin alone cannot fix it.

**The fix.** Certificates must pass both:

- data-scaled: `max(||Ax+s||, ||Px||) / (||A||_inf ||x||, ||P||_inf ||x||) < atol_infeas` (resp. `||A'y|| / (||A||_1 ||y||)`) — rejects mode 1;
- slope-scaled: `violations < atol_infeas * |c'x| + rtol_infeas * ||x||` (resp. `|b'y|`, `||y||`) — rejects mode 2;

plus a slope-robustness margin (`c'x < -rtol_infeas * ||c|| * ||x||`). No zero-ray guard is needed: as `||x|| -> 0` the data-scaled measure's numerator retains the O(1) slack while its denominator vanishes, so it diverges and nothing is certified. The reported `pinfeas`/`dinfeas` diagnostics become the scale-invariant data-scaled measures; operator norms are computed once at setup (O(nnz)).

## Validation

- Full NETLIB feasible (91): **89 SOLVED, 2 HIT_MAX_ITER (d6cube, dfl001), zero certified** — the four mode-2 instances now solve, and dfl001's false UNBOUNDED is gone (runs honestly toward the true optimum). Maros–Mészáros (93 supported): 90 solved, 3 max-iter, zero certified.
- NETLIB infeasible set (29): 26 detected INFEASIBLE in 5–44 iterations, statuses identical to the pre-fix branch (the 3 exceptions — cplex2, gran, greenbea-inf — are unchanged: marginally infeasible instances accepted as backward-error solutions, and one whose converted model HiGHS declares optimal).
- Synthetic infeasible/unbounded sweep: 120/120 correct across sizes, seeds, equilibrations.
- New regression test `test_certificate_rejects_large_slope_pseudo_ray` constructs the mode-1 gaming direction explicitly, asserts the legacy inequality accepted it, and asserts the new test rejects it.
- `_assert_infeasible` / `_assert_unbounded` updated to assert the data-scaled contract on the returned normalized certificates.
- Full test suite green.

Stacked on #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
