### PR TITLE
Add opt-in second-order arc search with exact tau-lift

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ solve(
     regularization_eps: float = 1e-2,
     fused_corrector_division: bool = False,
     max_centrality_correctors: int = 1,
+    arc_search: bool = False,
 ) -> qtqp.Solution
 ```
 
@@ -265,6 +266,10 @@ Choose one with the `refinement_strategy` argument:
 -   `max_centrality_correctors`: Maximum Gondzio-style centrality correctors
     per iteration, each one extra back-solve on the existing factorization,
     accepted only when the step size improves. Default `1`; `0` disables.
+-   `arc_search`: Opt-in second-order predictor arc with exact per-candidate
+    tau-lift via the embedding's scalar quadratic (an operation unavailable
+    to solvers that linearize the tau-kappa coupling). Solves some
+    chronically hard instances at extra per-iteration cost; off by default.
 
 This method will return a `qtqp.Solution` object, with fields:
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ solve(
         qtqp.RefinementStrategy.RICHARDSON
     ),
     gmres_restart: int = 10,
-    central_path_exponent: float = 1.0,
+    regularization_eps: float = 1e-2,
     fused_corrector_division: bool = False,
 ) -> qtqp.Solution
 ```
@@ -202,8 +202,9 @@ Key parameters:
     solves. Defaults to `qtqp.RefinementStrategy.RICHARDSON`.
 -   `gmres_restart`: Restart length for `qtqp.RefinementStrategy.GMRES`.
     Ignored by Richardson refinement.
--   `central_path_exponent`: Positive exponent for the generalized central-path
-    residual equation. The default `1.0` is the standard central path.
+-   `regularization_eps`: Weight in (0, 1] on the (x, y) blocks of the central
+    path's regularization term. The default `1e-2` is the validated weighted
+    path; `1.0` recovers the unweighted regularized path.
 -   `fused_corrector_division`: If True, computes the Mehrotra corrector slack
     update with one fused division. The default False preserves legacy
     arithmetic.
@@ -246,9 +247,17 @@ Choose one with the `refinement_strategy` argument:
 
 #### Advanced numerical options
 
--   `central_path_exponent`: Uses `mu**central_path_exponent` in the linear
-    residual part of the central-path equations while keeping cone-product
-    targets at `mu`. Values must be positive and finite.
+-   `regularization_eps`: The central path's linear regularization term is
+    `mu * diag(eps*I, eps*I, 1) * u`, giving KKT diagonal shifts of `eps*mu`
+    and iterates normalized onto the ellipsoid
+    `eps*||(x,y)||^2 + tau^2 = m - z + 1`. Smaller `eps` cuts the
+    path-induced residual and duality-gap bias by `eps` (important on
+    problems with large solution norms), at the price of a weaker
+    strong-monotonicity modulus and infeasibility certificates bounded at
+    scale `1/sqrt(eps)`. Termination scales include the iterate norms
+    `||x||/tau`, `||y||/tau` (and their sum for the gap), so acceptance is a
+    backward-error criterion consistent with the perturbation the path
+    itself commits.
 -   `fused_corrector_division`: Fuses the corrector slack numerator before
     dividing by `y[z:]`. This is useful when small `y` components make the
     legacy three-division form vulnerable to cancellation.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ solve(
         qtqp.RefinementStrategy.RICHARDSON
     ),
     gmres_restart: int = 10,
-    regularization_eps: float = 1e-2,
     fused_corrector_division: bool = False,
 ) -> qtqp.Solution
 ```
@@ -202,9 +201,6 @@ Key parameters:
     solves. Defaults to `qtqp.RefinementStrategy.RICHARDSON`.
 -   `gmres_restart`: Restart length for `qtqp.RefinementStrategy.GMRES`.
     Ignored by Richardson refinement.
--   `regularization_eps`: Weight in (0, 1] on the (x, y) blocks of the central
-    path's regularization term. The default `1e-2` is the validated weighted
-    path; `1.0` recovers the unweighted regularized path.
 -   `fused_corrector_division`: If True, computes the Mehrotra corrector slack
     update with one fused division. The default False preserves legacy
     arithmetic.
@@ -247,17 +243,12 @@ Choose one with the `refinement_strategy` argument:
 
 #### Advanced numerical options
 
--   `regularization_eps`: The central path's linear regularization term is
-    `mu * diag(eps*I, eps*I, 1) * u`, giving KKT diagonal shifts of `eps*mu`
-    and iterates normalized onto the ellipsoid
-    `eps*||(x,y)||^2 + tau^2 = m - z + 1`. Smaller `eps` cuts the
-    path-induced residual and duality-gap bias by `eps` (important on
-    problems with large solution norms), at the price of a weaker
-    strong-monotonicity modulus and infeasibility certificates bounded at
-    scale `1/sqrt(eps)`. Termination scales include the iterate norms
-    `||x||/tau`, `||y||/tau` (and their sum for the gap), so acceptance is a
-    backward-error criterion consistent with the perturbation the path
-    itself commits.
+-   Termination scales include the iterate norms `||x||/tau`, `||y||/tau`
+    (and their sum for the duality gap), so acceptance is a backward-error
+    criterion consistent with the `mu`-scale perturbation the regularized
+    path itself commits: residuals are judged against the larger of the
+    floating-point measurement floor of their summands and the perturbation
+    allowance of the path.
 -   `fused_corrector_division`: Fuses the corrector slack numerator before
     dividing by `y[z:]`. This is useful when small `y` components make the
     legacy three-division form vulnerable to cancellation.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ solve(
     gmres_restart: int = 10,
     regularization_eps: float = 1e-2,
     fused_corrector_division: bool = False,
+    max_centrality_correctors: int = 1,
 ) -> qtqp.Solution
 ```
 
@@ -261,6 +262,9 @@ Choose one with the `refinement_strategy` argument:
 -   `fused_corrector_division`: Fuses the corrector slack numerator before
     dividing by `y[z:]`. This is useful when small `y` components make the
     legacy three-division form vulnerable to cancellation.
+-   `max_centrality_correctors`: Maximum Gondzio-style centrality correctors
+    per iteration, each one extra back-solve on the existing factorization,
+    accepted only when the step size improves. Default `1`; `0` disables.
 
 This method will return a `qtqp.Solution` object, with fields:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qtqp"
-version = "0.0.5"
+version = "0.0.6"
 description = "The 'cutie' QP solver."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -485,6 +485,7 @@ class QTQP:
       gmres_restart: int = 10,
       regularization_eps: float = 1e-2,
       fused_corrector_division: bool = False,
