### PR TITLE
Validate finiteness of 'a' and 'c' at construction

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -271,6 +271,8 @@ class QTQP:
     # Input validation
     if not sp.isspmatrix_csc(a):
       raise TypeError("Constraint matrix 'a' must be in CSC format.")
+    if not np.all(np.isfinite(a.data)):
+      raise ValueError("Constraint matrix 'a' must contain only finite values.")
     self.a = a
 
     self.b = np.array(b, dtype=np.float64)
@@ -280,6 +282,8 @@ class QTQP:
     self.c = np.array(c, dtype=np.float64)
     if self.c.shape != (self.n,):
       raise ValueError(f"c must have shape ({self.n},), got {self.c.shape}")
+    if not np.all(np.isfinite(self.c)):
+      raise ValueError("Cost vector 'c' must contain only finite values.")
 
     if self.z < 0 or self.z > self.m:
       raise ValueError(

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1044,6 +1044,21 @@ def test_equivalent_tau_solution(seed, linear_solver):
   np.testing.assert_allclose(tau_1, tau_2, atol=1e-11, rtol=1e-11)
 
 
+def test_rejects_nonfinite_a_and_c():
+  """NaN/inf in a.data or c must be rejected at construction, not surface
+  later as a cryptic linear-solver failure."""
+  rng = np.random.default_rng(31)
+  a, b, c, p = _gen_feasible(20, 12, 3, random_state=rng)
+  a_bad = a.copy()
+  a_bad.data[0] = np.nan
+  with pytest.raises(ValueError, match="'a'"):
+    qtqp.QTQP(a=a_bad, b=b, c=c, z=3, p=p)
+  c_bad = c.copy()
+  c_bad[0] = np.inf
+  with pytest.raises(ValueError, match="'c'"):
+    qtqp.QTQP(a=a, b=b, c=c_bad, z=3, p=p)
+
+
 def test_solve_for_tau_handles_linear_equation():
   """Near-zero quadratic coefficient should fall back to a linear solve."""
   p = sparse.csc_matrix((1, 1))


### PR DESCRIPTION
The constructor validated `p` (finite, symmetric) and `b` (per-cone rules), but a NaN/inf in `a.data` or `c` passed through and eventually surfaced as the cryptic "Linear solver returned NaNs" deep in the factorization. Two `np.isfinite` checks at construction, with tests.