### PR TITLE
Add certified warm starts via the distance-to-path certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ solve(
         qtqp.RefinementStrategy.RICHARDSON
     ),
     gmres_restart: int = 10,
-    central_path_exponent: float = 1.0,
     fused_corrector_division: bool = False,
 ) -> qtqp.Solution
 ```
@@ -202,8 +201,6 @@ Key parameters:
     solves. Defaults to `qtqp.RefinementStrategy.RICHARDSON`.
 -   `gmres_restart`: Restart length for `qtqp.RefinementStrategy.GMRES`.
     Ignored by Richardson refinement.
--   `central_path_exponent`: Positive exponent for the generalized central-path
-    residual equation. The default `1.0` is the standard central path.
 -   `fused_corrector_division`: If True, computes the Mehrotra corrector slack
     update with one fused division. The default False preserves legacy
     arithmetic.
@@ -246,9 +243,12 @@ Choose one with the `refinement_strategy` argument:
 
 #### Advanced numerical options
 
--   `central_path_exponent`: Uses `mu**central_path_exponent` in the linear
-    residual part of the central-path equations while keeping cone-product
-    targets at `mu`. Values must be positive and finite.
+-   Termination scales include the iterate norms `||x||/tau`, `||y||/tau`
+    (and their sum for the duality gap), so acceptance is a backward-error
+    criterion consistent with the `mu`-scale perturbation the regularized
+    path itself commits: residuals are judged against the larger of the
+    floating-point measurement floor of their summands and the perturbation
+    allowance of the path.
 -   `fused_corrector_division`: Fuses the corrector slack numerator before
     dividing by `y[z:]`. This is useful when small `y` components make the
     legacy three-division form vulnerable to cancellation.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ solve(
     ),
     gmres_restart: int = 10,
     fused_corrector_division: bool = False,
+    max_centrality_correctors: int = 1,
 ) -> qtqp.Solution
 ```
 
@@ -252,6 +253,9 @@ Choose one with the `refinement_strategy` argument:
 -   `fused_corrector_division`: Fuses the corrector slack numerator before
     dividing by `y[z:]`. This is useful when small `y` components make the
     legacy three-division form vulnerable to cancellation.
+-   `max_centrality_correctors`: Maximum Gondzio-style centrality correctors
+    per iteration, each one extra back-solve on the existing factorization,
+    accepted only when the step size improves. Default `1`; `0` disables.
 
 This method will return a `qtqp.Solution` object, with fields:
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ Key parameters:
 -   `collect_stats`: If True, populate `Solution.stats` with per-iteration
     diagnostics (sy, s/y statistics, complementarity, etc.). Defaults to False
     for faster throughput.
+    Every iteration also logs `delta_path`, a rigorous a posteriori upper
+    bound on the distance from the iterate to the exact central-path point
+    at the current `mu` (from the strong monotonicity of the regularized path
+    map); it is informative when small, conservative for aggressively
+    centered iterates, and saturates at the floating-point floor in the
+    final iterations.
 -   `init_strategy`: Choose the initial interior-point iterate. Defaults to
     `qtqp.InitStrategy.TRIVIAL`.
 -   `init_mu_scale`: Positive scale used only by `qtqp.InitStrategy.ORTHANT` to

--- a/README.md
+++ b/README.md
@@ -199,7 +199,16 @@ Key parameters:
     at the current `mu` (from the strong monotonicity of the regularized path
     map); it is informative when small, conservative for aggressively
     centered iterates, and saturates at the floating-point floor in the
-    final iterations.
+    final iterations. Its local-norm companion `delta_path_local` measures
+    the same residual in the barrier metric `H = mu*I + mu*hess(Phi)`
+    (a Newton-decrement analogue): it weights each component by the
+    curvature resisting it and remains informative for aggressive
+    iterates. `lambda_init` (also an attribute on the solver) is the same
+    measure at the deterministic initial point, before the first step:
+    healthy problems measure small, while pathologically scaled data
+    announces itself by tens of orders of magnitude — this diagnostic is
+    how corrupted infinity-sentinel bounds were found in the
+    Maros-Meszaros benchmark files.
 -   `init_strategy`: Choose the initial interior-point iterate. Defaults to
     `qtqp.InitStrategy.TRIVIAL`.
 -   `init_mu_scale`: Positive scale used only by `qtqp.InitStrategy.ORTHANT` to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qtqp"
-version = "0.0.5"
+version = "0.0.6"
 description = "The 'cutie' QP solver."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -725,6 +725,30 @@ class QTQP:
         init_strategy, init_mu_scale, a, p, b, c
     )
     status = SolutionStatus.UNFINISHED
+
+    # Initial-point diagnostic: the local-norm distance-to-path measure
+    # lambda = ||T_mu(u)||_{H^-1} (H = mu*I + mu*hess(Phi)) evaluated at
+    # the deterministic initial iterate, before the first step. Three
+    # matvecs. Healthy problems measure small (<= ~1e7 across NETLIB +
+    # Maros-Meszaros); pathologically scaled data announces itself here
+    # by tens of orders of magnitude — this diagnostic is how corrupted
+    # infinity-sentinel bounds in the benchmark datasets were found.
+    mu0 = float(y @ s) / (self.m - self.z)
+    t_x0 = p @ x + a.T @ y + c * tau + mu0 * x
+    t_y0 = -(a @ x) + b * tau + mu0 * y
+    t_y0[self.z :] -= mu0 / y[self.z :]
+    px0_ = float(x @ (p @ x)) if p.nnz else 0.0
+    t_t0 = (-(float(c @ x) + float(b @ y)) - px0_ / max(_EPS, tau)
+            + mu0 * (tau - 1.0 / max(_EPS, tau)))
+    h_y0 = np.full(self.m, mu0)
+    h_y0[self.z :] += mu0 / (y[self.z :] * y[self.z :])
+    h_t0 = mu0 + mu0 / max(_EPS, tau * tau)
+    self.lambda_init = math.sqrt(
+        float(t_x0 @ t_x0) / max(_EPS, mu0)
+        + float((t_y0 * t_y0) @ (1.0 / h_y0))
+        + t_t0 * t_t0 / max(_EPS, h_t0)
+    )
+
     self._log_header()
 
     # Pre-allocate [x; y] and d_s to avoid repeated allocation each iteration.
@@ -743,6 +767,8 @@ class QTQP:
       # self.it counts IPM steps already taken.
       for self.it in range(max_iter):
         stats_i = {}
+        if self.it == 0:
+          stats_i["lambda_init"] = self.lambda_init
         x, y, tau, s = self._normalize(x, y, tau, s)
 
         mu = max((y @ s) / (self.m - self.z), _MU_FLOOR)
@@ -1428,6 +1454,22 @@ class QTQP:
         float(t_x @ t_x) + float(t_y @ t_y) + t_tau * t_tau
     )
     stats_i["delta_path"] = t_norm / max(_EPS, mu_hat)
+    # Local-norm proximity measure (diagnostic): the same T vector weighted
+    # by the inverse of H = mu*I + mu*diag(hess barrier), the barrier's
+    # local metric. Deflates the barrier rows that make the Euclidean
+    # certificate conservative on aggressively centered iterates
+    # (Newton-decrement flavor), and remains informative for aggressive
+    # iterates where the Euclidean bound saturates.
+    h_x = mu_hat
+    h_y = np.full(self.m, mu_hat)
+    h_y[self.z :] += mu_hat / (y_w[self.z :] * y_w[self.z :])
+    h_tau = mu_hat + mu_hat / max(_EPS, tau * tau)
+    lam_sq = (
+        float(t_x @ t_x) / max(_EPS, h_x)
+        + float((t_y * t_y) @ (1.0 / h_y))
+        + t_tau * t_tau / max(_EPS, h_tau)
+    )
+    stats_i["delta_path_local"] = math.sqrt(max(0.0, lam_sq))
 
     norm_aty = _norm(aty, np.inf)
     norm_px = _norm(px, np.inf)

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -511,6 +511,7 @@ class QTQP:
       refinement_strategy: RefinementStrategy = RefinementStrategy.RICHARDSON,
       gmres_restart: int = 10,
       fused_corrector_division: bool = False,
