### PR TITLE
Fix NameError crash in CupyDenseSolver.update_diag

### DIFF
--- a/src/qtqp/solvers_gpu.py
+++ b/src/qtqp/solvers_gpu.py
@@ -162,6 +162,7 @@ class CupyDenseSolver(LinearSolver):
     self._P_offdiag_gpu = cp.asarray(P_block, dtype=cp.float64)
 
   def update_diag(self, diag: np.ndarray) -> None:
+    cp = self._cp
     self._R_x_gpu.set(diag[:self._n])
     self._R_y_gpu.set(-diag[self._n:])
     cp.divide(1.0, self._R_y_gpu, out=self._inv_R_y_gpu)


### PR DESCRIPTION
The method used `cp.divide`/`cp.sqrt` without binding `cp = self._cp` (every other method in the class binds it; there is no module-level `cp`), so the GPU dense backend crashed with a NameError on the first KKT diagonal update. One-line fix. CI has no GPU runner so this is verified by inspection + AST; a lint step that catches undefined names statically is proposed separately.