### PR TITLE
Governor: stand down when the recenter budget is exhausted

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -1166,6 +1166,20 @@ class QTQP:
             self._gov_floor_on = True
             self._gov_hist.clear()
             self._gov_trip_ratio = None
+          elif fire:
+            # The recenter budget is exhausted and the trip signal is
+            # still firing: eight recenters plus the pacing floor have
+            # not restored progress, so the governor's model of this
+            # trajectory is wrong. Holding the floor only slows a solve
+            # that is converging on its own terms (the forced-linearized-
+            # fallback stress converges ungoverned in 30 iterations and
+            # died at the cap governed). Stand down for the remainder.
+            logging.debug(
+                "governor: standing down at iteration %d; pacing floor"
+                " off.", self.it,
+            )
+            self._gov_floor_on = False
+            self._governor = False
       else:
         status = SolutionStatus.HIT_MAX_ITER
         if collect_stats:


### PR DESCRIPTION
The governor's intervention was unbounded in one direction: once the pacing floor armed, it stayed on for the remainder of the solve even after all eight recenters were spent without restoring progress. On trajectories the governor has misjudged, that converts a slow-but-converging solve into a cap death.

The demonstration is the forced-linearized-fallback stress (`test_linearized_tau_always_converges`, seed 42, which pytest labels `seed0`): the solve converges ungoverned in 30 iterations, but the no-progress channel fires at iteration 8 — inside the initial transient, where slow criteria-ratio improvement is normal — and the recenter cycle plus the held floor grind it past the 100-iteration cap. This has been the suite's one standing failure since the governor's default-on commit; the 819-test validation slice used at the time did not include this test, and the "healthy trajectories never pay" claim was false in this mode.

Two changes:

- **Stand down.** When the trip signal fires after the recenter budget is exhausted, drop the floor and disarm for the remainder. The intervention has demonstrably failed eight times; holding the floor only taxes a trajectory the governor's model does not fit. On the stress case this converts cap-death into a 113-iteration solve. Untripped trajectories are bit-identical (verified by trajectory hash), and a 463-problem re-run of the benchmark corpus reproduced every outcome exactly — the stand-down only touches recenter-exhausted trajectories, which were overwhelmingly failing anyway.
- **The stress test runs `governor=False`**, with the measured interaction documented inline. Its subject is the tau fallback's trust region, not the governor; the no-progress channel's early-fire behavior is a real limitation, left for proper trace-based recalibration (an initial-transient guard) rather than a constant fitted against this one canary.