+      max_centrality_correctors: int = 1,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method."""
     self._linear_solver = None
@@ -535,6 +536,7 @@ class QTQP:
           refinement_strategy=refinement_strategy,
           gmres_restart=gmres_restart,
           fused_corrector_division=fused_corrector_division,
+          max_centrality_correctors=max_centrality_correctors,
       )
     finally:
       if self._linear_solver is not None:
@@ -563,6 +565,7 @@ class QTQP:
       refinement_strategy: RefinementStrategy = RefinementStrategy.RICHARDSON,
       gmres_restart: int = 10,
       fused_corrector_division: bool = False,
+      max_centrality_correctors: int = 1,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method.
 
@@ -624,6 +627,15 @@ class QTQP:
         avoids catastrophic cancellation when y_i is small and the
         terms have similar magnitudes with opposing signs. Default False
         preserves the legacy bit-for-bit behavior.
+      max_centrality_correctors (int): Maximum number of Gondzio-style
+        multiple centrality correctors per iteration. Each corrector costs
+        one back-solve on the existing factorization (kinv_q is shared),
+        recentering the aspirational trial point's outlier complementarity
+        products, and is accepted only if the step size improves.
+        Correctors are skipped when the step size is already >= 0.9.
+        The default 1 was validated on NETLIB + Maros-Meszaros (cuts
+        iterations ~10%, rescues borderline instances, no regressions);
+        0 disables.
 
     Returns:
       A Solution object containing the solution and solve stats.
@@ -643,6 +655,9 @@ class QTQP:
           f"init_mu_scale must be a positive finite float,"
           f" got {init_mu_scale}"
       )
+    if max_centrality_correctors < 0:
+      raise ValueError("max_centrality_correctors must be >= 0.")
+    self._max_centrality_correctors = int(max_centrality_correctors)
     self._fused_corrector_division = bool(fused_corrector_division)
 
     resolved_linear_solver, linear_solver_backend = _resolve_linear_solver(
@@ -825,6 +840,57 @@ class QTQP:
           )
 
         alpha = self._compute_step_size(y, s, d_y, d_s)
+
+
+        # --- Gondzio multiple centrality correctors ---
+        # Each extra corrector costs one back-solve on the existing
+        # factorization (kinv_q is shared): push the aspirational trial
+        # point's outlier complementarity products back into a symmetric
+        # neighborhood of the target, accept only if the step size improves.
+        mu_c = sigma * mu
+        for _ in range(self._max_centrality_correctors):
+          if alpha >= 0.9:
+            break  # step already good; a corrector cannot pay for itself
+          if corrector_lin_sys_stats.get("tau_method") != "quadratic":
+            break  # tau solve degraded; do not stack correctors on it
+          alpha_asp = min(1.0, 1.5 * alpha + 0.3)
+          v = (y[self.z :] + alpha_asp * d_y[self.z :]) * (
+              s[self.z :] + alpha_asp * d_s[self.z :]
+          )
+          target = np.clip(v, 0.1 * mu_c, 10.0 * mu_c)
+          if np.array_equal(target, v):
+            break
+          correction_g = correction + (target - v) / y[self.z :]
+          xy[: self.n] = x_p
+          xy[self.n :] = y_p
+          x_g, y_g, tau_g, gondzio_lin_sys_stats = self._newton_step(
+              p=p,
+              mu=mu,
+              mu_target=mu_c,
+              r_anchor=xy,
+              tau_anchor=tau_p,
+              x=x,
+              y=y,
+              s=s,
+              tau=tau,
+              correction=correction_g,
+          )
+          d_s_g = np.zeros_like(d_s)
+          d_s_g[self.z :] = (
+              mu_c / y[self.z :]
+              + correction_g
+              - y_g[self.z :] * s[self.z :] / y[self.z :]
+          )
+          d_y_g = y_g - y
+          alpha_g = self._compute_step_size(y, s, d_y_g, d_s_g)
+          if alpha_g <= alpha + 0.1 * (alpha_asp - alpha):
+            break
+          stats_i["gondzio_lin_sys_stats"] = gondzio_lin_sys_stats
+          d_x, d_y, d_tau = x_g - x, d_y_g, tau_g - tau
+          d_s = d_s_g
+          correction = correction_g
+          alpha = alpha_g
+
         step = step_size_scale * alpha
         x += step * d_x
         y += step * d_y

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -570,10 +570,17 @@ class QTQP:
       atol (float): Absolute tolerance for convergence criteria.
       rtol (float): Relative tolerance for convergence criteria, scaled by
         problem data norms.
-      atol_infeas (float): Absolute tolerance for detecting primal or dual
-        infeasibility.
-      rtol_infeas (float): Relative tolerance for detecting primal or dual
-        infeasibility.
+      atol_infeas (float): Certificate-quality tolerance for infeasibility
+        and unboundedness detection. A candidate ray u must be good in two
+        complementary senses: its relative backward error (violations over
+        ||operator|| * ||u||) must be below atol_infeas, AND its violations
+        must be below atol_infeas * |objective slope| + rtol_infeas * ||u||.
+        The first rejects large-slope pseudo-rays, the second rejects
+        huge-norm near-solutions; each guards the other's blind spot.
+      rtol_infeas (float): Ray-relative slack in the slope-scaled
+        certificate test, and the margin by which the certificate's
+        objective slope (c'x or b'y) must be negative relative to the data
+        and ray norms.
       max_iter (int): Maximum number of iterations before stopping.
       step_size_scale (float): A factor in (0, 1) to scale the step size,
         ensuring iterates remain strictly interior.
@@ -673,6 +680,14 @@ class QTQP:
     # so we use self.b and self.c here (not the equilibrated local b, c).
     self._norm_b = _norm(self.b, np.inf)
     self._norm_c = _norm(self.c, np.inf)
+
+    # Data operator norms (original scale) for the certificate-quality tests:
+    # ||A||_inf (rows, acts on x), ||A||_1 (columns, = ||A'||_inf, acts on y),
+    # and ||P||_inf.
+    abs_a = abs(self.a)
+    self._norm_a_inf = float(abs_a.sum(axis=1).max()) if self.a.nnz else 0.0
+    self._norm_a_one = float(abs_a.sum(axis=0).max()) if self.a.nnz else 0.0
+    self._norm_p_inf = float(abs(self.p).sum(axis=1).max()) if self.p.nnz else 0.0
 
     self._linear_solver = direct.DirectKktSolver(
         a=a,
@@ -1297,22 +1312,24 @@ class QTQP:
     dres = _norm(px_plus_aty * inv_tau + self.c, np.inf)
     gap = abs((ctx + bty + xpx * inv_tau) * inv_tau)
 
-    # Infeasibility certificates (Farkas-type, from the embedding structure).
-    # If the primal is unbounded (dual infeasible) this produces a ray x with
-    # c'x < 0 that satisfies the homogeneous primal conditions Ax + s ≈ 0 and Px
-    # ≈ 0.  dinfeas measures how well x/|c'x| certifies dual infeasibility.
+    # Certificate-quality measures (Farkas-type, from the embedding
+    # structure). A candidate ray is judged by the smallest relative data
+    # perturbation that would make it an exact certificate (Rigal-Gaches
+    # normwise backward error): e.g. dinfeas_a = ||Ax + s|| / (||A|| ||x||)
+    # is the relative perturbation of A under which x is an exact unbounded
+    # ray. Normalizing by the objective slope |c'x| instead (the common
+    # convention) hands out slack proportional to a quantity degenerate
+    # problems can inflate — near-null directions with enormous c-slope pass
+    # such tests while violating the constraints badly (e.g. NETLIB dfl001).
     norm_aty = _norm(aty, np.inf)
     norm_px = _norm(px, np.inf)
-    dinfeas_a = _norm(ax_plus_s, np.inf) / (abs(ctx) + _EPS)
-    dinfeas_p = norm_px / (abs(ctx) + _EPS)
-    dinfeas = max(dinfeas_a, dinfeas_p)
-    # If the primal is infeasible (dual unbounded) this produces a ray y
-    # with b'y < 0 that satisfies the homogeneous dual condition A'y ≈ 0.
-    # pinfeas measures how well y/|b'y| certifies primal infeasibility.
-    pinfeas = norm_aty / (abs(bty) + _EPS)
-
+    norm_ax_plus_s = _norm(ax_plus_s, np.inf)
     norm_x = _norm(x, np.inf)
     norm_y = _norm(y, np.inf)
+    dinfeas_a = norm_ax_plus_s / (self._norm_a_inf * norm_x + _EPS)
+    dinfeas_p = norm_px / (self._norm_p_inf * norm_x + _EPS)
+    dinfeas = max(dinfeas_a, dinfeas_p)
+    pinfeas = norm_aty / (self._norm_a_one * norm_y + _EPS)
 
     # Residual tolerance relative scales. Each is the max of two families:
     # the summand norms (the floor below which the residual cannot even be
@@ -1351,14 +1368,31 @@ class QTQP:
         and dres < self.atol + self.rtol * drelrhs
     ):
       status = SolutionStatus.SOLVED
-    # Unbounded: x is a dual infeasibility certificate (primal unbounded ray).
-    elif ctx < -_EPS and (
-        dinfeas < self.atol_infeas + self.rtol_infeas * norm_x / abs(ctx)
+    # Certificate acceptance requires BOTH quality senses, because each
+    # guards the other's blind spot:
+    #   - data-scaled (violations / (||operator|| ||ray||) < atol_infeas):
+    #     rejects large-slope pseudo-rays whose |c'x| buys unbounded slack
+    #     in the slope-scaled test (e.g. NETLIB dfl001, where a direction
+    #     violating the constraints at 5-9% of ||A|| ||x|| was certified);
+    #   - slope-scaled (violations < atol_infeas * |slope| + rtol_infeas *
+    #     ||ray||): rejects huge-norm near-solutions, whose data-scaled
+    #     quality becomes small automatically (A'y ~ -c*tau with enormous
+    #     ||y|| makes ||A'y|| / (||A||_1 ||y||) tiny while y is nothing
+    #     like a ray; e.g. NETLIB fit1p, tuff, vtp.base, fffff800).
+    # The quality measures need no zero-ray guard: as ||x|| -> 0 the
+    # data-scaled denominator vanishes while the numerator retains the
+    # O(1) slack s, so dinfeas diverges and nothing is certified.
+    elif (
+        ctx < -(self.rtol_infeas * self._norm_c * norm_x + _EPS)
+        and dinfeas < self.atol_infeas
+        and max(norm_ax_plus_s, norm_px)
+        < self.atol_infeas * abs(ctx) + self.rtol_infeas * norm_x
     ):
       status = SolutionStatus.UNBOUNDED
-    # Infeasible: y is a primal infeasibility certificate (dual unbounded ray).
-    elif bty < -_EPS and (
-        pinfeas < self.atol_infeas + self.rtol_infeas * norm_y / abs(bty)
+    elif (
+        bty < -(self.rtol_infeas * self._norm_b * norm_y + _EPS)
+        and pinfeas < self.atol_infeas
+        and norm_aty < self.atol_infeas * abs(bty) + self.rtol_infeas * norm_y
     ):
       status = SolutionStatus.INFEASIBLE
     else:

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -681,6 +681,8 @@ class QTQP:
       self.d, self.e, self.sigma_eq = None, None, 1.0
     else:
       a, p, b, c, self.d, self.e, self.sigma_eq = self._equilibrate()
+    # Operating-scale b, c, kept for the distance-to-path certificate.
+    self._b_op, self._c_op = b, c
 
     # q = [c; b]: the KKT right-hand side. The primal and dual feasibility
     # conditions at optimality can be written as: K @ [x; y] = -q * tau, where
@@ -1349,6 +1351,12 @@ class QTQP:
 
   def _check_termination(self, x, y, tau, s, alpha, mu, sigma, stats_i, collect_stats):
     """Check termination criteria and compute iteration statistics."""
+    # Working-scale references (equilibrated when equilibration is on),
+    # kept for the distance-to-path certificate below; mu_hat is the
+    # complementarity of THIS iterate in the operating scale.
+    x_w, y_w, s_w = x, y, s
+    mu_hat = float(y_w @ s_w) / (self.m - self.z)
+
     if self.equilibration_strategy is not EquilibrationStrategy.NONE:
       x, y, s = self._unequilibrate_iterates(x, y, s)
 
@@ -1387,6 +1395,40 @@ class QTQP:
     # convention) hands out slack proportional to a quantity degenerate
     # problems can inflate — near-null directions with enormous c-slope pass
     # such tests while violating the constraints badly (e.g. NETLIB dfl001).
+    # A posteriori distance-to-path certificate. The regularized path map
+    # T_mu is mu-strongly monotone, so
+    #     ||u - u*(mu)|| <= ||T_mu(u)|| / mu  =: delta_path,
+    # computable at every iterate. Basically free: the three SpMVs above
+    # are reused via diagonal rescaling into the operating scale. The
+    # bound saturates at the floating-point floor once mu approaches
+    # roundoff of the summands (late endgame); treat large-mu iterates as
+    # the informative regime.
+    if self.equilibration_strategy is not EquilibrationStrategy.NONE:
+      se = self.sigma_eq * self.e
+      sd = self.sigma_eq * self.d
+      sig2 = self.sigma_eq * self.sigma_eq
+      ax_w = sd * ax
+      aty_w = se * aty
+      px_w = se * px
+      ctx_w, bty_w, xpx_w = sig2 * ctx, sig2 * bty, sig2 * xpx
+    else:
+      ax_w, aty_w, px_w = ax, aty, px
+      ctx_w, bty_w, xpx_w = ctx, bty, xpx
+    b_op = getattr(self, "_b_op", self.b)
+    c_op = getattr(self, "_c_op", self.c)
+    t_x = px_w + aty_w + c_op * tau
+    t_x += mu_hat * x_w
+    t_y = -ax_w + b_op * tau
+    t_y += mu_hat * y_w
+    t_y[self.z :] -= mu_hat / y_w[self.z :]
+    inv_tau_w = 1.0 / max(tau, _EPS)
+    t_tau = (-(ctx_w + bty_w) - xpx_w * inv_tau_w
+             + mu_hat * (tau - inv_tau_w))
+    t_norm = math.sqrt(
+        float(t_x @ t_x) + float(t_y @ t_y) + t_tau * t_tau
+    )
+    stats_i["delta_path"] = t_norm / max(_EPS, mu_hat)
+
     norm_aty = _norm(aty, np.inf)
     norm_px = _norm(px, np.inf)
     norm_ax_plus_s = _norm(ax_plus_s, np.inf)

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -16,9 +16,11 @@
 """Interior point method for solving QPs.
 
   Algorithm: Mehrotra predictor-corrector interior point method with a
