### PR TITLE
Make P symmetry tolerance relative to data scale

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -309,9 +309,10 @@ class QTQP:
       if not np.all(np.isfinite(p.data)):
         raise ValueError("QP matrix 'p' must contain only finite values.")
       asymmetry = p - p.T
+      p_scale = max(1.0, np.max(np.abs(p.data), initial=0.0))
       if (
           asymmetry.nnz
-          and np.max(np.abs(asymmetry.data), initial=0.0) > 1e-12
+          and np.max(np.abs(asymmetry.data), initial=0.0) > 1e-12 * p_scale
       ):
         raise ValueError("QP matrix 'p' must be symmetric.")
       self.p = p

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1059,6 +1059,22 @@ def test_rejects_nonfinite_a_and_c():
     qtqp.QTQP(a=a, b=b, c=c_bad, z=3, p=p)
 
 
+def test_symmetry_tolerance_is_relative():
+  """A large-entry symmetric P assembled with roundoff must be accepted:
+  the asymmetry tolerance is relative to max|P|, not absolute."""
+  rng = np.random.default_rng(37)
+  a, b, c, _ = _gen_feasible(20, 12, 3, random_state=rng)
+  q_mat = rng.normal(size=(12, 12)) * 1e8
+  p_dense = q_mat + q_mat.T + np.eye(12) * 1e9
+  # Perturb one entry by an absolute 1e-10 (>> 1e-12 absolute, << relative)
+  p_dense[0, 1] += 1e-10
+  qtqp.QTQP(a=a, b=b, c=c, z=3, p=sparse.csc_matrix(p_dense))  # must not raise
+  # A genuinely asymmetric P at the data scale must still be rejected.
+  p_dense[0, 1] += 1e8
+  with pytest.raises(ValueError, match='symmetric'):
+    qtqp.QTQP(a=a, b=b, c=c, z=3, p=sparse.csc_matrix(p_dense))
+
+
 def test_solve_for_tau_handles_linear_equation():
   """Near-zero quadratic coefficient should fall back to a linear solve."""
   p = sparse.csc_matrix((1, 1))


### PR DESCRIPTION
`max|P − Pᵀ| > 1e-12` rejected legitimately symmetric matrices with large entries (~1e8 assembled with roundoff fails the absolute test). The tolerance is now `1e-12 · max(1, max|P|)` — identical behavior for unit-scale data, correct acceptance at scale. With tests for both acceptance (roundoff-scale asymmetry at 1e9 data scale) and rejection (genuine asymmetry at data scale).