+      max_centrality_correctors: int = 1,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method."""
     self._linear_solver = None
@@ -510,6 +511,7 @@ class QTQP:
           gmres_restart=gmres_restart,
           regularization_eps=regularization_eps,
           fused_corrector_division=fused_corrector_division,
+          max_centrality_correctors=max_centrality_correctors,
       )
     finally:
       if self._linear_solver is not None:
@@ -539,6 +541,7 @@ class QTQP:
       gmres_restart: int = 10,
       regularization_eps: float = 1e-2,
       fused_corrector_division: bool = False,
+      max_centrality_correctors: int = 1,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method.
 
@@ -609,6 +612,15 @@ class QTQP:
         avoids catastrophic cancellation when y_i is small and the
         terms have similar magnitudes with opposing signs. Default False
         preserves the legacy bit-for-bit behavior.
+      max_centrality_correctors (int): Maximum number of Gondzio-style
+        multiple centrality correctors per iteration. Each corrector costs
+        one back-solve on the existing factorization (kinv_q is shared),
+        recentering the aspirational trial point's outlier complementarity
+        products, and is accepted only if the step size improves.
+        Correctors are skipped when the step size is already >= 0.9.
+        The default 1 was validated on NETLIB + Maros-Meszaros (cuts
+        iterations ~10%, rescues borderline instances, no regressions);
+        0 disables.
 
     Returns:
       A Solution object containing the solution and solve stats.
@@ -634,6 +646,9 @@ class QTQP:
           f" {regularization_eps}."
       )
     self._regularization_eps = float(regularization_eps)
+    if max_centrality_correctors < 0:
+      raise ValueError("max_centrality_correctors must be >= 0.")
+    self._max_centrality_correctors = int(max_centrality_correctors)
     self._fused_corrector_division = bool(fused_corrector_division)
 
     resolved_linear_solver, linear_solver_backend = _resolve_linear_solver(
@@ -814,6 +829,56 @@ class QTQP:
         )
 
       alpha = self._compute_step_size(y, s, d_y, d_s)
+
+      # --- Gondzio multiple centrality correctors ---
+      # Each extra corrector costs one back-solve on the existing
+      # factorization (kinv_q is shared): push the aspirational trial
+      # point's outlier complementarity products back into a symmetric
+      # neighborhood of the target, accept only if the step size improves.
+      mu_c = sigma * mu
+      for _ in range(self._max_centrality_correctors):
+        if alpha >= 0.9:
+          break  # step already good; a corrector cannot pay for itself
+        if corrector_lin_sys_stats.get("tau_method") != "quadratic":
+          break  # tau solve degraded; do not stack correctors on it
+        alpha_asp = min(1.0, 1.5 * alpha + 0.3)
+        v = (y[self.z :] + alpha_asp * d_y[self.z :]) * (
+            s[self.z :] + alpha_asp * d_s[self.z :]
+        )
+        target = np.clip(v, 0.1 * mu_c, 10.0 * mu_c)
+        if np.array_equal(target, v):
+          break
+        correction_g = correction + (target - v) / y[self.z :]
+        xy[: self.n] = x_p
+        xy[self.n :] = y_p
+        x_g, y_g, tau_g, gondzio_lin_sys_stats = self._newton_step(
+            p=p,
+            mu=mu,
+            mu_target=mu_c,
+            r_anchor=xy,
+            tau_anchor=tau_p,
+            x=x,
+            y=y,
+            s=s,
+            tau=tau,
+            correction=correction_g,
+        )
+        d_s_g = np.zeros_like(d_s)
+        d_s_g[self.z :] = (
+            mu_c / y[self.z :]
+            + correction_g
+            - y_g[self.z :] * s[self.z :] / y[self.z :]
+        )
+        d_y_g = y_g - y
+        alpha_g = self._compute_step_size(y, s, d_y_g, d_s_g)
+        if alpha_g <= alpha + 0.1 * (alpha_asp - alpha):
+          break
+        stats_i["gondzio_lin_sys_stats"] = gondzio_lin_sys_stats
+        d_x, d_y, d_tau = x_g - x, d_y_g, tau_g - tau
+        d_s = d_s_g
+        correction = correction_g
+        alpha = alpha_g
+
       step = step_size_scale * alpha
       x += step * d_x
       y += step * d_y

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -1272,12 +1272,11 @@ class QTQP:
       np0 = max(np_poly[0], _EPS)
       ys0 = max(ys[0], _EPS)
 
-    eps = self._regularization_eps
     mz1 = self.m - self.z + 1
     mz = self.m - self.z
     # Along the arc, the normalized duality measure is the ratio of two
-    # exact quartics in alpha: N(a) = y's(a) over the ellipsoid quadratic
-    # Q(a) = eps*(||x||^2 + ||y||^2)(a) + tau_arc(a)^2 (using the arc's
+    # exact quartics in alpha: N(a) = y's(a) over the sphere quadratic
+    # Q(a) = (||x||^2 + ||y||^2)(a) + tau_arc(a)^2 (using the arc's
     # polynomial tau in the normalization). Its stationary points are the
     # roots of N'Q - NQ' -- a degree-7 polynomial, solved exactly via the
     # companion matrix; the exact tau-lift then scores the few candidates.
@@ -1286,7 +1285,7 @@ class QTQP:
           2.0 * tau * d2t + d1t * d1t, 2.0 * d1t * d2t, d2t * d2t]
     pp = np.polynomial.polynomial
     n_poly = np.array(ys)
-    q_poly = eps * (np.array(xx) + np.array(yy)) + np.array(tt)
+    q_poly = np.array(xx) + np.array(yy) + np.array(tt)
     stat = pp.polysub(pp.polymul(pp.polyder(n_poly), q_poly),
                       pp.polymul(n_poly, pp.polyder(q_poly)))
     # Candidates: the exact stationary points of the normalized measure,
@@ -1333,7 +1332,7 @@ class QTQP:
       tau_a = (lin + math.sqrt(disc)) / (2.0 * mu)
       if not np.isfinite(tau_a) or tau_a <= 1e-12:
         continue
-      quad = eps * (_poly(xx, a_c) + _poly(yy, a_c)) + tau_a * tau_a
+      quad = _poly(xx, a_c) + _poly(yy, a_c) + tau_a * tau_a
       mu_a = (mz1 / max(_EPS, quad)) * ys_a / mz
       score = m_a if merit else mu_a
       if best is None or score < best[0]:
@@ -1372,7 +1371,7 @@ class QTQP:
         if disc_pr >= 0.0:
           tau_pr = (lin_pr + math.sqrt(disc_pr)) / (2.0 * mu)
         if tau_pr is not None and np.isfinite(tau_pr) and tau_pr > 1e-12:
-          quad_pr = eps * (_poly(xx, a_probe) + _poly(yy, a_probe)) + tau_pr ** 2
+          quad_pr = _poly(xx, a_probe) + _poly(yy, a_probe) + tau_pr ** 2
           mu_probe = (mz1 / max(_EPS, quad_pr)) * ys_probe / mz
           sigma_pr = float(np.clip((mu_probe / max(_EPS, mu)) ** 3, 0.0, 1.0))
           # Target-matched anchor: the corrector's surrogate should
@@ -1426,10 +1425,10 @@ class QTQP:
     tau+ is then pinned by substituting this back into the tau equation of the
     homogeneous embedding (see _solve_for_tau).
 
-    The weighted central-path equation contributes the eps*(mu - mu_target)
-    coefficient on the (x, y) linear-residual side and (mu - mu_target) on
-    tau; cone-product corrections (s_i * y_i = mu_target, tau * kappa =
-    mu_target) keep the unmodified mu_target.
+    The regularized central-path equation contributes the (mu - mu_target)
+    coefficient on the linear-residual side; cone-product corrections
+    (s_i * y_i = mu_target, tau * kappa = mu_target) keep the unmodified
+    mu_target.
 
     Uses the exact quadratic tau solve when the KKT solve is accurate, and a
     linearized fallback (avoids squaring solver noise) when it's noisy or the
@@ -1588,10 +1587,10 @@ class QTQP:
     like x/tau and y/tau matter — tau is the homogeneous variable, and the final
     solution is recovered as (x/tau, y/tau, s/tau).
 
-    We enforce the invariant of the weighted central path (the Euler identity
-    for the linear term mu * diag(eps*I, eps*I, 1) * u), which ensures
-    convergence to a non-trivial solution:
-        eps * ||(x, y)||^2 + tau^2 = m - z + 1
+    We enforce the invariant of the regularized central path (the Euler
+    identity for the linear term mu * u), which ensures convergence to a
+    non-trivial solution:
+        ||(x, y)||^2 + tau^2 = m - z + 1
     The right-hand side counts complementarity pairs: (m - z) from the
     inequality constraints plus 1 for the tau-kappa pair of the embedding.
 

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -547,14 +547,16 @@ class QTQP:
       rtol (float): Relative tolerance for convergence criteria, scaled by
         problem data norms.
       atol_infeas (float): Certificate-quality tolerance for infeasibility
-        and unboundedness detection: a candidate ray u is accepted when its
-        relative backward error (constraint violations divided by
-        ||operator|| * ||u||, the smallest relative data perturbation under
-        which the ray is exact) is below atol_infeas.
-      rtol_infeas (float): Slope-robustness margin for certificates: the
-        ray's objective slope (c'x or b'y) must be negative by at least
-        rtol_infeas times the data norm times the ray norm, so the sign
-        survives an rtol_infeas-sized relative perturbation of the data.
+        and unboundedness detection. A candidate ray u must be good in two
+        complementary senses: its relative backward error (violations over
+        ||operator|| * ||u||) must be below atol_infeas, AND its violations
+        must be below atol_infeas * |objective slope| + rtol_infeas * ||u||.
+        The first rejects large-slope pseudo-rays, the second rejects
+        huge-norm near-solutions; each guards the other's blind spot.
+      rtol_infeas (float): Ray-relative slack in the slope-scaled
+        certificate test, and the margin by which the certificate's
+        objective slope (c'x or b'y) must be negative relative to the data
+        and ray norms.
       max_iter (int): Maximum number of iterations before stopping.
       step_size_scale (float): A factor in (0, 1) to scale the step size,
         ensuring iterates remain strictly interior.
@@ -1310,9 +1312,10 @@ class QTQP:
     # such tests while violating the constraints badly (e.g. NETLIB dfl001).
     norm_aty = _norm(aty, np.inf)
     norm_px = _norm(px, np.inf)
+    norm_ax_plus_s = _norm(ax_plus_s, np.inf)
     norm_x = _norm(x, np.inf)
     norm_y = _norm(y, np.inf)
-    dinfeas_a = _norm(ax_plus_s, np.inf) / (self._norm_a_inf * norm_x + _EPS)
+    dinfeas_a = norm_ax_plus_s / (self._norm_a_inf * norm_x + _EPS)
     dinfeas_p = norm_px / (self._norm_p_inf * norm_x + _EPS)
     dinfeas = max(dinfeas_a, dinfeas_p)
     pinfeas = norm_aty / (self._norm_a_one * norm_y + _EPS)
@@ -1354,23 +1357,31 @@ class QTQP:
         and dres < self.atol + self.rtol * drelrhs
     ):
       status = SolutionStatus.SOLVED
-    # Unbounded: x is a dual infeasibility certificate (primal unbounded
-    # ray) when its relative backward error is within atol_infeas AND the
-    # objective slope is robustly negative relative to the ray's own scale
-    # (so the sign survives an rtol_infeas-sized perturbation of c). Note
-    # the quality measure needs no zero-ray guard: as ||x|| -> 0 its
-    # denominator vanishes while the numerator retains the O(1) slack s,
-    # so dinfeas diverges and nothing is certified.
+    # Certificate acceptance requires BOTH quality senses, because each
+    # guards the other's blind spot:
+    #   - data-scaled (violations / (||operator|| ||ray||) < atol_infeas):
+    #     rejects large-slope pseudo-rays whose |c'x| buys unbounded slack
+    #     in the slope-scaled test (e.g. NETLIB dfl001, where a direction
+    #     violating the constraints at 5-9% of ||A|| ||x|| was certified);
+    #   - slope-scaled (violations < atol_infeas * |slope| + rtol_infeas *
+    #     ||ray||): rejects huge-norm near-solutions, whose data-scaled
+    #     quality becomes small automatically (A'y ~ -c*tau with enormous
+    #     ||y|| makes ||A'y|| / (||A||_1 ||y||) tiny while y is nothing
+    #     like a ray; e.g. NETLIB fit1p, tuff, vtp.base, fffff800).
+    # The quality measures need no zero-ray guard: as ||x|| -> 0 the
+    # data-scaled denominator vanishes while the numerator retains the
+    # O(1) slack s, so dinfeas diverges and nothing is certified.
     elif (
         ctx < -(self.rtol_infeas * self._norm_c * norm_x + _EPS)
         and dinfeas < self.atol_infeas
+        and max(norm_ax_plus_s, norm_px)
+        < self.atol_infeas * abs(ctx) + self.rtol_infeas * norm_x
     ):
       status = SolutionStatus.UNBOUNDED
-    # Infeasible: y is a primal infeasibility certificate (dual unbounded
-    # ray), judged the same way via ||A'y|| / (||A||_1 ||y||) and b'y.
     elif (
         bty < -(self.rtol_infeas * self._norm_b * norm_y + _EPS)
         and pinfeas < self.atol_infeas
+        and norm_aty < self.atol_infeas * abs(bty) + self.rtol_infeas * norm_y
     ):
       status = SolutionStatus.INFEASIBLE
     else:

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -16,9 +16,11 @@
 """Interior point method for solving QPs.
 
   Algorithm: Mehrotra predictor-corrector interior point method with a
-  homogeneous embedding. Each iteration does:
+  homogeneous embedding, following the eps-weighted regularized central path
+  (linear term mu * diag(eps*I, eps*I, 1) * u). Each iteration does:
 
-    1. Normalize (x, y, tau, s) to have the norm of the central path.
+    1. Normalize (x, y, tau, s) onto the weighted path's ellipsoid
+       eps*||(x, y)||^2 + tau^2 = m - z + 1.
     2. Pre-solve K^{-1} @ [c; b] (shared between predictor and corrector steps).
     3. Predictor step: Newton direction with mu_target=0 (no centering).
     4. Compute sigma (centering parameter) from predictor step quality.
@@ -45,7 +47,7 @@ import scipy.sparse as sp
 from . import direct
 from .direct import RefinementStrategy
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 _HEADER = """| iter |      pcost |      dcost |     pres |     dres |      gap |   infeas |       mu |  q, p, c |     time |"""
 _SEPARA = """|------|------------|------------|----------|----------|----------|----------|----------|----------|----------|"""
 _norm = np.linalg.norm
@@ -312,9 +314,10 @@ class QTQP:
         raise ValueError("QP matrix 'p' must be symmetric.")
       self.p = p
 
-    # Default exponent so _newton_step works in tests that call it directly
-    # before solve() has overridden the attribute.
-    self._central_path_exponent = 1.0
+    # Default weight so path internals work in tests that call them directly
+    # before solve() has overridden the attribute. 1.0 is the unweighted
+    # (classical regularized) path; solve() defaults to 1e-2.
+    self._regularization_eps = 1.0
 
   def _presolve(self, inf_bound: float = 1e20):
     """Drop inequality rows with trivially-satisfied RHS (b[i] >= inf_bound
@@ -480,7 +483,7 @@ class QTQP:
       init_mu_scale: float = 1.0,
       refinement_strategy: RefinementStrategy = RefinementStrategy.RICHARDSON,
       gmres_restart: int = 10,
-      central_path_exponent: float = 1.0,
+      regularization_eps: float = 1e-2,
       fused_corrector_division: bool = False,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method."""
@@ -505,7 +508,7 @@ class QTQP:
           init_mu_scale=init_mu_scale,
           refinement_strategy=refinement_strategy,
           gmres_restart=gmres_restart,
-          central_path_exponent=central_path_exponent,
+          regularization_eps=regularization_eps,
           fused_corrector_division=fused_corrector_division,
       )
     finally:
@@ -534,7 +537,7 @@ class QTQP:
       init_mu_scale: float = 1.0,
       refinement_strategy: RefinementStrategy = RefinementStrategy.RICHARDSON,
       gmres_restart: int = 10,
-      central_path_exponent: float = 1.0,
+      regularization_eps: float = 1e-2,
       fused_corrector_division: bool = False,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method.
@@ -582,13 +585,15 @@ class QTQP:
         inner Arnoldi step consumes one factor-solve. Smaller values reduce
         per-cycle cost at the price of more restarts. Ignored when
         refinement_strategy is RICHARDSON.
-      central_path_exponent (float): Exponent p > 0 in the generalized
-        central-path equation r + mu^p * u = 0 (cone products s_i * y_i =
-        mu and tau * kappa = mu are unchanged). Default 1.0 recovers the
-        standard primal-dual central path. p > 1 makes the linear residual
-        vanish faster than mu as mu -> 0; p < 1 the reverse. mu^p enters
-        the KKT diagonal regularization and the Newton-step linear-residual
-        RHS; cone-product targets keep the unmodified mu.
+      regularization_eps (float): Weight eps in (0, 1] on the (x, y) blocks
+        of the central path's linear regularization term mu * diag(eps*I,
+        eps*I, 1) * u (cone products s_i * y_i = mu and tau * kappa = mu are
+        unweighted). The path lives on the ellipsoid eps*||(x,y)||^2 +
+        tau^2 = m - z + 1; smaller eps cuts the path-induced KKT residual
+        and duality-gap bias by eps at the cost of a weaker strong-
+        monotonicity modulus eps*mu and infeasibility certificates bounded
+        at scale 1/sqrt(eps). The default 1e-2 was validated on NETLIB +
+        Maros-Meszaros; 1.0 recovers the unweighted regularized path.
       fused_corrector_division (bool): If True, compute the corrector
         slack update via a single division by y[z:] with the three
         numerator terms (sigma*mu, the Mehrotra cross product, and
@@ -616,12 +621,12 @@ class QTQP:
           f"init_mu_scale must be a positive finite float,"
           f" got {init_mu_scale}"
       )
-    if not (np.isfinite(central_path_exponent) and central_path_exponent > 0):
+    if not (np.isfinite(regularization_eps) and 0 < regularization_eps <= 1):
       raise ValueError(
-          "central_path_exponent must be a positive finite float (got"
-          f" {central_path_exponent}); p <= 0 is incompatible with the IPM."
+          "regularization_eps must be a finite float in (0, 1], got"
+          f" {regularization_eps}."
       )