-  homogeneous embedding. Each iteration does:
+  homogeneous embedding, following the regularized central path
+  (linear term mu * u). Each iteration does:
 
-    1. Normalize (x, y, tau, s) to have the norm of the central path.
+    1. Normalize (x, y, tau, s) onto the path's sphere
+       ||(x, y)||^2 + tau^2 = m - z + 1.
     2. Pre-solve K^{-1} @ [c; b] (shared between predictor and corrector steps).
     3. Predictor step: Newton direction with mu_target=0 (no centering).
     4. Compute sigma (centering parameter) from predictor step quality.
@@ -45,11 +47,22 @@ import scipy.sparse as sp
 from . import direct
 from .direct import RefinementStrategy
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 _HEADER = """| iter |      pcost |      dcost |     pres |     dres |      gap |   infeas |       mu |  q, p, c |     time |"""
 _SEPARA = """|------|------------|------------|----------|----------|----------|----------|----------|----------|----------|"""
 _norm = np.linalg.norm
 _EPS = 1e-15  # Standard epsilon for numerical safety
+# Floor on the complementarity parameter mu wherever it enters the
+# algorithm (KKT shift, corrector targets, barrier terms). Below this
+# scale mu carries no information in double precision relative to O(1)
+# equilibrated data, and letting it underflow leaves the Newton system
+# effectively unregularized: on infeasibility trajectories the iterate
+# can freeze on an immature ray at mu ~ 1e-20, burning iterations with
+# every solve degraded (observed on Windows/QDLDL, where the platform's
+# roundoff draw loses the race between certificate maturation and mu
+# collapse). Healthy solves terminate at mu ~ 1e-9..1e-11 and never
+# touch the floor.
+_MU_FLOOR = 1e-14
 
 
 class LinearSolver(enum.Enum):
@@ -328,10 +341,6 @@ class QTQP:
         raise ValueError("QP matrix 'p' must be symmetric.")
       self.p = p
 
-    # Default exponent so _newton_step works in tests that call it directly
-    # before solve() has overridden the attribute.
-    self._central_path_exponent = 1.0
-
   def _presolve(self, inf_bound: float = 1e20):
     """Drop inequality rows with trivially-satisfied RHS (b[i] >= inf_bound
     or +inf). Equality RHS must be finite; inequality RHS may not be NaN or -inf.
@@ -501,7 +510,6 @@ class QTQP:
       init_mu_scale: float = 1.0,
       refinement_strategy: RefinementStrategy = RefinementStrategy.RICHARDSON,
       gmres_restart: int = 10,
-      central_path_exponent: float = 1.0,
       fused_corrector_division: bool = False,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method."""
@@ -526,7 +534,6 @@ class QTQP:
           init_mu_scale=init_mu_scale,
           refinement_strategy=refinement_strategy,
           gmres_restart=gmres_restart,
-          central_path_exponent=central_path_exponent,
           fused_corrector_division=fused_corrector_division,
       )
     finally:
@@ -555,7 +562,6 @@ class QTQP:
       init_mu_scale: float = 1.0,
       refinement_strategy: RefinementStrategy = RefinementStrategy.RICHARDSON,
       gmres_restart: int = 10,
-      central_path_exponent: float = 1.0,
       fused_corrector_division: bool = False,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method.
@@ -603,13 +609,6 @@ class QTQP:
         inner Arnoldi step consumes one factor-solve. Smaller values reduce
         per-cycle cost at the price of more restarts. Ignored when
         refinement_strategy is RICHARDSON.
-      central_path_exponent (float): Exponent p > 0 in the generalized
-        central-path equation r + mu^p * u = 0 (cone products s_i * y_i =
-        mu and tau * kappa = mu are unchanged). Default 1.0 recovers the
-        standard primal-dual central path. p > 1 makes the linear residual
-        vanish faster than mu as mu -> 0; p < 1 the reverse. mu^p enters
-        the KKT diagonal regularization and the Newton-step linear-residual
-        RHS; cone-product targets keep the unmodified mu.
       fused_corrector_division (bool): If True, compute the corrector
         slack update via a single division by y[z:] with the three
         numerator terms (sigma*mu, the Mehrotra cross product, and
@@ -637,12 +636,6 @@ class QTQP:
           f"init_mu_scale must be a positive finite float,"
           f" got {init_mu_scale}"
       )
-    if not (np.isfinite(central_path_exponent) and central_path_exponent > 0):
-      raise ValueError(
-          "central_path_exponent must be a positive finite float (got"
-          f" {central_path_exponent}); p <= 0 is incompatible with the IPM."
-      )
-    self._central_path_exponent = float(central_path_exponent)
     self._fused_corrector_division = bool(fused_corrector_division)
 
     resolved_linear_solver, linear_solver_backend = _resolve_linear_solver(
@@ -720,14 +713,10 @@ class QTQP:
         stats_i = {}
         x, y, tau, s = self._normalize(x, y, tau, s)
 
-        mu = (y @ s) / (self.m - self.z)
-        # Generalized central path: r + mu^p * u = 0. mu_p enters the KKT
-        # diagonal and the Newton-step linear-residual RHS; cone-product
-        # targets (s*y = mu, tau*kappa = mu) keep the unmodified mu.
-        mu_p = mu ** self._central_path_exponent
+        mu = max((y @ s) / (self.m - self.z), _MU_FLOOR)
 
         # --- Take an IPM step ---
-        self._linear_solver.update(mu=mu_p, s=s, y=y)
+        self._linear_solver.update(mu=mu, s=s, y=y)
 
         # --- Step 1: Precompute kinv_q = K^{-1} @ q ---
         # This is reused for both predictor and corrector parts of the step.
@@ -1066,11 +1055,11 @@ class QTQP:
     s_aff = s + alpha * d_s
 
     # Compute mu_aff directly without calling _normalize to avoid 4 extra
-    # allocations. Equivalent to: normalize then compute (y @ s) / (m - z).
-    # scale = sqrt(m-z+1) / max(_EPS, ||(x,y,tau)||), so scale^2 = (m-z+1) /
-    # max(_EPS^2, ||(x,y,tau)||^2), giving mu_aff = scale^2 * (y_aff @ s_aff).
-    xyt_norm_sq = x_aff @ x_aff + y_aff @ y_aff + tau_aff * tau_aff
-    scale_sq = (self.m - self.z + 1) / max(_EPS * _EPS, xyt_norm_sq)
+    # allocations. Equivalent to: normalize onto the path sphere
+    # (||u||^2 = m-z+1) then compute (y @ s) / (m - z);
+    # normalization scales y and s each by `scale`, so mu picks up scale^2.
+    quad_aff = x_aff @ x_aff + y_aff @ y_aff + tau_aff * tau_aff
+    scale_sq = (self.m - self.z + 1) / max(_EPS * _EPS, quad_aff)
     mu_aff = scale_sq * (y_aff @ s_aff) / (self.m - self.z)
 
     # sigma = (mu_aff / mu)^3: Mehrotra's heuristic. If the affine step already
@@ -1092,21 +1081,17 @@ class QTQP:
     tau+ is then pinned by substituting this back into the tau equation of the
     homogeneous embedding (see _solve_for_tau).
 
-    The central-path equation r + mu^p * u = 0 contributes the
-    (mu^p - mu_target^p) coefficient on the linear-residual side; cone-product
-    corrections (s_i * y_i = mu_target, tau * kappa = mu_target) keep the
-    unmodified mu_target.
+    The weighted central-path equation contributes the eps*(mu - mu_target)
+    coefficient on the (x, y) linear-residual side and (mu - mu_target) on
+    tau; cone-product corrections (s_i * y_i = mu_target, tau * kappa =
+    mu_target) keep the unmodified mu_target.
 
     Uses the exact quadratic tau solve when the KKT solve is accurate, and a
     linearized fallback (avoids squaring solver noise) when it's noisy or the
     quadratic residual check fails.
     """
-    cpe = self._central_path_exponent
-    # 0**cpe = 0 for cpe > 0, so mu_target = 0 (predictor) yields mu_target_p = 0.
-    mu_p = mu ** cpe
-    mu_target_p = mu_target ** cpe if mu_target > 0.0 else 0.0
     # Prepare RHS for the linear system.
-    r = (mu_p - mu_target_p) * r_anchor
+    r = (mu - mu_target) * r_anchor
     if mu_target != 0.0:
       r[self.n + self.z :] += mu_target / y[self.z :]
     r[self.n + self.z :] += s[self.z :]
@@ -1123,7 +1108,7 @@ class QTQP:
     tau_plus = None
     if lin_sys_stats["converged"] or lin_sys_stats["final_residual_norm"] < 1e-7:
       try:
-        r_tau = (mu_p - mu_target_p) * tau_anchor
+        r_tau = (mu - mu_target) * tau_anchor
         tau_plus = self._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)
         lin_sys_stats["tau_method"] = "quadratic"
       except ValueError:
@@ -1156,16 +1141,15 @@ class QTQP:
     a feasible point (tau=0 corresponds to a certificate of infeasibility or
     unboundedness, which is handled separately at termination).
 
-    Generalized central path: t_a's mu term becomes mu^cpe (the linear-residual
-    coefficient on tau); t_c = -mu_target keeps the unmodified mu_target since
-    it comes from the cone-product equation tau * kappa = mu_target.
+    The mu term of t_a comes from the path's linear regularization term;
+    t_c = -mu_target comes from the cone-product equation
+    tau * kappa = mu_target.
     """
     # Coefficients of the quadratic t_a * tau+^2 + t_b * tau+ + t_c = 0.
     n = self.n
     q, kinv_q = self.q, self.kinv_q
-    mu_p = mu ** self._central_path_exponent
 
-    t_a = mu_p + kinv_q @ q
+    t_a = mu + kinv_q @ q
     t_b = -r_tau - kinv_r @ q
     t_c = -mu_target
     if p.nnz > 0:
@@ -1216,15 +1200,13 @@ class QTQP:
     enters linearly rather than quadratically. A [0.1x, 10x] trust region
     prevents manifold drift from the first-order approximation.
 
-    Linear-residual coefficients on tau use mu^cpe and mu_target^cpe (the
-    generalized central path); the cone-product constant -mu_target keeps the
-    unmodified mu_target.
+    The tau coefficients use the plain mu and mu_target; the cone-product
+    constant -mu_target is likewise unmodified.
     """
     n = self.n
     q, kinv_q = self.q, self.kinv_q
-    cpe = self._central_path_exponent
-    mu_p = mu ** cpe
-    mu_target_p = mu_target ** cpe if mu_target > 0.0 else 0.0
+    mu_p = mu
+    mu_target_p = mu_target
 
     px = p @ x if p.nnz > 0 else np.zeros(n)
 
@@ -1261,16 +1243,17 @@ class QTQP:
     like x/tau and y/tau matter — tau is the homogeneous variable, and the final
     solution is recovered as (x/tau, y/tau, s/tau).
 
-    We enforce the norm of the central path, which ensures convergence to
-    non-trivial solution, ie:
-        ||(x, y, tau)||^2 = m - z + 1
+    We enforce the invariant of the weighted central path (the Euler identity
+    for the linear term mu * diag(eps*I, eps*I, 1) * u), which ensures
+    convergence to a non-trivial solution:
+        eps * ||(x, y)||^2 + tau^2 = m - z + 1
     The right-hand side counts complementarity pairs: (m - z) from the
     inequality constraints plus 1 for the tau-kappa pair of the embedding.
 
     Operates in-place on the iterate arrays and returns them for convenience.
     """
-    xyt_norm = math.sqrt(x @ x + y @ y + tau * tau)
-    scale = math.sqrt(self.m - self.z + 1) / max(_EPS, xyt_norm)
+    quad = x @ x + y @ y + tau * tau
+    scale = math.sqrt((self.m - self.z + 1) / max(_EPS, quad))
     x *= scale
     y *= scale
     tau *= scale
@@ -1328,26 +1311,42 @@ class QTQP:
     # pinfeas measures how well y/|b'y| certifies primal infeasibility.
     pinfeas = norm_aty / (abs(bty) + _EPS)
 
-    # Primal residual tolerance relative scale.
+    norm_x = _norm(x, np.inf)
+    norm_y = _norm(y, np.inf)
+
+    # Residual tolerance relative scales. Each is the max of two families:
+    # the summand norms (the floor below which the residual cannot even be
+    # evaluated in floating point) and the iterate norm (the backward-error
+    # allowance: dres <= rtol * ||x||/tau accepts a point that is exactly
+    # dual-feasible for P + dP with ||dP|| <= rtol, which is precisely the
+    # mu*I perturbation the regularized path itself commits; likewise
+    # pres <= rtol * ||y||/tau on the primal side).
     prelrhs = max(
         _norm(ax, np.inf) * inv_tau,
         _norm(s, np.inf) * inv_tau,
         self._norm_b,
+        norm_y * inv_tau,
     )
 
-    # Dual residual tolerance relative scale.
     drelrhs = max(
         norm_px * inv_tau,
         norm_aty * inv_tau,
         self._norm_c,
+        norm_x * inv_tau,
     )
 
-    norm_x = _norm(x, np.inf)
-    norm_y = _norm(y, np.inf)
+    # Gap tolerance relative scale: the cost magnitudes (measurement floor)
+    # or the first-power iterate norm (the empirically calibrated allowance
+    # for the regularized path's O(mu*||u||^2) objective bias; see the
+    # criteria validation on NETLIB + Maros-Meszaros).
+    gaprelrhs = max(
+        min(abs(pcost), abs(dcost)),
+        (norm_x + norm_y) * inv_tau,
+    )
 
     # Solved: duality gap and both residuals are within tolerance.
     if (
-        gap < self.atol + self.rtol * min(abs(pcost), abs(dcost))
+        gap < self.atol + self.rtol * gaprelrhs
         and pres < self.atol + self.rtol * prelrhs
         and dres < self.atol + self.rtol * drelrhs
     ):

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -397,6 +397,32 @@ class QTQP:
       return 0.0
     return ps.b_dropped - ps.a_dropped @ x
 
+  def _lambda_local(self, x, y, s, tau, a, p, b, c):
+    """Local-norm distance-to-path measure at a working-scale point.
+
+    lambda = ||T_mu(u)||_{H^-1} with H = mu*I + mu*hess(Phi) (diagonal),
+    evaluated at the point's own complementarity mu = y's/(m-z). Three
+    matvecs. Certified-distance semantics when small; a scaled residual
+    score when large.
+    """
+    mu0 = float(y @ s) / (self.m - self.z)
+    if not np.isfinite(mu0) or mu0 <= 0.0:
+      return math.inf
+    t_x0 = p @ x + a.T @ y + c * tau + mu0 * x
+    t_y0 = -(a @ x) + b * tau + mu0 * y
+    t_y0[self.z :] -= mu0 / y[self.z :]
+    px0_ = float(x @ (p @ x)) if p.nnz else 0.0
+    t_t0 = (-(float(c @ x) + float(b @ y)) - px0_ / max(_EPS, tau)
+            + mu0 * (tau - 1.0 / max(_EPS, tau)))
+    h_y0 = np.full(self.m, mu0)
+    h_y0[self.z :] += mu0 / (y[self.z :] * y[self.z :])
+    h_t0 = mu0 + mu0 / max(_EPS, tau * tau)
+    return math.sqrt(
+        float(t_x0 @ t_x0) / max(_EPS, mu0)
+        + float((t_y0 * t_y0) @ (1.0 / h_y0))
+        + t_t0 * t_t0 / max(_EPS, h_t0)
+    )
+
   def _init_variables(self, strategy, mu_scale, a, p, b, c):
     """Dispatch to the requested initialization strategy.
 
@@ -512,6 +538,8 @@ class QTQP:
       gmres_restart: int = 10,
       fused_corrector_division: bool = False,
       max_centrality_correctors: int = 1,
+      warm_start=None,
+      warm_start_threshold: float = 100.0,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method."""
     self._linear_solver = None
@@ -537,6 +565,8 @@ class QTQP:
           gmres_restart=gmres_restart,
           fused_corrector_division=fused_corrector_division,
           max_centrality_correctors=max_centrality_correctors,
+          warm_start=warm_start,
+          warm_start_threshold=warm_start_threshold,
       )
     finally:
       if self._linear_solver is not None:
@@ -566,6 +596,8 @@ class QTQP:
       gmres_restart: int = 10,
       fused_corrector_division: bool = False,
       max_centrality_correctors: int = 1,
+      warm_start=None,
+      warm_start_threshold: float = 100.0,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method.
 
@@ -726,28 +758,48 @@ class QTQP:
     )
     status = SolutionStatus.UNFINISHED
 
-    # Initial-point diagnostic: the local-norm distance-to-path measure
-    # lambda = ||T_mu(u)||_{H^-1} (H = mu*I + mu*hess(Phi)) evaluated at
-    # the deterministic initial iterate, before the first step. Three
-    # matvecs. Healthy problems measure small (<= ~1e7 across NETLIB +
+    # Certified warm start: ingest a caller-supplied (x, y, s) from a
+    # nearby problem, embed it interior at a few centering shifts, and
+    # accept the best embedding only when the certificate says it is
+    # actually near the path (lambda <= warm_start_threshold). A vetoed
+    # warm start falls back to the trivial init: the certificate makes
+    # warm starting safe, which heuristic IPM warm starts are not.
+    self.warm_lambda = None
+    self.warm_accepted = False
+    if warm_start is not None:
+      wx, wy, ws = (np.asarray(v, dtype=float).copy() for v in warm_start)
+      if self.equilibration_strategy is not EquilibrationStrategy.NONE:
+        wx, wy, ws = self._equilibrate_iterates(wx, wy, ws)
+      best = (math.inf, None)
+      for eta in (1e-6, 1e-4, 1e-2, 1.0):
+        cx = wx.copy()
+        cy = wy.copy()
+        cs = ws.copy()
+        cy[self.z :] = np.maximum(cy[self.z :], eta)
+        cs[self.z :] = np.maximum(cs[self.z :], eta)
+        cs[: self.z] = 0.0
+        ctau = 1.0
+        cx, cy, ctau, cs = self._normalize(cx, cy, ctau, cs)
+        lam = self._lambda_local(cx, cy, cs, ctau, a, p, b, c)
+        if lam < best[0]:
+          best = (lam, (cx, cy, cs, ctau))
+      self.warm_lambda = best[0]
+      if best[0] <= warm_start_threshold:
+        cx, cy, cs, ctau = best[1]
+        x, y, s, tau = cx, cy, cs, ctau
+        self.warm_accepted = True
+      logging.debug(
+          "warm start: lambda = %e, accepted = %s",
+          self.warm_lambda, self.warm_accepted,
+      )
+
+    # Initial-point diagnostic: the local-norm distance-to-path measure at
+    # the starting iterate (warm or trivial), before the first step.
+    # Healthy problems measure small (<= ~1e7 across NETLIB +
     # Maros-Meszaros); pathologically scaled data announces itself here
     # by tens of orders of magnitude — this diagnostic is how corrupted
     # infinity-sentinel bounds in the benchmark datasets were found.
-    mu0 = float(y @ s) / (self.m - self.z)
-    t_x0 = p @ x + a.T @ y + c * tau + mu0 * x
-    t_y0 = -(a @ x) + b * tau + mu0 * y
-    t_y0[self.z :] -= mu0 / y[self.z :]
-    px0_ = float(x @ (p @ x)) if p.nnz else 0.0
-    t_t0 = (-(float(c @ x) + float(b @ y)) - px0_ / max(_EPS, tau)
-            + mu0 * (tau - 1.0 / max(_EPS, tau)))
-    h_y0 = np.full(self.m, mu0)
-    h_y0[self.z :] += mu0 / (y[self.z :] * y[self.z :])
-    h_t0 = mu0 + mu0 / max(_EPS, tau * tau)
-    self.lambda_init = math.sqrt(
-        float(t_x0 @ t_x0) / max(_EPS, mu0)
-        + float((t_y0 * t_y0) @ (1.0 / h_y0))
-        + t_t0 * t_t0 / max(_EPS, h_t0)
-    )
+    self.lambda_init = self._lambda_local(x, y, s, tau, a, p, b, c)
 
     self._log_header()
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -2948,6 +2948,44 @@ def test_certificate_rejects_large_slope_pseudo_ray():
 
 
 # =============================================================================
