### PR TITLE
Tolerate representation noise in the presolve infinity sentinel

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -334,7 +334,12 @@ class QTQP:
           "Inequality RHS entries in 'b' must be finite, +inf, or >= inf_bound."
       )
     drop = np.zeros(self.m, dtype=bool)
-    drop[self.z :] = ineq_b >= inf_bound
+    # Tolerate representation noise in the sentinel: benchmark files store
+    # +-1e20 infinity markers with ULP- or float32-level error (e.g.
+    # 9.999999999999998e19), which a strict >= comparison classifies as a
+    # genuine finite bound -- materializing a 1e20-magnitude row that
+    # silently poisons equilibration and residual scales.
+    drop[self.z :] = ineq_b >= inf_bound * (1.0 - 1e-6)
     if not np.any(drop):
       return
     keep = ~drop

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1075,6 +1075,21 @@ def test_symmetry_tolerance_is_relative():
     qtqp.QTQP(a=a, b=b, c=c, z=3, p=sparse.csc_matrix(p_dense))
 
 
+def test_presolve_drops_noisy_infinity_sentinels():
+  """Bounds within representation noise of the 1e20 infinity sentinel
+  (ULP or float32 storage error) must be dropped like the exact value."""
+  rng = np.random.default_rng(47)
+  a, b, c, p = _gen_feasible(20, 12, 3, random_state=rng)
+  b_noisy = b.copy()
+  b_noisy[5] = 9.999999999999998e19   # ULP-corrupted sentinel
+  b_noisy[6] = np.float64(np.float32(1e20))  # float32-stored sentinel
+  b_noisy[7] = 1e20                   # exact sentinel
+  solver = qtqp.QTQP(a=a, b=b_noisy, c=c, z=3, p=p)
+  assert solver.m == 17  # all three rows dropped
+  solution = solver.solve(verbose=False)
+  assert solution.status == qtqp.SolutionStatus.SOLVED
+
+
 def test_solve_for_tau_handles_linear_equation():
   """Near-zero quadratic coefficient should fall back to a linear solve."""
   p = sparse.csc_matrix((1, 1))


### PR DESCRIPTION
QTQP's own `_presolve` had the same off-by-ULP blind spot just fixed in the benchmark harness: `b >= 1e20` with strict comparison misses sentinels stored with ULP or float32 representation error (e.g. `9.999999999999998e19`, exactly what several Maros–Mészáros files contain), materializing 1e20-magnitude rows that silently poison equilibration and residual scaling — the root cause of the historical 'chronic' benchmark failures. Drop anything within relative 1e-6 of the sentinel (covers float32 error ~1.2e-7 with margin). Test covers ULP-corrupted, float32-stored, and exact sentinels.