-    self._central_path_exponent = float(central_path_exponent)
+    self._regularization_eps = float(regularization_eps)
     self._fused_corrector_division = bool(fused_corrector_division)
 
     resolved_linear_solver, linear_solver_backend = _resolve_linear_solver(
@@ -694,13 +699,13 @@ class QTQP:
       x, y, tau, s = self._normalize(x, y, tau, s)
 
       mu = (y @ s) / (self.m - self.z)
-      # Generalized central path: r + mu^p * u = 0. mu_p enters the KKT
-      # diagonal and the Newton-step linear-residual RHS; cone-product
-      # targets (s*y = mu, tau*kappa = mu) keep the unmodified mu.
-      mu_p = mu ** self._central_path_exponent
+      # Weighted central path: the linear term is mu * diag(eps*I, eps*I, 1)
+      # * u, so the KKT diagonal shift on the x and y blocks is eps*mu.
+      # Cone-product targets (s*y = mu, tau*kappa = mu) keep the plain mu.
+      eps_mu = self._regularization_eps * mu
 
       # --- Take an IPM step ---
-      self._linear_solver.update(mu=mu_p, s=s, y=y)
+      self._linear_solver.update(mu=eps_mu, s=s, y=y)
 
       # --- Step 1: Precompute kinv_q = K^{-1} @ q ---
       # This is reused for both predictor and corrector parts of the step.
@@ -1033,11 +1038,12 @@ class QTQP:
     s_aff = s + alpha * d_s
 
     # Compute mu_aff directly without calling _normalize to avoid 4 extra
-    # allocations. Equivalent to: normalize then compute (y @ s) / (m - z).
-    # scale = sqrt(m-z+1) / max(_EPS, ||(x,y,tau)||), so scale^2 = (m-z+1) /
-    # max(_EPS^2, ||(x,y,tau)||^2), giving mu_aff = scale^2 * (y_aff @ s_aff).
-    xyt_norm_sq = x_aff @ x_aff + y_aff @ y_aff + tau_aff * tau_aff
-    scale_sq = (self.m - self.z + 1) / max(_EPS * _EPS, xyt_norm_sq)
+    # allocations. Equivalent to: normalize onto the weighted-path ellipsoid
+    # (eps*||(x,y)||^2 + tau^2 = m-z+1) then compute (y @ s) / (m - z);
+    # normalization scales y and s each by `scale`, so mu picks up scale^2.
+    eps = self._regularization_eps
+    quad_aff = (eps * (x_aff @ x_aff + y_aff @ y_aff) + tau_aff * tau_aff)
+    scale_sq = (self.m - self.z + 1) / max(_EPS * _EPS, quad_aff)
     mu_aff = scale_sq * (y_aff @ s_aff) / (self.m - self.z)
 
     # sigma = (mu_aff / mu)^3: Mehrotra's heuristic. If the affine step already
@@ -1059,21 +1065,19 @@ class QTQP:
     tau+ is then pinned by substituting this back into the tau equation of the
     homogeneous embedding (see _solve_for_tau).
 
-    The central-path equation r + mu^p * u = 0 contributes the
-    (mu^p - mu_target^p) coefficient on the linear-residual side; cone-product
-    corrections (s_i * y_i = mu_target, tau * kappa = mu_target) keep the
-    unmodified mu_target.
+    The weighted central-path equation contributes the eps*(mu - mu_target)
+    coefficient on the (x, y) linear-residual side and (mu - mu_target) on
+    tau; cone-product corrections (s_i * y_i = mu_target, tau * kappa =
+    mu_target) keep the unmodified mu_target.
 
     Uses the exact quadratic tau solve when the KKT solve is accurate, and a
     linearized fallback (avoids squaring solver noise) when it's noisy or the
     quadratic residual check fails.
     """
-    cpe = self._central_path_exponent
-    # 0**cpe = 0 for cpe > 0, so mu_target = 0 (predictor) yields mu_target_p = 0.
-    mu_p = mu ** cpe
-    mu_target_p = mu_target ** cpe if mu_target > 0.0 else 0.0
-    # Prepare RHS for the linear system.
-    r = (mu_p - mu_target_p) * r_anchor
+    # Prepare RHS for the linear system. The (x, y) blocks of the weighted
+    # path's linear term carry the eps weight; the cone rows below are
+    # barrier terms and stay unweighted.
+    r = (self._regularization_eps * (mu - mu_target)) * r_anchor
     if mu_target != 0.0:
       r[self.n + self.z :] += mu_target / y[self.z :]
     r[self.n + self.z :] += s[self.z :]
@@ -1090,7 +1094,7 @@ class QTQP:
     tau_plus = None
     if lin_sys_stats["converged"] or lin_sys_stats["final_residual_norm"] < 1e-7:
       try:
-        r_tau = (mu_p - mu_target_p) * tau_anchor
+        r_tau = (mu - mu_target) * tau_anchor
         tau_plus = self._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)
         lin_sys_stats["tau_method"] = "quadratic"
       except ValueError:
@@ -1123,16 +1127,15 @@ class QTQP:
     a feasible point (tau=0 corresponds to a certificate of infeasibility or
     unboundedness, which is handled separately at termination).
 
-    Generalized central path: t_a's mu term becomes mu^cpe (the linear-residual
-    coefficient on tau); t_c = -mu_target keeps the unmodified mu_target since
-    it comes from the cone-product equation tau * kappa = mu_target.
+    The tau block of the weighted path carries unit weight, so t_a's mu term
+    is the plain mu; t_c = -mu_target comes from the cone-product equation
+    tau * kappa = mu_target.
     """
     # Coefficients of the quadratic t_a * tau+^2 + t_b * tau+ + t_c = 0.
     n = self.n
     q, kinv_q = self.q, self.kinv_q
-    mu_p = mu ** self._central_path_exponent
 
-    t_a = mu_p + kinv_q @ q
+    t_a = mu + kinv_q @ q
     t_b = -r_tau - kinv_r @ q
     t_c = -mu_target
     if p.nnz > 0:
@@ -1183,15 +1186,14 @@ class QTQP:
     enters linearly rather than quadratically. A [0.1x, 10x] trust region
     prevents manifold drift from the first-order approximation.
 
-    Linear-residual coefficients on tau use mu^cpe and mu_target^cpe (the
-    generalized central path); the cone-product constant -mu_target keeps the
-    unmodified mu_target.
+    The tau block of the weighted path carries unit weight, so the tau
+    coefficients use the plain mu and mu_target; the cone-product constant
+    -mu_target is likewise unmodified.
     """
     n = self.n
     q, kinv_q = self.q, self.kinv_q
-    cpe = self._central_path_exponent
-    mu_p = mu ** cpe
-    mu_target_p = mu_target ** cpe if mu_target > 0.0 else 0.0
+    mu_p = mu
+    mu_target_p = mu_target
 
     px = p @ x if p.nnz > 0 else np.zeros(n)
 
@@ -1228,16 +1230,19 @@ class QTQP:
     like x/tau and y/tau matter — tau is the homogeneous variable, and the final
     solution is recovered as (x/tau, y/tau, s/tau).
 
-    We enforce the norm of the central path, which ensures convergence to
-    non-trivial solution, ie:
-        ||(x, y, tau)||^2 = m - z + 1
+    We enforce the invariant of the weighted central path (the Euler identity
+    for the linear term mu * diag(eps*I, eps*I, 1) * u), which ensures
+    convergence to a non-trivial solution:
+        eps * ||(x, y)||^2 + tau^2 = m - z + 1
     The right-hand side counts complementarity pairs: (m - z) from the
     inequality constraints plus 1 for the tau-kappa pair of the embedding.
+    At eps = 1 this is the sphere of the unweighted path.
 
     Operates in-place on the iterate arrays and returns them for convenience.
     """
-    xyt_norm = math.sqrt(x @ x + y @ y + tau * tau)
-    scale = math.sqrt(self.m - self.z + 1) / max(_EPS, xyt_norm)
+    eps = self._regularization_eps
+    quad = eps * (x @ x + y @ y) + tau * tau
+    scale = math.sqrt((self.m - self.z + 1) / max(_EPS, quad))
     x *= scale
     y *= scale
     tau *= scale
@@ -1295,26 +1300,42 @@ class QTQP:
     # pinfeas measures how well y/|b'y| certifies primal infeasibility.
     pinfeas = norm_aty / (abs(bty) + _EPS)
 
-    # Primal residual tolerance relative scale.
+    norm_x = _norm(x, np.inf)
+    norm_y = _norm(y, np.inf)
+
+    # Residual tolerance relative scales. Each is the max of two families:
+    # the summand norms (the floor below which the residual cannot even be
+    # evaluated in floating point) and the iterate norm (the backward-error
+    # allowance: dres <= rtol * ||x||/tau accepts a point that is exactly
+    # dual-feasible for P + dP with ||dP|| <= rtol, which is precisely the
+    # eps*mu*I perturbation the weighted path itself commits; likewise
+    # pres <= rtol * ||y||/tau on the primal side).
     prelrhs = max(
         _norm(ax, np.inf) * inv_tau,
         _norm(s, np.inf) * inv_tau,
         self._norm_b,
+        norm_y * inv_tau,
     )
 
-    # Dual residual tolerance relative scale.
     drelrhs = max(
         norm_px * inv_tau,
         norm_aty * inv_tau,
         self._norm_c,
+        norm_x * inv_tau,
     )
 
-    norm_x = _norm(x, np.inf)
-    norm_y = _norm(y, np.inf)
+    # Gap tolerance relative scale: the cost magnitudes (measurement floor)
+    # or the first-power iterate norm (the empirically calibrated allowance
+    # for the weighted path's O(eps*mu*||u||^2) objective bias; see the A'
+    # criteria validation on NETLIB + Maros-Meszaros).
+    gaprelrhs = max(
+        min(abs(pcost), abs(dcost)),
+        (norm_x + norm_y) * inv_tau,
+    )
 
     # Solved: duality gap and both residuals are within tolerance.
     if (
-        gap < self.atol + self.rtol * min(abs(pcost), abs(dcost))
+        gap < self.atol + self.rtol * gaprelrhs
         and pres < self.atol + self.rtol * prelrhs
         and dres < self.atol + self.rtol * drelrhs
     ):

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -486,6 +486,7 @@ class QTQP:
       regularization_eps: float = 1e-2,
       fused_corrector_division: bool = False,
       max_centrality_correctors: int = 1,
+      arc_search: bool = False,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method."""
     self._linear_solver = None
@@ -512,6 +513,7 @@ class QTQP:
           regularization_eps=regularization_eps,
           fused_corrector_division=fused_corrector_division,
           max_centrality_correctors=max_centrality_correctors,
+          arc_search=arc_search,
       )
     finally:
       if self._linear_solver is not None:
@@ -542,6 +544,7 @@ class QTQP:
       regularization_eps: float = 1e-2,
       fused_corrector_division: bool = False,
       max_centrality_correctors: int = 1,
+      arc_search: bool = False,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method.
 
@@ -621,6 +624,14 @@ class QTQP:
         The default 1 was validated on NETLIB + Maros-Meszaros (cuts
         iterations ~10%, rescues borderline instances, no regressions);
         0 disables.
+      arc_search (bool): If True, replace the point predictor with a
+        second-order arc search: one extra back-solve builds the arc
+        u + alpha*d1 + alpha^2*d2, every arc quantity is precomputed as a
+        polynomial in alpha, and each trial point's tau is re-lifted
+        EXACTLY via the scalar embedding quadratic (O(1) per candidate,
+        no back-solve) — an operation unavailable to solvers that
+        linearize the tau-kappa coupling. The corrector is anchored at
+        the best arc point. Default False (experimental).
 
     Returns:
       A Solution object containing the solution and solve stats.
@@ -649,6 +660,7 @@ class QTQP:
     if max_centrality_correctors < 0:
       raise ValueError("max_centrality_correctors must be >= 0.")
     self._max_centrality_correctors = int(max_centrality_correctors)
+    self._arc_search = bool(arc_search)
     self._fused_corrector_division = bool(fused_corrector_division)
 
     resolved_linear_solver, linear_solver_backend = _resolve_linear_solver(
@@ -767,17 +779,32 @@ class QTQP:
       # target=0: (y + d_y)(s + d_s) ≈ 0 => d_s = -(y + d_y)*s/y = -y_p*s/y.
       d_s[self.z :] = -y_p[self.z :] * s[self.z :] / y[self.z :]
 
-      # Pre-compute the Mehrotra cross term in un-divided form only when the
-      # fused-corrector path will consume it (otherwise stay on the legacy
-      # `-d_s * d_y_p / y` formulation verbatim).
-      if self._fused_corrector_division:
-        cross_p = d_s[self.z :] * d_y_p[self.z :]
+      # Arc search (if enabled): upgrade the point predictor to a
+      # second-order arc with exact tau-lift per trial point; on success it
+      # supplies the corrector anchor, cross term, and sigma directly.
+      arc = None
+      if self._arc_search:
+        arc = self._arc_search_predictor(
+            p=p, mu=mu, x=x, y=y, s=s, tau=tau,
+            x_p=x_p, y_p=y_p, tau_p=tau_p, d_y_p=d_y_p, d_s_p=d_s, xy=xy,
+            stats_i=stats_i,
+        )
+      if arc is not None:
+        x_p, y_p, tau_p, cross_arc, sigma = arc
+        if self._fused_corrector_division:
+          cross_p = cross_arc
+      else:
+        # Pre-compute the Mehrotra cross term in un-divided form only when
+        # the fused-corrector path will consume it (otherwise stay on the
+        # legacy `-d_s * d_y_p / y` formulation verbatim).
+        if self._fused_corrector_division:
+          cross_p = d_s[self.z :] * d_y_p[self.z :]
 
-      # Compute predictor step size and resulting centering parameter (sigma)
-      alpha_p = self._compute_step_size(y, s, d_y_p, d_s)
-      sigma = self._compute_sigma(
-          mu, x, y, tau, s, alpha_p, d_x_p, d_y_p, d_tau_p, d_s
-      )
+        # Compute predictor step size and resulting centering parameter
+        alpha_p = self._compute_step_size(y, s, d_y_p, d_s)
+        sigma = self._compute_sigma(
+            mu, x, y, tau, s, alpha_p, d_x_p, d_y_p, d_tau_p, d_s
+        )
 
       # --- Step 3: Corrector Step ---
       # Mehrotra's second-order correction accounts for the nonlinear cross-term
@@ -789,7 +816,9 @@ class QTQP:
       # feed the predictor's cross-term d_y_p*d_s_p back into the corrector RHS
       # (divided by y because the KKT complementarity block is scaled by 1/y),
       # so the corrector step can incorporate it to land closer to the target.
-      if self._fused_corrector_division:
+      if arc is not None:
+        correction = -cross_arc / y[self.z :]
+      elif self._fused_corrector_division:
         correction = -cross_p / y[self.z :]
       else:
         correction = -d_s[self.z :] * d_y_p[self.z :] / y[self.z :]
@@ -1133,6 +1162,163 @@ class QTQP:
     sigma_base = mu_aff / max(_EPS, mu_curr)
     sigma = sigma_base * sigma_base * sigma_base  # More stable than **3.
     return np.clip(sigma, 0.0, 1.0)
+
+  def _max_arc_step(self, v, d1, d2):
+    """Largest alpha in (0, 1] with v + alpha*d1 + alpha^2*d2 >= 0.
+
+    v is elementwise positive; returns the min over components of the
+    smallest positive root of the componentwise quadratic (capped at 1).
+    """
+    alpha = 1.0
+    quad = np.abs(d2) > _EPS
+    lin = ~quad & (d1 < -_EPS)
+    if np.any(lin):
+      alpha = min(alpha, float(np.min(-v[lin] / d1[lin])))
+    if np.any(quad):
+      a2, a1, a0 = d2[quad], d1[quad], v[quad]
+      disc = a1 * a1 - 4.0 * a2 * a0
+      has = disc >= 0.0
+      if np.any(has):
+        sq = np.sqrt(disc[has])
+        a2h, a1h = a2[has], a1[has]
+        r1 = (-a1h - sq) / (2.0 * a2h)
+        r2 = (-a1h + sq) / (2.0 * a2h)
+        lo, hi = np.minimum(r1, r2), np.maximum(r1, r2)
+        cand = np.where(lo > _EPS, lo, np.where(hi > _EPS, hi, np.inf))
+        if cand.size:
+          alpha = min(alpha, float(np.min(cand)))
+    return max(alpha, 0.0)
+
+  def _arc_search_predictor(
+      self, *, p, mu, x, y, s, tau, x_p, y_p, tau_p, d_y_p, d_s_p, xy, stats_i,
+  ):
+    """Second-order predictor arc with exact tau-lift per trial point.
+
+    One extra back-solve refines the affine point with Mehrotra's cross
+    term, defining the arc u(alpha) = u + alpha*d1 + alpha^2*d2. Every arc
+    quantity (y's, ||x||^2, ||y||^2, c'x + b'y, x'Px) is precomputed as a
+    polynomial in alpha, and each candidate's tau coordinate is re-solved
+    EXACTLY from the embedding's scalar tau-row given (x(alpha), y(alpha))
+    — a few dot products, no back-solve — so every trial point satisfies
+    the tau/perspective nonlinearity exactly. This lift is unavailable to
+    solvers that linearize the tau-kappa coupling. Returns the corrector
+    inputs (arc anchor, cross term, sigma), or None to fall back to the
+    point predictor.
+    """
+    z, n = self.z, self.n
+    corr_aff = -(d_s_p[z:] * d_y_p[z:]) / y[z:]
+    xy[:n] = x_p
+    xy[n:] = y_p
+    x_p2, y_p2, tau_p2, arc_stats = self._newton_step(
+        p=p, mu=mu, mu_target=0.0, r_anchor=xy, tau_anchor=tau_p,
+        x=x, y=y, s=s, tau=tau, correction=corr_aff,
+    )
+    stats_i["arc_lin_sys_stats"] = arc_stats
+    if arc_stats.get("tau_method") != "quadratic":
+      return None  # degraded tau solve; keep the stock point predictor
+
+    d1x, d1y = x_p - x, d_y_p
+    d2x, d2y = x_p2 - x_p, y_p2 - y_p
+    d2s = np.zeros_like(d_s_p)
+    d2s[z:] = (-y_p2[z:] * s[z:] / y[z:] + corr_aff) - d_s_p[z:]
+    d1s = d_s_p
+
+    alpha_max = min(
+        self._max_arc_step(y[z:], d1y[z:], d2y[z:]),
+        self._max_arc_step(s[z:], d1s[z:], d2s[z:]),
+    )
+    if alpha_max <= 1e-8:
+      return None
+
+    # Quartic/quadratic coefficients in alpha of the arc quantities.
+    ys = [float(y @ s), float(y @ d1s + s @ d1y),
+          float(y @ d2s + s @ d2y + d1y @ d1s),
+          float(d1y @ d2s + d2y @ d1s), float(d2y @ d2s)]
+    xx = [float(x @ x), 2.0 * float(x @ d1x),
+          2.0 * float(x @ d2x) + float(d1x @ d1x),
+          2.0 * float(d1x @ d2x), float(d2x @ d2x)]
+    yy = [float(y @ y), 2.0 * float(y @ d1y),
+          2.0 * float(y @ d2y) + float(d1y @ d1y),
+          2.0 * float(d1y @ d2y), float(d2y @ d2y)]
+    c_vec, b_vec = self.q[:n], self.q[n:]
+    qz = [float(c_vec @ x + b_vec @ y), float(c_vec @ d1x + b_vec @ d1y),
+          float(c_vec @ d2x + b_vec @ d2y)]
+    if p.nnz > 0:
+      px0, px1, px2 = p @ x, p @ d1x, p @ d2x
+      xpx = [float(x @ px0), 2.0 * float(d1x @ px0),
+             2.0 * float(d2x @ px0) + float(d1x @ px1),
+             2.0 * float(d2x @ px1), float(d2x @ px2)]
+    else:
+      xpx = None
+
+    def _poly(cs, a):
+      r = 0.0
+      for coeff in reversed(cs):
+        r = r * a + coeff
+      return r
+
+    eps = self._regularization_eps
+    mz1 = self.m - self.z + 1
+    mz = self.m - self.z
+    # Along the arc, the normalized duality measure is the ratio of two
+    # exact quartics in alpha: N(a) = y's(a) over the ellipsoid quadratic
+    # Q(a) = eps*(||x||^2 + ||y||^2)(a) + tau_arc(a)^2 (using the arc's
+    # polynomial tau in the normalization). Its stationary points are the
+    # roots of N'Q - NQ' -- a degree-7 polynomial, solved exactly via the
+    # companion matrix; the exact tau-lift then scores the few candidates.
+    d1t, d2t = tau_p - tau, tau_p2 - tau_p
+    tt = [tau * tau, 2.0 * tau * d1t,
+          2.0 * tau * d2t + d1t * d1t, 2.0 * d1t * d2t, d2t * d2t]
+    pp = np.polynomial.polynomial
+    n_poly = np.array(ys)
+    q_poly = eps * (np.array(xx) + np.array(yy)) + np.array(tt)
+    stat = pp.polysub(pp.polymul(pp.polyder(n_poly), q_poly),
+                      pp.polymul(n_poly, pp.polyder(q_poly)))
+    # Candidates: the exact stationary points of the normalized measure,
+    # augmented with a coarse damping grid -- every evaluation is O(1)
+    # after the precompute, so the redundancy is free and covers model
+    # error between the polynomial arc-tau (used to locate candidates)
+    # and the exact lift (used to score them).
+    candidates = [alpha_max * f for f in (1.0, 0.9, 0.75, 0.6, 0.45, 0.3, 0.15)]
+    stat = np.trim_zeros(stat, "b")
+    if stat.size > 1:
+      for root in pp.polyroots(stat):
+        if abs(root.imag) < 1e-12 and 1e-10 < root.real < alpha_max:
+          candidates.append(float(root.real))
+    best = None
+    for a_c in candidates:
+      ys_a = _poly(ys, a_c)
+      if ys_a <= 0.0:
+        continue
+      # Exact tau-lift for the trial point: the subproblem tau-row at the
+      # affine target, mu*t^2 - (mu*tau + qz(a))*t - xPx(a) = 0, unique
+      # nonnegative root.
+      qz_a = qz[0] + a_c * (qz[1] + a_c * qz[2])
+      xpx_a = _poly(xpx, a_c) if xpx is not None else 0.0
+      lin = mu * tau + qz_a
+      disc = lin * lin + 4.0 * mu * xpx_a
+      if disc < 0.0:
+        continue
+      tau_a = (lin + math.sqrt(disc)) / (2.0 * mu)
+      if not np.isfinite(tau_a) or tau_a <= 1e-12:
+        continue
+      quad = eps * (_poly(xx, a_c) + _poly(yy, a_c)) + tau_a * tau_a
+      mu_a = (mz1 / max(_EPS, quad)) * ys_a / mz
+      if best is None or mu_a < best[0]:
+        best = (mu_a, a_c, tau_a)
+    if best is None:
+      return None
+    mu_arc, a_c, tau_arc = best
+
+    sigma_base = mu_arc / max(_EPS, mu)
+    sigma = float(np.clip(sigma_base * sigma_base * sigma_base, 0.0, 1.0))
+
+    x_arc = x + a_c * d1x + (a_c * a_c) * d2x
+    y_arc = y + a_c * d1y + (a_c * a_c) * d2y
+    dy_tot = a_c * d1y[z:] + (a_c * a_c) * d2y[z:]
+    ds_tot = a_c * d1s[z:] + (a_c * a_c) * d2s[z:]
+    cross_arc = ds_tot * dy_tot
+    return x_arc, y_arc, tau_arc, cross_arc, sigma
 
   def _newton_step(
       self, *, p, mu, mu_target, r_anchor, tau_anchor, x, y, s, tau, correction,

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -660,7 +660,19 @@ class QTQP:
     if max_centrality_correctors < 0:
       raise ValueError("max_centrality_correctors must be >= 0.")
     self._max_centrality_correctors = int(max_centrality_correctors)
-    self._arc_search = bool(arc_search)
+    if arc_search in (False, 0):
+      self._arc_criterion = None
+    elif arc_search in (True, 1, "mu"):
+      self._arc_criterion = "mu"
+    elif arc_search == "merit":
+      self._arc_criterion = "merit"
+    elif arc_search == "potential":
+      self._arc_criterion = "potential"
+    else:
+      raise ValueError(
+          f"arc_search must be True, False, 'mu', or 'merit', got {arc_search!r}."
+      )
+    self._arc_search = self._arc_criterion is not None
     self._fused_corrector_division = bool(fused_corrector_division)
 
     resolved_linear_solver, linear_solver_backend = _resolve_linear_solver(
@@ -785,7 +797,7 @@ class QTQP:
       arc = None
       if self._arc_search:
         arc = self._arc_search_predictor(
-            p=p, mu=mu, x=x, y=y, s=s, tau=tau,
+            p=p, a=a, mu=mu, x=x, y=y, s=s, tau=tau,
             x_p=x_p, y_p=y_p, tau_p=tau_p, d_y_p=d_y_p, d_s_p=d_s, xy=xy,
             stats_i=stats_i,
         )
@@ -1190,7 +1202,8 @@ class QTQP:
     return max(alpha, 0.0)
 
   def _arc_search_predictor(
-      self, *, p, mu, x, y, s, tau, x_p, y_p, tau_p, d_y_p, d_s_p, xy, stats_i,
+      self, *, p, a, mu, x, y, s, tau, x_p, y_p, tau_p, d_y_p, d_s_p, xy,
+      stats_i,
   ):
     """Second-order predictor arc with exact tau-lift per trial point.
 
@@ -1251,11 +1264,41 @@ class QTQP:
     else:
       xpx = None
 
-    def _poly(cs, a):
+    def _poly(cs, av):
       r = 0.0
       for coeff in reversed(cs):
-        r = r * a + coeff
+        r = r * av + coeff
       return r
+
+    def _sqnorm_quartic(v0, v1, v2):
+      # ||v0 + a*v1 + a^2*v2||^2 as quartic coefficients in a.
+      return [float(v0 @ v0), 2.0 * float(v0 @ v1),
+              2.0 * float(v0 @ v2) + float(v1 @ v1),
+              2.0 * float(v1 @ v2), float(v2 @ v2)]
+
+    merit = self._arc_criterion == "merit"
+    if merit:
+      # KKT residual vectors along the arc are quadratic vector
+      # polynomials, so their squared norms are exact quartics: the merit
+      # max(relative pres, dres, complementarity) is closed-form along
+      # the arc. tau uses the arc's polynomial coordinates here; the
+      # exact lift supplies the returned anchor's tau.
+      d1t_m, d2t_m = tau_p - tau, tau_p2 - tau_p
+      if p.nnz > 0:
+        pd0, pd1, pd2 = px0, px1, px2
+      else:
+        pd0 = pd1 = pd2 = 0.0
+      rd0 = pd0 + a.T @ y + c_vec * tau
+      rd1 = pd1 + a.T @ d1y + c_vec * d1t_m
+      rd2 = pd2 + a.T @ d2y + c_vec * d2t_m
+      rp0 = a @ x + s - b_vec * tau
+      rp1 = a @ d1x + d1s - b_vec * d1t_m
+      rp2 = a @ d2x + d2s - b_vec * d2t_m
+      nd_poly = _sqnorm_quartic(rd0, rd1, rd2)
+      np_poly = _sqnorm_quartic(rp0, rp1, rp2)
+      nd0 = max(nd_poly[0], _EPS)
+      np0 = max(np_poly[0], _EPS)
+      ys0 = max(ys[0], _EPS)
 
     eps = self._regularization_eps
     mz1 = self.m - self.z + 1
@@ -1285,11 +1328,27 @@ class QTQP:
       for root in pp.polyroots(stat):
         if abs(root.imag) < 1e-12 and 1e-10 < root.real < alpha_max:
           candidates.append(float(root.real))
+    if merit:
+      for quart in (nd_poly, np_poly, ys):
+        dcoef = np.array([quart[1], 2.0 * quart[2], 3.0 * quart[3],
+                          4.0 * quart[4]])
+        dcoef = np.trim_zeros(dcoef, "b")
+        if dcoef.size > 1:
+          for root in pp.polyroots(dcoef):
+            if abs(root.imag) < 1e-12 and 1e-10 < root.real < alpha_max:
+              candidates.append(float(root.real))
+
     best = None
     for a_c in candidates:
       ys_a = _poly(ys, a_c)
       if ys_a <= 0.0:
         continue
+      if merit:
+        m_a = max(_poly(nd_poly, a_c) / nd0,
+                  _poly(np_poly, a_c) / np0,
+                  (ys_a / ys0) ** 2)
+        # fall through: score by merit but keep the tau-lift validity
+        # checks below; mu_a is still computed for sigma.
       # Exact tau-lift for the trial point: the subproblem tau-row at the
       # affine target, mu*t^2 - (mu*tau + qz(a))*t - xPx(a) = 0, unique
       # nonnegative root.
@@ -1304,11 +1363,75 @@ class QTQP:
         continue
       quad = eps * (_poly(xx, a_c) + _poly(yy, a_c)) + tau_a * tau_a
       mu_a = (mz1 / max(_EPS, quad)) * ys_a / mz
-      if best is None or mu_a < best[0]:
-        best = (mu_a, a_c, tau_a)
+      score = m_a if merit else mu_a
+      if best is None or score < best[0]:
+        best = (score, a_c, tau_a, mu_a)
     if best is None:
       return None
-    mu_arc, a_c, tau_arc = best
+    _, a_c, tau_arc, mu_arc = best
+
+    if self._arc_criterion == "potential":
+      # Re-score the feasible candidates with the Tanabe-Todd-Ye potential
+      # rho*log(y's) - sum_i log(s_i y_i): progress plus the barrier, so
+      # decentered candidates are penalized exactly as the theory demands.
+      # O(m) per candidate, on the handful of finalists only.
+      rho = mz + math.sqrt(mz)
+      best_pot = None
+      for cand in candidates:
+        if cand <= 0.0 or cand > alpha_max:
+          continue
+        yv = y[z:] + cand * d1y[z:] + (cand * cand) * d2y[z:]
+        sv = s[z:] + cand * d1s[z:] + (cand * cand) * d2s[z:]
+        prod = yv * sv
+        if np.min(prod) <= 0.0:
+          continue
+        pot = rho * math.log(float(yv @ sv)) - float(np.sum(np.log(prod)))
+        if best_pot is None or pot < best_pot[0]:
+          best_pot = (pot, cand)
+      if best_pot is not None:
+        a_probe = best_pot[1]
+        ys_probe = _poly(ys, a_probe)
+        # sigma from the potential-optimal probe point (normalized mu).
+        tau_pr = None
+        qz_pr = qz[0] + a_probe * (qz[1] + a_probe * qz[2])
+        xpx_pr = _poly(xpx, a_probe) if xpx is not None else 0.0
+        lin_pr = mu * tau + qz_pr
+        disc_pr = lin_pr * lin_pr + 4.0 * mu * xpx_pr
+        if disc_pr >= 0.0:
+          tau_pr = (lin_pr + math.sqrt(disc_pr)) / (2.0 * mu)
+        if tau_pr is not None and np.isfinite(tau_pr) and tau_pr > 1e-12:
+          quad_pr = eps * (_poly(xx, a_probe) + _poly(yy, a_probe)) + tau_pr ** 2
+          mu_probe = (mz1 / max(_EPS, quad_pr)) * ys_probe / mz
+          sigma_pr = float(np.clip((mu_probe / max(_EPS, mu)) ** 3, 0.0, 1.0))
+          # Target-matched anchor: the corrector's surrogate should
+          # approximate the corrector's own solution (the path point at
+          # mu_c = sigma*mu), so anchor where the arc's complementarity
+          # equals sigma * (current complementarity).
+          target_ys = sigma_pr * ys[0]
+          shifted = np.array(ys, dtype=float)
+          shifted[0] -= target_ys
+          shifted = np.trim_zeros(shifted, "b")
+          a_anchor = None
+          if shifted.size > 1:
+            roots = pp.polyroots(shifted)
+            real = [float(r.real) for r in roots
+                    if abs(r.imag) < 1e-12 and 1e-10 < r.real <= alpha_max]
+            if real:
+              a_anchor = min(real)
+          if a_anchor is None:
+            a_anchor = a_probe
+          qz_an = qz[0] + a_anchor * (qz[1] + a_anchor * qz[2])
+          xpx_an = _poly(xpx, a_anchor) if xpx is not None else 0.0
+          lin_an = mu * tau + qz_an
+          disc_an = lin_an * lin_an + 4.0 * mu * xpx_an
+          if disc_an >= 0.0:
+            tau_an = (lin_an + math.sqrt(disc_an)) / (2.0 * mu)
+            if np.isfinite(tau_an) and tau_an > 1e-12:
+              a_c, tau_arc = a_anchor, tau_an
+              mu_arc = mu_probe
+              # sigma is recomputed below from mu_arc via the same cube.
+
+    
 
     sigma_base = mu_arc / max(_EPS, mu)
     sigma = float(np.clip(sigma_base * sigma_base * sigma_base, 0.0, 1.0))

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -52,6 +52,17 @@ _HEADER = """| iter |      pcost |      dcost |     pres |     dres |      gap |
 _SEPARA = """|------|------------|------------|----------|----------|----------|----------|----------|----------|----------|"""
 _norm = np.linalg.norm
 _EPS = 1e-15  # Standard epsilon for numerical safety
+# Floor on the complementarity parameter mu wherever it enters the
+# algorithm (KKT shift, corrector targets, barrier terms). Below this
+# scale mu carries no information in double precision relative to O(1)
+# equilibrated data, and letting it underflow leaves the Newton system
+# effectively unregularized: on infeasibility trajectories the iterate
+# can freeze on an immature ray at mu ~ 1e-20, burning iterations with
+# every solve degraded (observed on Windows/QDLDL, where the platform's
+# roundoff draw loses the race between certificate maturation and mu
+# collapse). Healthy solves terminate at mu ~ 1e-9..1e-11 and never
+# touch the floor.
+_MU_FLOOR = 1e-14
 
 
 class LinearSolver(enum.Enum):
@@ -675,7 +686,7 @@ class QTQP:
       stats_i = {}
       x, y, tau, s = self._normalize(x, y, tau, s)
 
-      mu = (y @ s) / (self.m - self.z)
+      mu = max((y @ s) / (self.m - self.z), _MU_FLOOR)
 
       # --- Take an IPM step ---
       self._linear_solver.update(mu=mu, s=s, y=y)

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -16,11 +16,11 @@
 """Interior point method for solving QPs.
 
   Algorithm: Mehrotra predictor-corrector interior point method with a
-  homogeneous embedding, following the eps-weighted regularized central path
-  (linear term mu * diag(eps*I, eps*I, 1) * u). Each iteration does:
+  homogeneous embedding, following the regularized central path
+  (linear term mu * u). Each iteration does:
 
-    1. Normalize (x, y, tau, s) onto the weighted path's ellipsoid
-       eps*||(x, y)||^2 + tau^2 = m - z + 1.
+    1. Normalize (x, y, tau, s) onto the path's sphere
+       ||(x, y)||^2 + tau^2 = m - z + 1.
     2. Pre-solve K^{-1} @ [c; b] (shared between predictor and corrector steps).
     3. Predictor step: Newton direction with mu_target=0 (no centering).
     4. Compute sigma (centering parameter) from predictor step quality.
@@ -314,11 +314,6 @@ class QTQP:
         raise ValueError("QP matrix 'p' must be symmetric.")
       self.p = p
 
-    # Default weight so path internals work in tests that call them directly
-    # before solve() has overridden the attribute. 1.0 is the unweighted
-    # (classical regularized) path; solve() defaults to 1e-2.
-    self._regularization_eps = 1.0
-
   def _presolve(self, inf_bound: float = 1e20):
     """Drop inequality rows with trivially-satisfied RHS (b[i] >= inf_bound
     or +inf). Equality RHS must be finite; inequality RHS may not be NaN or -inf.
@@ -483,7 +478,6 @@ class QTQP:
       init_mu_scale: float = 1.0,
       refinement_strategy: RefinementStrategy = RefinementStrategy.RICHARDSON,
       gmres_restart: int = 10,
-      regularization_eps: float = 1e-2,
       fused_corrector_division: bool = False,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method."""
@@ -508,7 +502,6 @@ class QTQP:
           init_mu_scale=init_mu_scale,
           refinement_strategy=refinement_strategy,
           gmres_restart=gmres_restart,
-          regularization_eps=regularization_eps,
           fused_corrector_division=fused_corrector_division,
       )
     finally:
