### PR TITLE
Tighten defaults to atol=rtol=1e-9; add ALMOST_SOLVED status

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ This class has a single API method `solve`:
 ```python
 solve(
     *,
-    atol: float = 1e-7,
-    rtol: float = 1e-8,
+    atol: float = 1e-9,
+    rtol: float = 1e-9,
     atol_infeas: float = 1e-8,
     rtol_infeas: float = 1e-9,
     max_iter: int = 100,
@@ -278,7 +278,15 @@ This method will return a `qtqp.Solution` object, with fields:
 -   `y`: (m) Dual variable or certificate of infeasibility.
 -   `s`: (m) Slack variable or certificate of unboundedness.
 -   `status`: (`qtqp.SolutionStatus`) One of `SOLVED`, `INFEASIBLE`,
-    `UNBOUNDED`, `HIT_MAX_ITER`, `FAILED`.
+    `UNBOUNDED`, `ALMOST_SOLVED`, `HIT_MAX_ITER`, `FAILED`.
+    `ALMOST_SOLVED` is returned in place of `HIT_MAX_ITER` (or of a
+    numerical breakdown of the linear solver, which never raises) when
+    the best iterate over the trajectory (by max normalized residual)
+    meets the solved-criteria form at tolerances `1000x` looser than the
+    requested `atol`/`rtol` (so `1e-6` at the defaults): the returned
+    solution is that best iterate, honestly labeled as not meeting the
+    full `SOLVED` contract. `SOLVED` semantics are unchanged. A
+    breakdown whose best iterate does not qualify returns `FAILED`.
 -   `stats`: (list of dicts) Per-iteration diagnostics. Empty unless
     `collect_stats=True`. When enabled, includes primal/dual objective,
     residuals, gap, mu, elapsed time, and complementarity statistics.

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -63,6 +63,15 @@ _EPS = 1e-15  # Standard epsilon for numerical safety
 # collapse). Healthy solves terminate at mu ~ 1e-9..1e-11 and never
 # touch the floor.
 _MU_FLOOR = 1e-14
+# ALMOST_SOLVED acceptance: on HIT_MAX_ITER or numerical breakdown of
+# the linear solver, the best iterate over the trajectory (min over
+# iterations of the max normalized residual) is returned with status
+# ALMOST_SOLVED when it meets the same criteria form at tolerances this
+# factor looser than the user-requested atol/rtol (at the 1e-9
+# defaults: 1e-6). Relative to the request, so the label keeps its
+# meaning at any tolerance setting. SOLVED semantics are unchanged and
+# unambiguous.
+_ALMOST_FACTOR = 1000.0
 
 
 class LinearSolver(enum.Enum):
@@ -147,6 +156,7 @@ class SolutionStatus(enum.Enum):
   INFEASIBLE = "infeasible"
   UNBOUNDED = "unbounded"
   HIT_MAX_ITER = "hit_max_iter"
+  ALMOST_SOLVED = "almost_solved"
   FAILED = "failed"
   UNFINISHED = "unfinished"
 
@@ -341,6 +351,11 @@ class QTQP:
         raise ValueError("QP matrix 'p' must be symmetric.")
       self.p = p
 
+    # Defaults so _check_termination works in tests that call it
+    # directly before solve() has initialized the tracking state.
+    self._best_almost_score = math.inf
+    self._best_almost_iterate = None
+
   def _presolve(self, inf_bound: float = 1e20):
     """Drop inequality rows with trivially-satisfied RHS (b[i] >= inf_bound
     or +inf). Equality RHS must be finite; inequality RHS may not be NaN or -inf.
@@ -518,8 +533,8 @@ class QTQP:
   def solve(
       self,
       *,
-      atol: float = 1e-7,
-      rtol: float = 1e-8,
+      atol: float = 1e-9,
+      rtol: float = 1e-9,
       atol_infeas: float = 1e-8,
       rtol_infeas: float = 1e-9,
       max_iter: int = 100,
@@ -576,8 +591,8 @@ class QTQP:
   def _solve_impl(
       self,
       *,
-      atol: float = 1e-7,
-      rtol: float = 1e-8,
+      atol: float = 1e-9,
+      rtol: float = 1e-9,
       atol_infeas: float = 1e-8,
       rtol_infeas: float = 1e-9,
       max_iter: int = 100,
@@ -757,6 +772,8 @@ class QTQP:
         init_strategy, init_mu_scale, a, p, b, c
     )
     status = SolutionStatus.UNFINISHED
+    self._best_almost_score = math.inf
+    self._best_almost_iterate = None
 
     # Certified warm start: ingest a caller-supplied (x, y, s) from a
     # nearby problem, embed it interior at a few centering shifts, and
@@ -994,12 +1011,16 @@ class QTQP:
         status = SolutionStatus.HIT_MAX_ITER
         if collect_stats:
           stats[-1]["status"] = status
-
     except (ValueError, ArithmeticError, np.linalg.LinAlgError) as exc:
-      logging.warning("Numeric failure at iteration %d: %s", self.it, exc)
-      status = SolutionStatus.UNFINISHED
-      if collect_stats and stats:
-        stats[-1]["status"] = SolutionStatus.FAILED
+      # Numerical breakdown inside the iteration (singular KKT systems,
+      # NaN propagation, degenerate tau equations at extreme conditioning
+      # in the deep endgame). The iterates preceding the breakdown are
+      # intact and the best one is already tracked, so salvage it below
+      # instead of crashing. Programming errors still propagate.
+      logging.warning(
+          "Numeric failure at iteration %d: %s", self.it, exc
+      )
+      status = SolutionStatus.FAILED
 
     # We have terminated for one reason or another.
     if self.equilibration_strategy is not EquilibrationStrategy.NONE:
@@ -1024,8 +1045,17 @@ class QTQP:
         x, s = x / abs_ctx, s / abs_ctx
         y, s = self._postsolve(y, s, y_dropped=np.nan)
         return Solution(x, y, s, stats, status)
-      case SolutionStatus.HIT_MAX_ITER:
-        self._log_footer("Hit maximum iterations")
+      case SolutionStatus.HIT_MAX_ITER | SolutionStatus.FAILED:
+        if self._best_almost_score <= 1.0:
+          self._log_footer("Almost solved (best iterate)")
+          bx, by, bs, btau = self._best_almost_iterate
+          x, y, s = bx / btau, by / btau, bs / btau
+          y, s = self._postsolve(y, s, s_dropped=self._dropped_slack(x))
+          return Solution(x, y, s, stats, SolutionStatus.ALMOST_SOLVED)
+        if status is SolutionStatus.HIT_MAX_ITER:
+          self._log_footer("Hit maximum iterations")
+        else:
+          self._log_footer("Linear solver breakdown")
         x, y, s = x / tau, y / tau, s / tau
         y, s = self._postsolve(y, s, s_dropped=self._dropped_slack(x))
         return Solution(x, y, s, stats, status)
@@ -1567,6 +1597,21 @@ class QTQP:
         min(abs(pcost), abs(dcost)),
         (norm_x + norm_y) * inv_tau,
     )
+
+    # Track the best iterate seen, scored by the max normalized residual
+    # at the ALMOST_SOLVED thresholds (same criteria form, looser
+    # constants). Used to return an honestly-labeled near-solution when
+    # the iteration cap is reached without meeting the SOLVED contract.
+    almost_atol = _ALMOST_FACTOR * self.atol
+    almost_rtol = _ALMOST_FACTOR * self.rtol
+    almost_score = max(
+        gap / (almost_atol + almost_rtol * gaprelrhs),
+        pres / (almost_atol + almost_rtol * prelrhs),
+        dres / (almost_atol + almost_rtol * drelrhs),
+    )
+    if almost_score < self._best_almost_score:
+      self._best_almost_score = almost_score
+      self._best_almost_iterate = (x.copy(), y.copy(), s.copy(), tau)
 
     # Solved: duality gap and both residuals are within tolerance.
     if (

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1161,6 +1161,88 @@ def test_numeric_failure_returns_failed_status():
     solver2.solve(verbose=False)
 
 
+def test_default_tolerances_are_1e9():
+  import inspect
+  sig = inspect.signature(qtqp.QTQP.solve)
+  assert sig.parameters['atol'].default == 1e-9
+  assert sig.parameters['rtol'].default == 1e-9
+
+
+def test_almost_solved_near_cap():
+  """Capping one iteration below the solve count returns the best iterate
+  with ALMOST_SOLVED (it meets the 1e-6 criteria form), while a very early
+  cap still returns HIT_MAX_ITER."""
+  rng = np.random.default_rng(9600)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  kw = dict(verbose=False, linear_solver=qtqp.LinearSolver.SCIPY)
+  full = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(collect_stats=True, **kw)
+  assert full.status == qtqp.SolutionStatus.SOLVED
+  n_it = len(full.stats)
+  near = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(max_iter=n_it - 1, **kw)
+  assert near.status == qtqp.SolutionStatus.ALMOST_SOLVED
+  # The returned best iterate is a genuine near-solution.
+  sv = b - a @ near.x
+  pres = max(np.max(np.abs(sv[:z]), initial=0.0),
+             np.max(np.maximum(-sv[z:], 0.0), initial=0.0))
+  assert pres < 1e-4 * (1 + np.max(np.abs(b)))
+  early = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(max_iter=2, **kw)
+  assert early.status == qtqp.SolutionStatus.HIT_MAX_ITER
+
+
+def test_linear_solver_breakdown_returns_best_iterate(monkeypatch):
+  """A linear-solver breakdown mid-solve must not raise: a late breakdown
+  returns the tracked best iterate as ALMOST_SOLVED, an immediate one
+  returns FAILED (regression: DUALC8 / brazil3 NaN under QDLDL at 1e-9)."""
+  from qtqp import direct as qtqp_direct
+
+  rng = np.random.default_rng(9700)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  kw = dict(verbose=False, linear_solver=qtqp.LinearSolver.SCIPY)
+  original = qtqp_direct.DirectKktSolver.solve
+
+  calls = {'n': 0}
+  def counting(self, *args, **kwargs):
+    calls['n'] += 1
+    return original(self, *args, **kwargs)
+  monkeypatch.setattr(qtqp_direct.DirectKktSolver, 'solve', counting)
+  full = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(**kw)
+  assert full.status == qtqp.SolutionStatus.SOLVED
+  total = calls['n']
+
+  def breaking_after(limit):
+    state = {'n': 0}
+    def solve(self, *args, **kwargs):
+      state['n'] += 1
+      if state['n'] > limit:
+        raise ValueError('Linear solver returned NaNs.')
+      return original(self, *args, **kwargs)
+    return solve
+
+  # Breakdown on the very last solve: all but the final iteration completed,
+  # so the tracked best iterate qualifies at the ALMOST thresholds.
+  monkeypatch.setattr(
+      qtqp_direct.DirectKktSolver, 'solve', breaking_after(total - 1)
+  )
+  late = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(**kw)
+  assert late.status == qtqp.SolutionStatus.ALMOST_SOLVED
+  assert np.all(np.isfinite(late.x))
+  sv = b - a @ late.x
+  pres = max(np.max(np.abs(sv[:z]), initial=0.0),
+             np.max(np.maximum(-sv[z:], 0.0), initial=0.0))
+  assert pres < 1e-4 * (1 + np.max(np.abs(b)))
+
+  # Breakdown in the first iteration, before any termination check: no
+  # iterate has been tracked, so the solve reports FAILED (and still does
+  # not raise).
+  monkeypatch.setattr(
+      qtqp_direct.DirectKktSolver, 'solve', breaking_after(2)
+  )
+  early_break = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(**kw)
+  assert early_break.status == qtqp.SolutionStatus.FAILED
+
+
 def test_solve_for_tau_handles_linear_equation():
   """Near-zero quadratic coefficient should fall back to a linear solve."""
   p = sparse.csc_matrix((1, 1))


### PR DESCRIPTION
Per the measured tolerance frontier: at 1e-9/1e-9 QTQP delivers Clarabel-grade true accuracy (dres 7.3e-10, gap 2.4e-10 — tighter than Clarabel's true 1.6e-9 gap) at +7.4% iterations, 212 strict solves vs Clarabel's 208 on the supported NETLIB+MM set. New ALMOST_SOLVED: on iteration cap, the best trajectory iterate (argmin max-normalized-residual) is returned when it meets the same criteria form at 1e-6 — an honest distinct status, never a disguised SOLVED (d6cube returns ALMOST_SOLVED with best-iterate pres_rel 9e-11). ALMOST_SOLVED counts as not-solved in all benchmark tallies, matching the convention applied to Clarabel. Stacked on #97.

**Breakdown handling (added):** tightening the defaults exposed a crash class — on ill-conditioned instances (MM DUALC8, MIPLIB brazil3, both solved at 1e-7) the deep 1e-9 endgame can drive an unpivoted backend (QDLDL) to NaN, which previously escaped `solve()` as an unhandled `ValueError`. The main loop now catches linear-solver breakdown and exits through the same best-iterate gate as the iteration cap: `ALMOST_SOLVED` when the tracked best iterate meets the 1000x-relative thresholds, `FAILED` otherwise; `solve()` no longer raises on numerical breakdown. Both known crashers now return `ALMOST_SOLVED` with near-tolerance residuals (DUALC8 dres 5.0e-9 / gap 1.5e-9; brazil3 pres 3.5e-12 / gap 1.9e-8). Regression test injects breakdown at the last solve (→ `ALMOST_SOLVED`) and in the first iteration (→ `FAILED`).

**Cost note:** the tighter defaults roughly double CI suite wall time (~30 → ~70 min), concentrated in the MUMPS-backend column of the test matrix (all 30 slowest tests; the 12 `*_large[MUMPS-*]` cases at 100–142 s each) — the 1e-9 endgame is cheap on most instances and expensive on slow-tail families (LISWET/STADAT class), which is the same tail that loses the 3 solves at 1e-9 in the frontier data.