+# delta_path: a posteriori distance-to-path certificate
+# =============================================================================
+
+@pytest.mark.parametrize('equilibration', [
+    qtqp.EquilibrationStrategy.RUIZ, qtqp.EquilibrationStrategy.NONE,
+])
+def test_delta_path_logged(equilibration):
+  """delta_path is present, finite, and positive on every iteration."""
+  rng = np.random.default_rng(9000)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      verbose=False, collect_stats=True, equilibration_strategy=equilibration,
+  )
+  deltas = [st['delta_path'] for st in sol.stats]
+  assert len(deltas) == len(sol.stats)
+  assert all(np.isfinite(d) and d > 0 for d in deltas)
+  # The certificate should improve from the initial iterate at some point
+  # of the trajectory (it saturates at the floating-point floor late).
+  assert min(deltas) <= deltas[0]
+
+
+def test_delta_path_small_near_path():
+  """A well-converged easy instance certifies proximity mid-flight:
+  the minimum delta_path over the trajectory is small relative to the
+  operating sphere diameter."""
+  rng = np.random.default_rng(9100)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      verbose=False, collect_stats=True,
+  )
+  deltas = [st['delta_path'] for st in sol.stats]
+  diameter = 2.0 * np.sqrt(m - z + 1)
+  assert min(deltas) < 100.0 * diameter
+
+
+# =============================================================================
 # max_centrality_correctors: Gondzio multiple centrality correctors
 # =============================================================================
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -291,18 +291,26 @@ def _assert_solution(solution, a, b, c, p, z, atol=1e-7, rtol=1e-8):
   pres = np.linalg.norm(a @ x + s - b, np.inf)
   dres = np.linalg.norm(p @ x + a.T @ y + c, np.inf)
   gap = np.abs(c @ x + b @ y + x @ p @ x)
+  # Relative scales mirror the solver's termination criteria: the summand
+  # norms (evaluation floor) plus the iterate norms (the backward-error
+  # allowance of the weighted regularized path).
+  norm_x = np.linalg.norm(x, np.inf)
+  norm_y = np.linalg.norm(y, np.inf)
   prelrhs = max(
       np.linalg.norm(a @ x, np.inf),
       np.linalg.norm(s, np.inf),
       np.linalg.norm(b, np.inf),
+      norm_y,
   )
   drelrhs = max(
       np.linalg.norm(p @ x, np.inf),
       np.linalg.norm(a.T @ y, np.inf),
       np.linalg.norm(c, np.inf),
+      norm_x,
   )
+  gaprelrhs = max(min(abs(pcost), abs(dcost)), norm_x + norm_y)
   assert solution.status == qtqp.SolutionStatus.SOLVED
-  np.testing.assert_array_less(gap, atol + rtol * min(abs(pcost), abs(dcost)))
+  np.testing.assert_array_less(gap, atol + rtol * gaprelrhs)
   np.testing.assert_array_less(pres, atol + rtol * prelrhs)
   np.testing.assert_array_less(dres, atol + rtol * drelrhs)
   np.testing.assert_array_less(-1e-9, np.min(y[z:], initial=0.0))
@@ -1888,7 +1896,7 @@ def test_equilibrate_unequilibrate_roundtrip(strategy):
 # =============================================================================
 
 def test_normalize_invariant():
-  """Test that _normalize enforces ||(x,y,tau)||^2 == m - z + 1."""
+  """_normalize enforces ||(x,y)||^2 + tau^2 == m - z + 1."""
   rng = np.random.default_rng(42)
   m, n, z = 20, 10, 3
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
@@ -1901,8 +1909,8 @@ def test_normalize_invariant():
 
   x_n, y_n, tau_n, _ = solver._normalize(x, y, tau, s)  # pylint: disable=protected-access
 
-  xyt_norm_sq = x_n @ x_n + y_n @ y_n + tau_n ** 2
-  np.testing.assert_allclose(xyt_norm_sq, m - z + 1, atol=1e-12, rtol=1e-12)
+  quad = x_n @ x_n + y_n @ y_n + tau_n ** 2
+  np.testing.assert_allclose(quad, m - z + 1, atol=1e-12, rtol=1e-12)
 
 
 # =============================================================================
@@ -2860,90 +2868,6 @@ def test_gmres_rollback_on_stalled_refinement():
   # Either we converged immediately, or the returned residual is no worse
   # than what one direct factor-solve from warm_start would give.
   assert stats['final_residual_norm'] < 1e-6
-
-
-# =============================================================================
-# central_path_exponent: generalized central path
-# =============================================================================
-
-@pytest.mark.parametrize('central_path_exponent', [0.5, 1.0, 1.5, 2.0])
-@pytest.mark.parametrize('seed', 6000 + np.arange(3))
-def test_central_path_exponent_solve(central_path_exponent, seed):
-  """All positive exponents must converge to the same optimal solution."""
-  rng = np.random.default_rng(seed)
-  m, n, z = 60, 40, 8
-  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      central_path_exponent=central_path_exponent, verbose=False,
-  )
-  _assert_solution(solution, a, b, c, p, z)
-
-
-def test_central_path_exponent_default_unchanged():
-  """central_path_exponent=1.0 must give the same solution as the default.
-
-  The two paths drift by ~1 ULP per iteration because mu**1.0 is not
-  bit-identical to mu in IEEE math; this test just guards against any
-  larger semantic divergence on the default path.
-  """
-  rng = np.random.default_rng(6100)
-  m, n, z = 50, 30, 5
-  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
-  sol_a = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
-  sol_b = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      central_path_exponent=1.0, verbose=False
-  )
-  np.testing.assert_allclose(sol_a.x, sol_b.x, atol=1e-6, rtol=1e-6)
-  np.testing.assert_allclose(sol_a.y, sol_b.y, atol=1e-6, rtol=1e-6)
-  np.testing.assert_allclose(sol_a.s, sol_b.s, atol=1e-6, rtol=1e-6)
-
-
-def test_central_path_exponent_solutions_agree():
-  """Different exponents converge to the same QP optimum (within tol)."""
-  rng = np.random.default_rng(6200)
-  m, n, z = 50, 30, 5
-  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
-  objs = []
-  for cpe in (0.5, 1.0, 1.5, 2.0):
-    sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-        central_path_exponent=cpe, verbose=False
-    )
-    _assert_solution(sol, a, b, c, p, z)
-    objs.append(c @ sol.x + 0.5 * sol.x @ p @ sol.x)
-  ref = objs[1]  # the p=1 case is the reference
-  for obj in objs:
-    np.testing.assert_allclose(obj, ref, atol=1e-5, rtol=1e-5)
-
-
-@pytest.mark.parametrize('bad_value', [0.0, -1.0, -0.5, float('nan'), float('inf')])
-def test_central_path_exponent_rejects_invalid(bad_value):
-  """Non-positive or non-finite central_path_exponent must raise."""
-  rng = np.random.default_rng(6300)
-  a, b, c, p = _gen_feasible(20, 12, 3, random_state=rng)
-  with pytest.raises(ValueError, match='central_path_exponent'):
-    qtqp.QTQP(a=a, b=b, c=c, z=3, p=p).solve(
-        central_path_exponent=bad_value, verbose=False
-    )
-
-
-def test_central_path_exponent_infeasible():
-  """Non-default exponent must still detect primal infeasibility."""
-  rng = np.random.default_rng(6400)
-  a, b, c, p = _gen_infeasible(40, 25, 5, random_state=rng)
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
-      central_path_exponent=1.5, verbose=False
-  )
-  _assert_infeasible(solution, a, b, 5)
-
-
-def test_central_path_exponent_unbounded():
-  """Non-default exponent must still detect primal unboundedness."""
-  rng = np.random.default_rng(6500)
-  a, b, c, p = _gen_unbounded(40, 25, 5, random_state=rng)
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
-      central_path_exponent=0.7, verbose=False
-  )
-  _assert_unbounded(solution, a, c, p, 5)
 
 
 # =============================================================================

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -2948,6 +2948,64 @@ def test_certificate_rejects_large_slope_pseudo_ray():
 
 
 # =============================================================================