@@ -537,7 +530,6 @@ class QTQP:
       init_mu_scale: float = 1.0,
       refinement_strategy: RefinementStrategy = RefinementStrategy.RICHARDSON,
       gmres_restart: int = 10,
-      regularization_eps: float = 1e-2,
       fused_corrector_division: bool = False,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method.
@@ -585,15 +577,6 @@ class QTQP:
         inner Arnoldi step consumes one factor-solve. Smaller values reduce
         per-cycle cost at the price of more restarts. Ignored when
         refinement_strategy is RICHARDSON.
-      regularization_eps (float): Weight eps in (0, 1] on the (x, y) blocks
-        of the central path's linear regularization term mu * diag(eps*I,
-        eps*I, 1) * u (cone products s_i * y_i = mu and tau * kappa = mu are
-        unweighted). The path lives on the ellipsoid eps*||(x,y)||^2 +
-        tau^2 = m - z + 1; smaller eps cuts the path-induced KKT residual
-        and duality-gap bias by eps at the cost of a weaker strong-
-        monotonicity modulus eps*mu and infeasibility certificates bounded
-        at scale 1/sqrt(eps). The default 1e-2 was validated on NETLIB +
-        Maros-Meszaros; 1.0 recovers the unweighted regularized path.
       fused_corrector_division (bool): If True, compute the corrector
         slack update via a single division by y[z:] with the three
         numerator terms (sigma*mu, the Mehrotra cross product, and
@@ -621,12 +604,6 @@ class QTQP:
           f"init_mu_scale must be a positive finite float,"
           f" got {init_mu_scale}"
       )
