### PR TITLE
Guard GMRES Givens breakdown; canonicalize duplicate CSC entries

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -273,7 +273,15 @@ class QTQP:
       raise TypeError("Constraint matrix 'a' must be in CSC format.")
     if not np.all(np.isfinite(a.data)):
       raise ValueError("Constraint matrix 'a' must contain only finite values.")
-    self.a = a
+    if a.has_canonical_format:
+      self.a = a
+    else:
+      # Non-canonical CSC (duplicate entries) is summed correctly by the
+      # KKT assembly (sp.bmat goes through COO, which sums duplicates)
+      # but not by the equilibration norms, which would see max(|d1|,
+      # |d2|) where the true entry is |d1 + d2|. Canonicalize a copy.
+      self.a = a.copy()
+      self.a.sum_duplicates()
 
     self.b = np.array(b, dtype=np.float64)
     if self.b.shape != (self.m,):
@@ -302,6 +310,9 @@ class QTQP:
     else:
       if not sp.isspmatrix_csc(p):
         raise TypeError("QP matrix 'p' must be in CSC format.")
+      if not p.has_canonical_format:
+        p = p.copy()
+        p.sum_duplicates()
       if p.shape != (self.n, self.n):
         raise ValueError(
             f"p must have shape ({self.n}, {self.n}), got {p.shape}"

--- a/src/qtqp/direct.py
+++ b/src/qtqp/direct.py
@@ -531,8 +531,13 @@ class DirectKktSolver:
 
       # New Givens rotation to zero out h[j+1, j].
       rho = float(np.hypot(h[j, j], h[j + 1, j]))
-      cs[j] = h[j, j] / rho
-      sn[j] = h[j + 1, j] / rho
+      if rho == 0.0:
+        # Breakdown with a zero pivot: both entries vanish, so the
+        # rotation is arbitrary; the identity keeps everything finite.
+        cs[j], sn[j] = 1.0, 0.0
+      else:
+        cs[j] = h[j, j] / rho
+        sn[j] = h[j + 1, j] / rho
       h[j, j] = rho
       h[j + 1, j] = 0.0
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1090,6 +1090,33 @@ def test_presolve_drops_noisy_infinity_sentinels():
   assert solution.status == qtqp.SolutionStatus.SOLVED
 
 
+def test_duplicate_csc_entries_summed():
+  """Non-canonical CSC inputs (duplicate entries) must behave as if the
+  duplicates were summed, including in equilibration norms."""
+  rng = np.random.default_rng(41)
+  a, b, c, p = _gen_feasible(20, 12, 3, random_state=rng)
+  sol_ref = qtqp.QTQP(a=a, b=b, c=c, z=3, p=p).solve(verbose=False)
+  # Build a genuinely non-canonical CSC by duplicating every stored entry
+  # within its column (constructing from COO would sum during conversion).
+  import scipy.sparse as _sp
+  data, indices, indptr = a.data, a.indices, a.indptr
+  new_data, new_indices, new_indptr = [], [], [0]
+  for col in range(a.shape[1]):
+    lo, hi = indptr[col], indptr[col + 1]
+    new_data.extend(0.5 * data[lo:hi]); new_data.extend(0.5 * data[lo:hi])
+    new_indices.extend(indices[lo:hi]); new_indices.extend(indices[lo:hi])
+    new_indptr.append(len(new_indices))
+  dup = _sp.csc_matrix(
+      (np.array(new_data), np.array(new_indices), np.array(new_indptr)),
+      shape=a.shape,
+  )
+  assert dup.nnz == 2 * a.nnz  # genuinely non-canonical
+  sol_dup = qtqp.QTQP(a=dup, b=b, c=c, z=3, p=p).solve(verbose=False)
+  np.testing.assert_allclose(
+      c @ sol_dup.x, c @ sol_ref.x, atol=1e-6, rtol=1e-6
+  )
+
+
 def test_solve_for_tau_handles_linear_equation():
   """Near-zero quadratic coefficient should fall back to a linear solve."""
   p = sparse.csc_matrix((1, 1))


### PR DESCRIPTION
Two small numeric edge cases from the review: (1) the GMRES Givens rotation divides by `rho = hypot(h[j,j], h[j+1,j])`, which is zero on a Krylov breakdown with a zero pivot — NaN rotations; the identity rotation is used instead (both entries vanish, so the rotation is arbitrary). (2) Non-canonical CSC inputs with duplicate entries were handled correctly by KKT assembly (`sp.bmat` → COO sums duplicates) but not by the equilibration norms, which take `max(|d1|,|d2|)` where the true entry is `|d1+d2|` — `sum_duplicates()` on copies at construction closes the inconsistency. Test constructs a genuinely non-canonical CSC (direct `(data, indices, indptr)` build; COO conversion would sum) and checks solve equivalence.