+# max_centrality_correctors: Gondzio multiple centrality correctors
+# =============================================================================
+
+@pytest.mark.parametrize('mcc', [0, 1, 2, 3])
+@pytest.mark.parametrize('seed', 7000 + np.arange(3))
+def test_centrality_correctors_solve(mcc, seed):
+  """All corrector counts must converge to a valid optimal solution."""
+  rng = np.random.default_rng(seed)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      max_centrality_correctors=mcc, verbose=False,
+  )
+  _assert_solution(solution, a, b, c, p, z)
+
+
+def test_centrality_correctors_solutions_agree():
+  """Different corrector counts converge to the same QP optimum."""
+  rng = np.random.default_rng(7200)
+  m, n, z = 50, 30, 5
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  objs = []
+  for mcc in (0, 1, 2):
+    sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+        max_centrality_correctors=mcc, verbose=False
+    )
+    _assert_solution(sol, a, b, c, p, z)
+    objs.append(c @ sol.x + 0.5 * sol.x @ p @ sol.x)
+  for obj in objs:
+    np.testing.assert_allclose(obj, objs[1], atol=1e-5, rtol=1e-5)
+
+
+def test_centrality_correctors_rejects_negative():
+  rng = np.random.default_rng(7300)
+  a, b, c, p = _gen_feasible(20, 12, 3, random_state=rng)
+  with pytest.raises(ValueError, match='max_centrality_correctors'):
+    qtqp.QTQP(a=a, b=b, c=c, z=3, p=p).solve(
+        max_centrality_correctors=-1, verbose=False
+    )
+
+
+def test_centrality_correctors_infeasible_unbounded():
+  """Correctors must not disturb certificate detection."""
+  rng = np.random.default_rng(7400)
+  a, b, c, p = _gen_infeasible(40, 25, 5, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
+      max_centrality_correctors=2, verbose=False
+  )
+  _assert_infeasible(sol, a, b, 5)
+  rng = np.random.default_rng(7500)
+  a, b, c, p = _gen_unbounded(40, 25, 5, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
+      max_centrality_correctors=2, verbose=False
+  )
+  _assert_unbounded(sol, a, c, p, 5)
+
+
+# =============================================================================
 # fused_corrector_division: single-division Mehrotra corrector
 # =============================================================================
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -2970,6 +2970,33 @@ def test_delta_path_logged(equilibration):
   assert min(deltas) <= deltas[0]
 
 