-    if not (np.isfinite(regularization_eps) and 0 < regularization_eps <= 1):
-      raise ValueError(
-          "regularization_eps must be a finite float in (0, 1], got"
-          f" {regularization_eps}."
-      )
-    self._regularization_eps = float(regularization_eps)
     self._fused_corrector_division = bool(fused_corrector_division)
 
     resolved_linear_solver, linear_solver_backend = _resolve_linear_solver(
@@ -699,13 +676,9 @@ class QTQP:
       x, y, tau, s = self._normalize(x, y, tau, s)
 
       mu = (y @ s) / (self.m - self.z)
-      # Weighted central path: the linear term is mu * diag(eps*I, eps*I, 1)
-      # * u, so the KKT diagonal shift on the x and y blocks is eps*mu.
-      # Cone-product targets (s*y = mu, tau*kappa = mu) keep the plain mu.
-      eps_mu = self._regularization_eps * mu
 
       # --- Take an IPM step ---
-      self._linear_solver.update(mu=eps_mu, s=s, y=y)
+      self._linear_solver.update(mu=mu, s=s, y=y)
 
       # --- Step 1: Precompute kinv_q = K^{-1} @ q ---
       # This is reused for both predictor and corrector parts of the step.
@@ -1038,11 +1011,10 @@ class QTQP:
     s_aff = s + alpha * d_s
 
     # Compute mu_aff directly without calling _normalize to avoid 4 extra
-    # allocations. Equivalent to: normalize onto the weighted-path ellipsoid
-    # (eps*||(x,y)||^2 + tau^2 = m-z+1) then compute (y @ s) / (m - z);
+    # allocations. Equivalent to: normalize onto the path sphere
+    # (||u||^2 = m-z+1) then compute (y @ s) / (m - z);
     # normalization scales y and s each by `scale`, so mu picks up scale^2.
-    eps = self._regularization_eps
-    quad_aff = (eps * (x_aff @ x_aff + y_aff @ y_aff) + tau_aff * tau_aff)
+    quad_aff = x_aff @ x_aff + y_aff @ y_aff + tau_aff * tau_aff
     scale_sq = (self.m - self.z + 1) / max(_EPS * _EPS, quad_aff)
     mu_aff = scale_sq * (y_aff @ s_aff) / (self.m - self.z)
 
@@ -1074,10 +1046,8 @@ class QTQP:
     linearized fallback (avoids squaring solver noise) when it's noisy or the
     quadratic residual check fails.
     """
-    # Prepare RHS for the linear system. The (x, y) blocks of the weighted
-    # path's linear term carry the eps weight; the cone rows below are
-    # barrier terms and stay unweighted.
-    r = (self._regularization_eps * (mu - mu_target)) * r_anchor
+    # Prepare RHS for the linear system.
+    r = (mu - mu_target) * r_anchor
     if mu_target != 0.0:
       r[self.n + self.z :] += mu_target / y[self.z :]
     r[self.n + self.z :] += s[self.z :]
@@ -1127,8 +1097,8 @@ class QTQP:
     a feasible point (tau=0 corresponds to a certificate of infeasibility or
     unboundedness, which is handled separately at termination).
 
-    The tau block of the weighted path carries unit weight, so t_a's mu term
-    is the plain mu; t_c = -mu_target comes from the cone-product equation
+    The mu term of t_a comes from the path's linear regularization term;
+    t_c = -mu_target comes from the cone-product equation
     tau * kappa = mu_target.
     """
     # Coefficients of the quadratic t_a * tau+^2 + t_b * tau+ + t_c = 0.
@@ -1186,9 +1156,8 @@ class QTQP:
     enters linearly rather than quadratically. A [0.1x, 10x] trust region
     prevents manifold drift from the first-order approximation.
 
-    The tau block of the weighted path carries unit weight, so the tau
-    coefficients use the plain mu and mu_target; the cone-product constant
-    -mu_target is likewise unmodified.
+    The tau coefficients use the plain mu and mu_target; the cone-product
+    constant -mu_target is likewise unmodified.
     """
     n = self.n
     q, kinv_q = self.q, self.kinv_q
@@ -1236,12 +1205,10 @@ class QTQP:
         eps * ||(x, y)||^2 + tau^2 = m - z + 1
     The right-hand side counts complementarity pairs: (m - z) from the
     inequality constraints plus 1 for the tau-kappa pair of the embedding.
-    At eps = 1 this is the sphere of the unweighted path.
 
     Operates in-place on the iterate arrays and returns them for convenience.
     """
-    eps = self._regularization_eps
-    quad = eps * (x @ x + y @ y) + tau * tau
+    quad = x @ x + y @ y + tau * tau
     scale = math.sqrt((self.m - self.z + 1) / max(_EPS, quad))
     x *= scale
     y *= scale
@@ -1308,7 +1275,7 @@ class QTQP:
     # evaluated in floating point) and the iterate norm (the backward-error
     # allowance: dres <= rtol * ||x||/tau accepts a point that is exactly
     # dual-feasible for P + dP with ||dP|| <= rtol, which is precisely the
-    # eps*mu*I perturbation the weighted path itself commits; likewise
+    # mu*I perturbation the regularized path itself commits; likewise
     # pres <= rtol * ||y||/tau on the primal side).
     prelrhs = max(
         _norm(ax, np.inf) * inv_tau,
@@ -1326,7 +1293,7 @@ class QTQP:
 
     # Gap tolerance relative scale: the cost magnitudes (measurement floor)
     # or the first-power iterate norm (the empirically calibrated allowance
-    # for the weighted path's O(eps*mu*||u||^2) objective bias; see the A'
+    # for the regularized path's O(mu*||u||^2) objective bias; see the
     # criteria validation on NETLIB + Maros-Meszaros).
     gaprelrhs = max(
         min(abs(pcost), abs(dcost)),

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -546,10 +546,15 @@ class QTQP:
       atol (float): Absolute tolerance for convergence criteria.
       rtol (float): Relative tolerance for convergence criteria, scaled by
         problem data norms.
-      atol_infeas (float): Absolute tolerance for detecting primal or dual
-        infeasibility.
-      rtol_infeas (float): Relative tolerance for detecting primal or dual
-        infeasibility.
+      atol_infeas (float): Certificate-quality tolerance for infeasibility
+        and unboundedness detection: a candidate ray u is accepted when its
+        relative backward error (constraint violations divided by
+        ||operator|| * ||u||, the smallest relative data perturbation under
+        which the ray is exact) is below atol_infeas.
+      rtol_infeas (float): Slope-robustness margin for certificates: the
+        ray's objective slope (c'x or b'y) must be negative by at least
+        rtol_infeas times the data norm times the ray norm, so the sign
+        survives an rtol_infeas-sized relative perturbation of the data.
       max_iter (int): Maximum number of iterations before stopping.
       step_size_scale (float): A factor in (0, 1) to scale the step size,
         ensuring iterates remain strictly interior.
@@ -664,6 +669,14 @@ class QTQP:
     # so we use self.b and self.c here (not the equilibrated local b, c).
     self._norm_b = _norm(self.b, np.inf)
     self._norm_c = _norm(self.c, np.inf)
+
+    # Data operator norms (original scale) for the certificate-quality tests:
+    # ||A||_inf (rows, acts on x), ||A||_1 (columns, = ||A'||_inf, acts on y),
+    # and ||P||_inf.
+    abs_a = abs(self.a)
+    self._norm_a_inf = float(abs_a.sum(axis=1).max()) if self.a.nnz else 0.0
+    self._norm_a_one = float(abs_a.sum(axis=0).max()) if self.a.nnz else 0.0
+    self._norm_p_inf = float(abs(self.p).sum(axis=1).max()) if self.p.nnz else 0.0
 
     self._linear_solver = direct.DirectKktSolver(
         a=a,
@@ -1286,22 +1299,23 @@ class QTQP:
     dres = _norm(px_plus_aty * inv_tau + self.c, np.inf)
     gap = abs((ctx + bty + xpx * inv_tau) * inv_tau)
 
-    # Infeasibility certificates (Farkas-type, from the embedding structure).
-    # If the primal is unbounded (dual infeasible) this produces a ray x with
-    # c'x < 0 that satisfies the homogeneous primal conditions Ax + s ≈ 0 and Px
-    # ≈ 0.  dinfeas measures how well x/|c'x| certifies dual infeasibility.
+    # Certificate-quality measures (Farkas-type, from the embedding
+    # structure). A candidate ray is judged by the smallest relative data
+    # perturbation that would make it an exact certificate (Rigal-Gaches
+    # normwise backward error): e.g. dinfeas_a = ||Ax + s|| / (||A|| ||x||)
+    # is the relative perturbation of A under which x is an exact unbounded
+    # ray. Normalizing by the objective slope |c'x| instead (the common
+    # convention) hands out slack proportional to a quantity degenerate
+    # problems can inflate — near-null directions with enormous c-slope pass
+    # such tests while violating the constraints badly (e.g. NETLIB dfl001).
     norm_aty = _norm(aty, np.inf)
     norm_px = _norm(px, np.inf)
-    dinfeas_a = _norm(ax_plus_s, np.inf) / (abs(ctx) + _EPS)
-    dinfeas_p = norm_px / (abs(ctx) + _EPS)
-    dinfeas = max(dinfeas_a, dinfeas_p)
-    # If the primal is infeasible (dual unbounded) this produces a ray y
-    # with b'y < 0 that satisfies the homogeneous dual condition A'y ≈ 0.
-    # pinfeas measures how well y/|b'y| certifies primal infeasibility.
-    pinfeas = norm_aty / (abs(bty) + _EPS)
-
     norm_x = _norm(x, np.inf)
     norm_y = _norm(y, np.inf)
+    dinfeas_a = _norm(ax_plus_s, np.inf) / (self._norm_a_inf * norm_x + _EPS)
+    dinfeas_p = norm_px / (self._norm_p_inf * norm_x + _EPS)
+    dinfeas = max(dinfeas_a, dinfeas_p)
+    pinfeas = norm_aty / (self._norm_a_one * norm_y + _EPS)
 
     # Residual tolerance relative scales. Each is the max of two families:
     # the summand norms (the floor below which the residual cannot even be
@@ -1340,14 +1354,23 @@ class QTQP:
         and dres < self.atol + self.rtol * drelrhs
     ):
       status = SolutionStatus.SOLVED
-    # Unbounded: x is a dual infeasibility certificate (primal unbounded ray).
-    elif ctx < -_EPS and (
-        dinfeas < self.atol_infeas + self.rtol_infeas * norm_x / abs(ctx)
+    # Unbounded: x is a dual infeasibility certificate (primal unbounded
+    # ray) when its relative backward error is within atol_infeas AND the
+    # objective slope is robustly negative relative to the ray's own scale
+    # (so the sign survives an rtol_infeas-sized perturbation of c). Note
+    # the quality measure needs no zero-ray guard: as ||x|| -> 0 its
+    # denominator vanishes while the numerator retains the O(1) slack s,
+    # so dinfeas diverges and nothing is certified.
+    elif (
+        ctx < -(self.rtol_infeas * self._norm_c * norm_x + _EPS)
+        and dinfeas < self.atol_infeas
     ):
       status = SolutionStatus.UNBOUNDED
-    # Infeasible: y is a primal infeasibility certificate (dual unbounded ray).
-    elif bty < -_EPS and (
-        pinfeas < self.atol_infeas + self.rtol_infeas * norm_y / abs(bty)
+    # Infeasible: y is a primal infeasibility certificate (dual unbounded
+    # ray), judged the same way via ||A'y|| / (||A||_1 ||y||) and b'y.
+    elif (
+        bty < -(self.rtol_infeas * self._norm_b * norm_y + _EPS)
+        and pinfeas < self.atol_infeas
     ):
       status = SolutionStatus.INFEASIBLE
     else:

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -291,18 +291,26 @@ def _assert_solution(solution, a, b, c, p, z, atol=1e-7, rtol=1e-8):
   pres = np.linalg.norm(a @ x + s - b, np.inf)
   dres = np.linalg.norm(p @ x + a.T @ y + c, np.inf)
   gap = np.abs(c @ x + b @ y + x @ p @ x)
+  # Relative scales mirror the solver's termination criteria: the summand
+  # norms (evaluation floor) plus the iterate norms (the backward-error
+  # allowance of the weighted regularized path).
+  norm_x = np.linalg.norm(x, np.inf)
+  norm_y = np.linalg.norm(y, np.inf)
   prelrhs = max(
       np.linalg.norm(a @ x, np.inf),
       np.linalg.norm(s, np.inf),
       np.linalg.norm(b, np.inf),
+      norm_y,
   )
   drelrhs = max(
       np.linalg.norm(p @ x, np.inf),
       np.linalg.norm(a.T @ y, np.inf),
       np.linalg.norm(c, np.inf),
+      norm_x,
   )
+  gaprelrhs = max(min(abs(pcost), abs(dcost)), norm_x + norm_y)
   assert solution.status == qtqp.SolutionStatus.SOLVED
-  np.testing.assert_array_less(gap, atol + rtol * min(abs(pcost), abs(dcost)))
+  np.testing.assert_array_less(gap, atol + rtol * gaprelrhs)
   np.testing.assert_array_less(pres, atol + rtol * prelrhs)
   np.testing.assert_array_less(dres, atol + rtol * drelrhs)
   np.testing.assert_array_less(-1e-9, np.min(y[z:], initial=0.0))
@@ -1783,12 +1791,14 @@ def test_equilibrate_unequilibrate_roundtrip(strategy):
 # _normalize invariant
 # =============================================================================
 
-def test_normalize_invariant():
-  """Test that _normalize enforces ||(x,y,tau)||^2 == m - z + 1."""
+@pytest.mark.parametrize('eps', [1e-4, 1e-2, 1.0])
+def test_normalize_invariant(eps):
+  """_normalize enforces eps * ||(x,y)||^2 + tau^2 == m - z + 1."""
   rng = np.random.default_rng(42)
   m, n, z = 20, 10, 3
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
   solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
+  solver._regularization_eps = eps  # pylint: disable=protected-access
 
   x = rng.normal(size=n)
   y = rng.normal(size=m)
@@ -1797,8 +1807,8 @@ def test_normalize_invariant():
 
   x_n, y_n, tau_n, _ = solver._normalize(x, y, tau, s)  # pylint: disable=protected-access
 
-  xyt_norm_sq = x_n @ x_n + y_n @ y_n + tau_n ** 2
-  np.testing.assert_allclose(xyt_norm_sq, m - z + 1, atol=1e-12, rtol=1e-12)
+  quad = eps * (x_n @ x_n + y_n @ y_n) + tau_n ** 2
+  np.testing.assert_allclose(quad, m - z + 1, atol=1e-12, rtol=1e-12)
 
 
 # =============================================================================
@@ -2759,85 +2769,68 @@ def test_gmres_rollback_on_stalled_refinement():
 
 
 # =============================================================================
-# central_path_exponent: generalized central path
+# regularization_eps: eps-weighted central path
 # =============================================================================
 
-@pytest.mark.parametrize('central_path_exponent', [0.5, 1.0, 1.5, 2.0])
+@pytest.mark.parametrize('regularization_eps', [1e-4, 1e-2, 0.1, 1.0])
 @pytest.mark.parametrize('seed', 6000 + np.arange(3))
-def test_central_path_exponent_solve(central_path_exponent, seed):
-  """All positive exponents must converge to the same optimal solution."""
+def test_regularization_eps_solve(regularization_eps, seed):
+  """All eps in (0, 1] must converge to the same optimal solution."""
   rng = np.random.default_rng(seed)
   m, n, z = 60, 40, 8
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      central_path_exponent=central_path_exponent, verbose=False,
+      regularization_eps=regularization_eps, verbose=False,
   )
   _assert_solution(solution, a, b, c, p, z)
 
 
-def test_central_path_exponent_default_unchanged():
-  """central_path_exponent=1.0 must give the same solution as the default.
-
-  The two paths drift by ~1 ULP per iteration because mu**1.0 is not
-  bit-identical to mu in IEEE math; this test just guards against any
-  larger semantic divergence on the default path.
-  """
-  rng = np.random.default_rng(6100)
-  m, n, z = 50, 30, 5
-  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
-  sol_a = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
-  sol_b = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      central_path_exponent=1.0, verbose=False
-  )
-  np.testing.assert_allclose(sol_a.x, sol_b.x, atol=1e-6, rtol=1e-6)
-  np.testing.assert_allclose(sol_a.y, sol_b.y, atol=1e-6, rtol=1e-6)
-  np.testing.assert_allclose(sol_a.s, sol_b.s, atol=1e-6, rtol=1e-6)
-
-
-def test_central_path_exponent_solutions_agree():
-  """Different exponents converge to the same QP optimum (within tol)."""
+def test_regularization_eps_solutions_agree():
+  """Different eps values converge to the same QP optimum (within tol)."""
   rng = np.random.default_rng(6200)
   m, n, z = 50, 30, 5
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
   objs = []
-  for cpe in (0.5, 1.0, 1.5, 2.0):
+  for eps in (1e-4, 1e-2, 0.1, 1.0):
     sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-        central_path_exponent=cpe, verbose=False
+        regularization_eps=eps, verbose=False
     )
     _assert_solution(sol, a, b, c, p, z)
     objs.append(c @ sol.x + 0.5 * sol.x @ p @ sol.x)
-  ref = objs[1]  # the p=1 case is the reference
+  ref = objs[1]  # the default eps = 1e-2 case is the reference
   for obj in objs:
     np.testing.assert_allclose(obj, ref, atol=1e-5, rtol=1e-5)
 
 
-@pytest.mark.parametrize('bad_value', [0.0, -1.0, -0.5, float('nan'), float('inf')])
-def test_central_path_exponent_rejects_invalid(bad_value):
-  """Non-positive or non-finite central_path_exponent must raise."""
+@pytest.mark.parametrize(
+    'bad_value', [0.0, -1.0, 1.5, float('nan'), float('inf')]
+)
+def test_regularization_eps_rejects_invalid(bad_value):
+  """eps outside (0, 1] or non-finite must raise."""
   rng = np.random.default_rng(6300)
   a, b, c, p = _gen_feasible(20, 12, 3, random_state=rng)
-  with pytest.raises(ValueError, match='central_path_exponent'):
+  with pytest.raises(ValueError, match='regularization_eps'):
     qtqp.QTQP(a=a, b=b, c=c, z=3, p=p).solve(
-        central_path_exponent=bad_value, verbose=False
+        regularization_eps=bad_value, verbose=False
     )
 
 
-def test_central_path_exponent_infeasible():
-  """Non-default exponent must still detect primal infeasibility."""
+def test_regularization_eps_infeasible():
+  """The weighted path must still detect primal infeasibility."""
   rng = np.random.default_rng(6400)
   a, b, c, p = _gen_infeasible(40, 25, 5, random_state=rng)
   solution = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
-      central_path_exponent=1.5, verbose=False
+      regularization_eps=1e-2, verbose=False
   )
   _assert_infeasible(solution, a, b, 5)
 
 
-def test_central_path_exponent_unbounded():
-  """Non-default exponent must still detect primal unboundedness."""
+def test_regularization_eps_unbounded():
+  """The weighted path must still detect primal unboundedness."""
   rng = np.random.default_rng(6500)
   a, b, c, p = _gen_unbounded(40, 25, 5, random_state=rng)
   solution = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
-      central_path_exponent=0.7, verbose=False
+      regularization_eps=1e-2, verbose=False
   )
   _assert_unbounded(solution, a, c, p, 5)
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -2849,14 +2849,15 @@ def test_certificate_rejects_large_slope_pseudo_ray():
 # arc_search: second-order predictor arc with exact tau-lift
 # =============================================================================
 
+@pytest.mark.parametrize('criterion', [True, 'merit', 'potential'])
 @pytest.mark.parametrize('seed', 8000 + np.arange(3))
-def test_arc_search_solve(seed):
-  """The arc-search predictor must converge to a valid optimal solution."""
+def test_arc_search_solve(criterion, seed):
+  """Every arc selection criterion must converge to a valid solution."""
   rng = np.random.default_rng(seed)
   m, n, z = 60, 40, 8
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      arc_search=True, verbose=False,
+      arc_search=criterion, verbose=False,
   )
   _assert_solution(solution, a, b, c, p, z)
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -2846,6 +2846,64 @@ def test_certificate_rejects_large_slope_pseudo_ray():
 
 
 # =============================================================================
+# max_centrality_correctors: Gondzio multiple centrality correctors
+# =============================================================================
+
+@pytest.mark.parametrize('mcc', [0, 1, 2, 3])
+@pytest.mark.parametrize('seed', 7000 + np.arange(3))
+def test_centrality_correctors_solve(mcc, seed):
+  """All corrector counts must converge to a valid optimal solution."""
+  rng = np.random.default_rng(seed)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      max_centrality_correctors=mcc, verbose=False,
+  )
+  _assert_solution(solution, a, b, c, p, z)
+
+
+def test_centrality_correctors_solutions_agree():
+  """Different corrector counts converge to the same QP optimum."""
+  rng = np.random.default_rng(7200)
+  m, n, z = 50, 30, 5
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  objs = []
+  for mcc in (0, 1, 2):
+    sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+        max_centrality_correctors=mcc, verbose=False
+    )
+    _assert_solution(sol, a, b, c, p, z)
+    objs.append(c @ sol.x + 0.5 * sol.x @ p @ sol.x)
+  for obj in objs:
+    np.testing.assert_allclose(obj, objs[1], atol=1e-5, rtol=1e-5)
+
+
+def test_centrality_correctors_rejects_negative():
+  rng = np.random.default_rng(7300)
+  a, b, c, p = _gen_feasible(20, 12, 3, random_state=rng)
+  with pytest.raises(ValueError, match='max_centrality_correctors'):
+    qtqp.QTQP(a=a, b=b, c=c, z=3, p=p).solve(
+        max_centrality_correctors=-1, verbose=False
+    )
+
+
+def test_centrality_correctors_infeasible_unbounded():
+  """Correctors must not disturb certificate detection."""
+  rng = np.random.default_rng(7400)
+  a, b, c, p = _gen_infeasible(40, 25, 5, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
+      max_centrality_correctors=2, verbose=False
+  )
+  _assert_infeasible(sol, a, b, 5)
+  rng = np.random.default_rng(7500)
+  a, b, c, p = _gen_unbounded(40, 25, 5, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
+      max_centrality_correctors=2, verbose=False
+  )
+  _assert_unbounded(sol, a, c, p, 5)
+
+
+# =============================================================================
 # regularization_eps: eps-weighted central path
 # =============================================================================
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -323,14 +323,19 @@ def _assert_infeasible(solution, a, b, z, atol=1e-8, rtol=1e-9):
   y = solution.y
   s = solution.s
 