+@pytest.mark.parametrize('equilibration', [
+    qtqp.EquilibrationStrategy.RUIZ, qtqp.EquilibrationStrategy.NONE,
+])
+def test_delta_path_local_logged(equilibration):
+  """delta_path_local is present, finite, and positive every iteration."""
+  rng = np.random.default_rng(9200)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      verbose=False, collect_stats=True, equilibration_strategy=equilibration,
+  )
+  lams = [st['delta_path_local'] for st in sol.stats]
+  assert all(np.isfinite(v) and v > 0 for v in lams)
+
+
+def test_lambda_init_logged():
+  """lambda_init is computed at the initial point and surfaced in stats."""
+  rng = np.random.default_rng(9300)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
+  sol = solver.solve(verbose=False, collect_stats=True)
+  assert np.isfinite(solver.lambda_init) and solver.lambda_init > 0
+  assert sol.stats[0]['lambda_init'] == solver.lambda_init
+  assert 'lambda_init' not in sol.stats[1]
+
+
 def test_delta_path_small_near_path():
   """A well-converged easy instance certifies proximity mid-flight:
   the minimum delta_path over the trajectory is small relative to the

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -2102,14 +2102,16 @@ def test_complementarity_at_convergence():
 
 def test_iterative_refinement_improves_residual():
   """Test that more refinement steps reduce the final linear system residual."""
+  # QDLDL pinned: the ordering assertion compares residuals at the noise
+  # floor, and the multithreaded backends are not run-to-run stable there.
   rng = np.random.default_rng(42)
   m, n, z = 50, 30, 5
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
-  sol_1 = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+  sol_1 = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(linear_solver=qtqp.LinearSolver.QDLDL, 
       max_iterative_refinement_steps=1, verbose=True, collect_stats=True
   )
-  sol_50 = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+  sol_50 = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(linear_solver=qtqp.LinearSolver.QDLDL, 
       max_iterative_refinement_steps=50, verbose=True, collect_stats=True
   )
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -323,14 +323,19 @@ def _assert_infeasible(solution, a, b, z, atol=1e-8, rtol=1e-9):
   y = solution.y
   s = solution.s
 
-  pinfeas = np.linalg.norm(a.T @ y, np.inf)
+  # Certificate quality is judged as relative backward error, mirroring the
+  # solver's detection contract: violations over ||A||_1 * ||y||.
+  norm_a_one = float(abs(a).sum(axis=0).max())
+  pinfeas = np.linalg.norm(a.T @ y, np.inf) / (
+      norm_a_one * np.linalg.norm(y, np.inf) + 1e-300
+  )
 
   assert solution.status == qtqp.SolutionStatus.INFEASIBLE
   np.testing.assert_array_equal(np.isnan(x), True)
   np.testing.assert_array_equal(np.isnan(s), True)
   np.testing.assert_allclose(b @ y, -1.0, atol=atol, rtol=rtol)
   np.testing.assert_array_less(-1e-9, np.min(y[z:], initial=0.0))
-  np.testing.assert_array_less(pinfeas, atol + rtol * np.linalg.norm(y, np.inf))
+  np.testing.assert_array_less(pinfeas, atol)
 
 
 def _assert_unbounded(solution, a, c, p, z, atol=1e-8, rtol=1e-9):
@@ -339,19 +344,21 @@ def _assert_unbounded(solution, a, c, p, z, atol=1e-8, rtol=1e-9):
   y = solution.y
   s = solution.s
 
-  dinfeas_a = np.linalg.norm(a @ x + s, np.inf)
-  dinfeas_p = np.linalg.norm(p @ x, np.inf)
+  # Certificate quality is judged as relative backward error, mirroring the
+  # solver's detection contract: violations over ||A||_inf * ||x|| (and
+  # ||P||_inf * ||x|| for the quadratic part).
+  norm_x = np.linalg.norm(x, np.inf)
+  norm_a_inf = float(abs(a).sum(axis=1).max())
+  norm_p_inf = float(abs(p).sum(axis=1).max()) if p.nnz else 0.0
+  dinfeas_a = np.linalg.norm(a @ x + s, np.inf) / (norm_a_inf * norm_x + 1e-300)
+  dinfeas_p = np.linalg.norm(p @ x, np.inf) / (norm_p_inf * norm_x + 1e-300)
 
   assert solution.status == qtqp.SolutionStatus.UNBOUNDED
   np.testing.assert_array_equal(np.isnan(y), True)
   np.testing.assert_allclose(c @ x, -1.0, atol=atol, rtol=rtol)
   np.testing.assert_array_less(-1e-9, np.min(s[z:], initial=0.0))
-  np.testing.assert_array_less(
-      dinfeas_a, atol + rtol * np.linalg.norm(x, np.inf)
-  )
-  np.testing.assert_array_less(
-      dinfeas_p, atol + rtol * np.linalg.norm(x, np.inf)
-  )
+  np.testing.assert_array_less(dinfeas_a, atol)
+  np.testing.assert_array_less(dinfeas_p, atol)
 
 
 @pytest.mark.parametrize('equilibration', [qtqp.EquilibrationStrategy.RUIZ, qtqp.EquilibrationStrategy.NONE])
@@ -533,7 +540,6 @@ def test_equality_only_lp(seed):
   y_star = rng.normal(size=m)
   b = a @ x_star
   c = -(a.T @ y_star)
-  p = sparse.csc_matrix((n, n))
   with pytest.raises(ValueError, match='effective z == m'):
     _ = qtqp.QTQP(a=a, b=b, c=c, z=z).solve(verbose=True)
 
@@ -556,7 +562,6 @@ def test_presolve_drops_all_inequalities():
   rng = np.random.default_rng(842)
   m_eq, n = 5, 20
   m_ineq = 5
-  m = m_eq + m_ineq
   z = m_eq
   a, b, c, p = _gen_equality_only(m_eq, n, random_state=rng)
   a, b = _append_dropped_inequalities(
@@ -2870,6 +2875,76 @@ def test_gmres_rollback_on_stalled_refinement():
   # Either we converged immediately, or the returned residual is no worse
   # than what one direct factor-solve from warm_start would give.
   assert stats['final_residual_norm'] < 1e-6
+
+
+# =============================================================================
+# Certificate quality: pseudo-rays must not be certified
+# =============================================================================
+
+def test_certificate_rejects_large_slope_pseudo_ray():
+  """A direction with enormous |c'x| but non-trivial constraint violations
+  must not be accepted as an unboundedness certificate.
+
+  This is the mechanism behind false certificates on degenerate LPs (e.g.
+  NETLIB dfl001): tests that normalize violations by |c'x| hand out slack
+  proportional to the objective slope, which a near-null direction of A with
+  a large c-component can inflate arbitrarily. The certificate test must
+  judge violations against ||A|| ||x|| instead.
+  """
+  rng = np.random.default_rng(7)
+  m, n, z = 12, 8, 3
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+
+  # Direction v: right singular vector of A with the smallest singular value
+  # (near-null for A but not null), and a cost vector with a huge component
+  # along v so that c'v is enormously negative.
+  u_svd, s_svd, vt_svd = np.linalg.svd(a.toarray())
+  mid = len(s_svd) // 2
+  v = vt_svd[mid]
+  sigma_v = s_svd[mid]  # clearly nonzero: v is NOT a feasible ray
+  norm_a = np.max(np.abs(a.toarray()).sum(axis=1))
+  big = 1e12
+  c_adv = -big * v
+
+  solver = qtqp.QTQP(a=a, b=b, c=c_adv, z=z, p=p)
+  # Prime the state that solve() would normally set before termination checks.
+  solver.atol, solver.rtol = 1e-7, 1e-8
+  solver.atol_infeas, solver.rtol_infeas = 1e-8, 1e-9
+  solver.equilibration_strategy = qtqp.EquilibrationStrategy.NONE
+  solver._norm_b = np.linalg.norm(solver.b, np.inf)
+  solver._norm_c = np.linalg.norm(solver.c, np.inf)
+  abs_a = abs(solver.a)
+  solver._norm_a_inf = float(abs_a.sum(axis=1).max())
+  solver._norm_a_one = float(abs_a.sum(axis=0).max())
+  solver._norm_p_inf = (
+      float(abs(solver.p).sum(axis=1).max()) if solver.p.nnz else 0.0
+  )
+  solver.it = 0
+  solver.start_time = 0.0
+
+  x = v.copy()
+  y = np.zeros(m)
+  y[z:] = 1e-6
+  s = np.zeros(m)
+  s[z:] = 1e-6
+  tau = 1e-8  # deep in the certificate regime
+
+  ctx = c_adv @ x
+  assert ctx < 0
+
+  # The legacy |c'x|-normalized test would have accepted this pseudo-ray:
+  legacy_dinfeas = np.linalg.norm(a @ x + s, np.inf) / abs(ctx)
+  assert legacy_dinfeas < 1e-8 + 1e-9 * np.linalg.norm(x, np.inf) / abs(ctx)
+
+  # The data-scaled test must reject it: the violations are a sigma_v /
+  # ||A|| fraction of ||A|| ||x||, far above any certificate tolerance.
+  assert sigma_v / norm_a > 1e-3
+  status = solver._check_termination(  # pylint: disable=protected-access
+      x, y, tau, s, alpha=0.5, mu=1.0, sigma=0.5, stats_i={},
+      collect_stats=False,
+  )
+  assert status != qtqp.SolutionStatus.UNBOUNDED
+  assert status != qtqp.SolutionStatus.INFEASIBLE
 
 
 # =============================================================================

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -2985,6 +2985,40 @@ def test_delta_path_local_logged(equilibration):
   assert all(np.isfinite(v) and v > 0 for v in lams)
 
 
+def test_warm_start_same_problem_accepted_and_fast():
+  """Re-solving from a solution certifies near-path and cuts iterations."""
+  rng = np.random.default_rng(9400)
+  m, n, z = 80, 50, 10
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  cold = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False, collect_stats=True)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
+  warm = solver.solve(
+      verbose=False, collect_stats=True, warm_start=(sol.x, sol.y, sol.s)
+  )
+  _assert_solution(warm, a, b, c, p, z)
+  assert solver.warm_accepted
+  assert solver.warm_lambda < 10.0
+  assert len(warm.stats) < len(cold.stats)
+
+
+def test_warm_start_junk_vetoed():
+  """A junk warm point is vetoed by the certificate; solve falls back to
+  the trivial init and still converges."""
+  rng = np.random.default_rng(9500)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  junk = (1e12 * rng.normal(size=n), 1e12 * rng.normal(size=m),
+          np.abs(rng.normal(size=m)))
+  solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
+  warm = solver.solve(
+      verbose=False, collect_stats=True, warm_start=junk,
+      warm_start_threshold=10.0,
+  )
+  _assert_solution(warm, a, b, c, p, z)
+  assert not solver.warm_accepted
+
+
 def test_lambda_init_logged():
   """lambda_init is computed at the initial point and surfaced in stats."""
   rng = np.random.default_rng(9300)


### PR DESCRIPTION
## Summary

Adds certified warm starts: `solve(warm_start=(x, y, s), warm_start_threshold=100.0)` ingests a solution from a nearby problem and enters the path from it **only when the distance-to-path certificate says the entry is sound**.

**Mechanism.** The ingested point is equilibrated into the operating scale, its inequality blocks floored at a shift η (swept over {1e-6, 1e-4, 1e-2, 1}), τ set to 1, and the point normalized. Each candidate embedding is scored by the local-norm certificate λ = ‖T_μ(u)‖_{H⁻¹} at the point's own complementarity (three matvecs, via the `_lambda_local` helper); the best η wins, and the entry is accepted iff λ ≤ `warm_start_threshold`, otherwise the solve falls back to the trivial init. Because the floored point's μ̂ scales with η, the η-sweep doubles as certified entry-μ selection.

**Why this evades the classical warm-start stall.** Warm points carry zeros in y and s at every constraint; classical infeasible-start warm entries stall there (thin neighborhood + near-singular KKT at degenerate active sets). Here: (i) the barrier metric *discounts* boundary-adjacent coordinates (their curvature 1/y² is in H), so certification is judged on the interior structure and Newton fixes the floored coordinates multiplicatively; (ii) the regularized KKT diagonal keeps the system uniformly invertible at any μ, removing the conditioning half of the stall; (iii) when flooring cannot produce a near-path point, the certificate *knows* — the failure mode becomes a clean cold fallback instead of a stall. The certificate exists only because the regularized path map is strongly monotone; merely-monotone embeddings admit no such measure (Clarabel 0.11 exposes no iterate warm start at all — its `update()` reuses the KKT setup but re-solves from the default init, measured identical iteration counts).

## Experiments

Perturbation sequences (9 NETLIB/MM instances × 20-step 1% multiplicative random walks on c and on b, warm-starting each step from the previous solution):

- **1.99× aggregate iteration reduction** vs cold starts; up to 5.5× (sc205, PRIMALC2 ~5×); RHS walks gain less than cost walks, as expected from active-set drift.
- **Zero warm-caused failures; zero steps costing > 3 iterations over cold** (342 warm entries).
- λ at entry forecasts the payoff monotonically (λ ~ 0.06 → 5×; λ ~ 7 → 1.5×): the certificate is both the safety gate and a value estimate.
- Same-problem re-entry: certified λ ~ 1e-2, one iteration to termination.
- Junk warm points (wrong scale, wrong problem) measure λ = ∞ and are vetoed; tests cover both accept-fast and veto paths.
- Against Clarabel on identical sequences: QTQP-warm completes the workload in **45% of Clarabel's iterations** (Clarabel cold ≡ Clarabel `update()`: 6354; QTQP cold 5740; QTQP certified warm 2881).

**Adversarial sequences — the certificate is the feature.** 8 instances × 20-step hostile schedules cycling ±50% objective tilts ("large"), full objective resamples ("fresh"), and warm points poisoned by 1e8 mis-scaling ("junk"); scored on the 118 steps the cold arm can solve (fully-resampled objectives are frequently genuinely unbounded — those steps are excluded for all arms):

| step type | n | cold | certified (θ=100) | naive (always accept) |
|---|---|---|---|---|
| large tilt | 76 | 1247 | **882** | 890 |
| resampled c | 24 | 393 | 363 | 362 |
| poisoned warm point | 18 | 296 | **296** (veto → = cold) | **1510**, incl. one outright failure on a cold-solvable problem |
| total | 118 | 1936 | **1541** | 2762 |

Under adversarial fire, **naive warm starting is net-harmful — 1.43× worse than never warm starting** — while the certified mode stays strictly no-worse-than-cold on every step type and keeps the 1.4× gains where they exist. The veto's discrimination is clean: poisoned entries measure λ ~ 4.5e6, legitimate ones λ ~ 6–11 (four orders of separation), and the certified arm rejected 18/18 poisoned entries while accepting 86/102 legitimate ones. Threshold calibration: θ = 100 (the default) beats θ = 10, which over-vetoes borderline-profitable entries (λ ≈ 10) on both mild and adversarial sequences.

Stacked on #85 (uses its `_lambda_local` certificate machinery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