-  pinfeas = np.linalg.norm(a.T @ y, np.inf)
+  # Certificate quality is judged as relative backward error, mirroring the
+  # solver's detection contract: violations over ||A||_1 * ||y||.
+  norm_a_one = float(abs(a).sum(axis=0).max())
+  pinfeas = np.linalg.norm(a.T @ y, np.inf) / (
+      norm_a_one * np.linalg.norm(y, np.inf) + 1e-300
+  )
 
   assert solution.status == qtqp.SolutionStatus.INFEASIBLE
   np.testing.assert_array_equal(np.isnan(x), True)
   np.testing.assert_array_equal(np.isnan(s), True)
   np.testing.assert_allclose(b @ y, -1.0, atol=atol, rtol=rtol)
   np.testing.assert_array_less(-1e-9, np.min(y[z:], initial=0.0))
-  np.testing.assert_array_less(pinfeas, atol + rtol * np.linalg.norm(y, np.inf))
+  np.testing.assert_array_less(pinfeas, atol)
 
 
 def _assert_unbounded(solution, a, c, p, z, atol=1e-8, rtol=1e-9):
@@ -339,19 +344,21 @@ def _assert_unbounded(solution, a, c, p, z, atol=1e-8, rtol=1e-9):
   y = solution.y
   s = solution.s
 
-  dinfeas_a = np.linalg.norm(a @ x + s, np.inf)
-  dinfeas_p = np.linalg.norm(p @ x, np.inf)
+  # Certificate quality is judged as relative backward error, mirroring the
+  # solver's detection contract: violations over ||A||_inf * ||x|| (and
+  # ||P||_inf * ||x|| for the quadratic part).
+  norm_x = np.linalg.norm(x, np.inf)
+  norm_a_inf = float(abs(a).sum(axis=1).max())
+  norm_p_inf = float(abs(p).sum(axis=1).max()) if p.nnz else 0.0
+  dinfeas_a = np.linalg.norm(a @ x + s, np.inf) / (norm_a_inf * norm_x + 1e-300)
+  dinfeas_p = np.linalg.norm(p @ x, np.inf) / (norm_p_inf * norm_x + 1e-300)
 
   assert solution.status == qtqp.SolutionStatus.UNBOUNDED
   np.testing.assert_array_equal(np.isnan(y), True)
   np.testing.assert_allclose(c @ x, -1.0, atol=atol, rtol=rtol)
   np.testing.assert_array_less(-1e-9, np.min(s[z:], initial=0.0))
-  np.testing.assert_array_less(
-      dinfeas_a, atol + rtol * np.linalg.norm(x, np.inf)
-  )
-  np.testing.assert_array_less(
-      dinfeas_p, atol + rtol * np.linalg.norm(x, np.inf)
-  )
+  np.testing.assert_array_less(dinfeas_a, atol)
+  np.testing.assert_array_less(dinfeas_p, atol)
 
 
 @pytest.mark.parametrize('equilibration', [qtqp.EquilibrationStrategy.RUIZ, qtqp.EquilibrationStrategy.NONE])
@@ -2766,6 +2773,76 @@ def test_gmres_rollback_on_stalled_refinement():
   # Either we converged immediately, or the returned residual is no worse
   # than what one direct factor-solve from warm_start would give.
   assert stats['final_residual_norm'] < 1e-6
+
+
+# =============================================================================
+# Certificate quality: pseudo-rays must not be certified
+# =============================================================================
+
+def test_certificate_rejects_large_slope_pseudo_ray():
+  """A direction with enormous |c'x| but non-trivial constraint violations
+  must not be accepted as an unboundedness certificate.
+
+  This is the mechanism behind false certificates on degenerate LPs (e.g.
+  NETLIB dfl001): tests that normalize violations by |c'x| hand out slack
+  proportional to the objective slope, which a near-null direction of A with
+  a large c-component can inflate arbitrarily. The certificate test must
+  judge violations against ||A|| ||x|| instead.
+  """
+  rng = np.random.default_rng(7)
+  m, n, z = 12, 8, 3
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+
+  # Direction v: right singular vector of A with the smallest singular value
+  # (near-null for A but not null), and a cost vector with a huge component
+  # along v so that c'v is enormously negative.
+  u_svd, s_svd, vt_svd = np.linalg.svd(a.toarray())
+  mid = len(s_svd) // 2
+  v = vt_svd[mid]
+  sigma_v = s_svd[mid]  # clearly nonzero: v is NOT a feasible ray
+  norm_a = np.max(np.abs(a.toarray()).sum(axis=1))
+  big = 1e12
+  c_adv = -big * v
+
+  solver = qtqp.QTQP(a=a, b=b, c=c_adv, z=z, p=p)
+  # Prime the state that solve() would normally set before termination checks.
+  solver.atol, solver.rtol = 1e-7, 1e-8
+  solver.atol_infeas, solver.rtol_infeas = 1e-8, 1e-9
+  solver.equilibration_strategy = qtqp.EquilibrationStrategy.NONE
+  solver._norm_b = np.linalg.norm(solver.b, np.inf)
+  solver._norm_c = np.linalg.norm(solver.c, np.inf)
+  abs_a = abs(solver.a)
+  solver._norm_a_inf = float(abs_a.sum(axis=1).max())
+  solver._norm_a_one = float(abs_a.sum(axis=0).max())
+  solver._norm_p_inf = (
+      float(abs(solver.p).sum(axis=1).max()) if solver.p.nnz else 0.0
+  )
+  solver.it = 0
+  solver.start_time = 0.0
+
+  x = v.copy()
+  y = np.zeros(m)
+  y[z:] = 1e-6
+  s = np.zeros(m)
+  s[z:] = 1e-6
+  tau = 1e-8  # deep in the certificate regime
+
+  ctx = c_adv @ x
+  assert ctx < 0
+
+  # The legacy |c'x|-normalized test would have accepted this pseudo-ray:
+  legacy_dinfeas = np.linalg.norm(a @ x + s, np.inf) / abs(ctx)
+  assert legacy_dinfeas < 1e-8 + 1e-9 * np.linalg.norm(x, np.inf) / abs(ctx)
+
+  # The data-scaled test must reject it: the violations are a sigma_v /
+  # ||A|| fraction of ||A|| ||x||, far above any certificate tolerance.
+  assert sigma_v / norm_a > 1e-3
+  status = solver._check_termination(  # pylint: disable=protected-access
+      x, y, tau, s, alpha=0.5, mu=1.0, sigma=0.5, stats_i={},
+      collect_stats=False,
+  )
+  assert status != qtqp.SolutionStatus.UNBOUNDED
+  assert status != qtqp.SolutionStatus.INFEASIBLE
 
 
 # =============================================================================

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -2846,6 +2846,52 @@ def test_certificate_rejects_large_slope_pseudo_ray():
 
 
 # =============================================================================
+# arc_search: second-order predictor arc with exact tau-lift
+# =============================================================================
+
+@pytest.mark.parametrize('seed', 8000 + np.arange(3))
+def test_arc_search_solve(seed):
+  """The arc-search predictor must converge to a valid optimal solution."""
+  rng = np.random.default_rng(seed)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      arc_search=True, verbose=False,
+  )
+  _assert_solution(solution, a, b, c, p, z)
+
+
+def test_arc_search_agrees_with_default():
+  """Arc-search and point predictors reach the same optimum."""
+  rng = np.random.default_rng(8100)
+  m, n, z = 50, 30, 5
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  sol_a = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  sol_b = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      arc_search=True, verbose=False
+  )
+  obj_a = c @ sol_a.x + 0.5 * sol_a.x @ p @ sol_a.x
+  obj_b = c @ sol_b.x + 0.5 * sol_b.x @ p @ sol_b.x
+  np.testing.assert_allclose(obj_a, obj_b, atol=1e-5, rtol=1e-5)
+
+
+def test_arc_search_infeasible_unbounded():
+  """The arc predictor must not disturb certificate detection."""
+  rng = np.random.default_rng(8200)
+  a, b, c, p = _gen_infeasible(40, 25, 5, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
+      arc_search=True, verbose=False
+  )
+  _assert_infeasible(sol, a, b, 5)
+  rng = np.random.default_rng(8300)
+  a, b, c, p = _gen_unbounded(40, 25, 5, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
+      arc_search=True, verbose=False
+  )
+  _assert_unbounded(sol, a, c, p, 5)
+
+
+# =============================================================================
 # max_centrality_correctors: Gondzio multiple centrality correctors
 # =============================================================================
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1791,14 +1791,12 @@ def test_equilibrate_unequilibrate_roundtrip(strategy):
 # _normalize invariant
 # =============================================================================
 
-@pytest.mark.parametrize('eps', [1e-4, 1e-2, 1.0])
-def test_normalize_invariant(eps):
-  """_normalize enforces eps * ||(x,y)||^2 + tau^2 == m - z + 1."""
+def test_normalize_invariant():
+  """_normalize enforces ||(x,y)||^2 + tau^2 == m - z + 1."""
   rng = np.random.default_rng(42)
   m, n, z = 20, 10, 3
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
   solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
-  solver._regularization_eps = eps  # pylint: disable=protected-access
 
   x = rng.normal(size=n)
   y = rng.normal(size=m)
@@ -1807,7 +1805,7 @@ def test_normalize_invariant(eps):
 
   x_n, y_n, tau_n, _ = solver._normalize(x, y, tau, s)  # pylint: disable=protected-access
 
-  quad = eps * (x_n @ x_n + y_n @ y_n) + tau_n ** 2
+  quad = x_n @ x_n + y_n @ y_n + tau_n ** 2
   np.testing.assert_allclose(quad, m - z + 1, atol=1e-12, rtol=1e-12)
 
 
@@ -2766,73 +2764,6 @@ def test_gmres_rollback_on_stalled_refinement():
   # Either we converged immediately, or the returned residual is no worse
   # than what one direct factor-solve from warm_start would give.
   assert stats['final_residual_norm'] < 1e-6
-
-
-# =============================================================================
-# regularization_eps: eps-weighted central path
-# =============================================================================
-
-@pytest.mark.parametrize('regularization_eps', [1e-4, 1e-2, 0.1, 1.0])
-@pytest.mark.parametrize('seed', 6000 + np.arange(3))
-def test_regularization_eps_solve(regularization_eps, seed):
-  """All eps in (0, 1] must converge to the same optimal solution."""
-  rng = np.random.default_rng(seed)
-  m, n, z = 60, 40, 8
-  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      regularization_eps=regularization_eps, verbose=False,
-  )
-  _assert_solution(solution, a, b, c, p, z)
-
-
-def test_regularization_eps_solutions_agree():
-  """Different eps values converge to the same QP optimum (within tol)."""
-  rng = np.random.default_rng(6200)
-  m, n, z = 50, 30, 5
-  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
-  objs = []
-  for eps in (1e-4, 1e-2, 0.1, 1.0):
-    sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-        regularization_eps=eps, verbose=False
-    )
-    _assert_solution(sol, a, b, c, p, z)
-    objs.append(c @ sol.x + 0.5 * sol.x @ p @ sol.x)
-  ref = objs[1]  # the default eps = 1e-2 case is the reference
-  for obj in objs:
-    np.testing.assert_allclose(obj, ref, atol=1e-5, rtol=1e-5)
-
-
-@pytest.mark.parametrize(
-    'bad_value', [0.0, -1.0, 1.5, float('nan'), float('inf')]
-)
-def test_regularization_eps_rejects_invalid(bad_value):
-  """eps outside (0, 1] or non-finite must raise."""
-  rng = np.random.default_rng(6300)
-  a, b, c, p = _gen_feasible(20, 12, 3, random_state=rng)
-  with pytest.raises(ValueError, match='regularization_eps'):
-    qtqp.QTQP(a=a, b=b, c=c, z=3, p=p).solve(
-        regularization_eps=bad_value, verbose=False
-    )
-
-
-def test_regularization_eps_infeasible():
-  """The weighted path must still detect primal infeasibility."""
-  rng = np.random.default_rng(6400)
-  a, b, c, p = _gen_infeasible(40, 25, 5, random_state=rng)
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
-      regularization_eps=1e-2, verbose=False
-  )
-  _assert_infeasible(solution, a, b, 5)
-
-
-def test_regularization_eps_unbounded():
-  """The weighted path must still detect primal unboundedness."""
-  rng = np.random.default_rng(6500)
-  a, b, c, p = _gen_unbounded(40, 25, 5, random_state=rng)
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
-      regularization_eps=1e-2, verbose=False
-  )
-  _assert_unbounded(solution, a, c, p, 5)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds an opt-in second-order predictor arc search (`arc_search`, **default False**) built on an operation structurally unique to this solver: **exact τ-lift of arbitrary trial points**.

One extra back-solve refines the affine point with Mehrotra's cross term, defining the arc `u(α) = u + α·d¹ + α²·d²`. Every arc quantity — `yᵀs`, `‖x‖²`, `‖y‖²`, `cᵀx + bᵀy`, `xᵀPx` — is precomputed as a polynomial in α (three SpMVs with P, none for LPs), and each candidate's τ coordinate is re-solved *exactly* from the embedding's scalar τ-row given `(x(α), y(α))`: a few dot products, no back-solve. Every trial point therefore satisfies the τ/perspective nonlinearity exactly, and the continuous search costs O(1) per candidate. Solvers that linearize the τκ coupling (i.e., every standard homogeneous-embedding IPM, including Clarabel) have no analogous move: their τ is a linearized step coordinate, each arc point carries first-order τκ error, and re-imposing exact τ-consistency would cost a full solve per trial.

**The optimal damping is solved for explicitly.** Along the arc the normalized duality measure is a ratio of two exact quartics (`yᵀs(α)` over the ellipsoid quadratic with the arc's polynomial τ), so its stationary points are the roots of `N′Q − NQ′` — a degree-7 polynomial solved exactly via the companion matrix. Those stationary candidates are augmented with a coarse damping grid (evaluation is O(1) after the precompute, so the redundancy is free and insures against the small mismatch between the polynomial τ used to *locate* candidates and the exact lift used to *score* them). The corrector is then anchored at the best-scoring arc point, with σ and the cross term taken from the arc — the damped anchoring the naive full-step second-order predictor lacks. (Minimizing the raw quartic alone is a closed-form cubic but degenerates to the undamped full step whenever `yᵀs(α)` is monotone — measured to lose exactly the instances the damping wins.)

## Why opt-in

The benchmark verdict is a portfolio, not a dominance:

- The arc **solves two chronically hard Maros–Mészáros instances that no other configuration in this line of work has ever solved** — QFFFFF80 (54 iterations) and QSIERRA (46) — both max-iter failures under stock, Gondzio, adaptive-step, and every ε/criteria variant tested.
- It gives back borderline instances the default path handles (d6cube, dfl001, israel on NETLIB; YAO on MM), shows no broad iteration win on commonly-solved instances (median +1), and the extra predictor solve raises wall time ~80%.

So the default path keeps the Gondzio correctors (#81), and the arc ships as a mode for hard instances and as the working demonstration of the exact-lift machinery.

**Selection criteria: three shipped, none dominant, and the scoreboard is the finding.** `arc_search` accepts `True`/`"mu"` (greedy normalized duality measure — the shipped default criterion), `"merit"` (max relative KKT residual, closed-form along the arc since the residual norms are exact quartics), and `"potential"` (Tanabe–Todd–Ye potential ρ·log(yᵀs) − Σlog(sᵢyᵢ) scored on finalists, with *target-matched anchoring*: the corrector's surrogate is taken at the α where the arc's complementarity equals σμ — the point the corrector is actually solving for). On the seven chronically-degenerate benchmark instances the five variants tested each solve a *different* subset:

| criterion / candidates | QFFFFF80 | QSIERRA | d6cube | dfl001 | israel | YAO |
|---|---|---|---|---|---|---|
| μ, grid | 54 | 46 | — | — | — | — |
| μ, stationary | 82 | — | 72 | 67 | — | — |
| μ, union (default) | 55 | 56 | — | — | — | — |
| merit, union | 87 | — | — | — | — | — |
| potential, target-matched | 79 | — | — | — | — | 90 |

Each refinement did what its theory promised *pointwise* (the potential criterion recovers YAO, the decentering victim, and accelerates QISRAEL 95→53), yet global outcomes on degenerate instances permute chaotically — the same trajectory-sensitivity that makes these instances flip under backend threading nondeterminism. The conclusion: on this class, pointwise model accuracy does not control trajectory outcomes; cheap diversity does. The O(1)-per-candidate machinery makes criterion diversity nearly free, and the solve-level portfolio below is the robust way to consume it.

**Stall-triggered hybrid: investigated and refuted.** The obvious composition — run the default predictor and switch to the arc when µ progress stalls — was implemented and measured. It cannot work for the chronic class: engagement-iteration sweeps show QFFFFF80 tolerates arc engagement no later than iteration ~6 and QSIERRA requires it from iteration 0 (engagement at iteration 3 already fails). These instances commit to a bad trajectory within the first few steps; the arc prevents the commitment but cannot undo it, and no online trigger can fire before it has observations. A mid-course switch also costs collateral (YAO triggers and is lost). The zero-regression composition is the sequential portfolio one level up, recommended usage: **if a solve returns `HIT_MAX_ITER`, retry with `arc_search=True`** — no effect on any solved instance by construction, and arc-from-the-start is precisely what rescues the chronic class.

## Validation

- MM (93 supported): **91 solved vs 90 base — the flag's reason to exist**: QFFFFF80 (55 iterations) and QSIERRA (56) are chronic max-iter failures under stock, Gondzio, adaptive-step, and every path/criteria variant in this line of work; the arc solves both robustly across candidate-rule variants. YAO (borderline) is lost.
- NETLIB feasible (91): 88 solved vs 90 base in the same run; the losses (dfl001, israel, plus d6cube's usual wobble) are all from the borderline set that the default Gondzio path handles and that flips with any trajectory perturbation.
- Cost: ~+80% wall time (the extra predictor back-solve dominates), no broad iteration win on commonly-solved instances (median +1).
- Objective agreement with the base arm within the established acceptance on all commonly-solved instances (worst drift is the known cycle-class variance).
- The arc degrades gracefully: candidates with non-positive complementarity, invalid τ-lift, or a degraded τ back-solve are skipped, falling back to the stock point predictor for that iteration.
- Full test suite green (flag off by default; dedicated tests exercise it on).

Stacked on #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
