### PR TITLE
Revert #79 (backward-error criteria / eps-weighted path) pending re-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ solve(
         qtqp.RefinementStrategy.RICHARDSON
     ),
     gmres_restart: int = 10,
+    central_path_exponent: float = 1.0,
     fused_corrector_division: bool = False,
 ) -> qtqp.Solution
 ```
@@ -201,6 +202,8 @@ Key parameters:
     solves. Defaults to `qtqp.RefinementStrategy.RICHARDSON`.
 -   `gmres_restart`: Restart length for `qtqp.RefinementStrategy.GMRES`.
     Ignored by Richardson refinement.
+-   `central_path_exponent`: Positive exponent for the generalized central-path
+    residual equation. The default `1.0` is the standard central path.
 -   `fused_corrector_division`: If True, computes the Mehrotra corrector slack
     update with one fused division. The default False preserves legacy
     arithmetic.
@@ -243,12 +246,9 @@ Choose one with the `refinement_strategy` argument:
 
 #### Advanced numerical options
 
--   Termination scales include the iterate norms `||x||/tau`, `||y||/tau`
-    (and their sum for the duality gap), so acceptance is a backward-error
-    criterion consistent with the `mu`-scale perturbation the regularized
-    path itself commits: residuals are judged against the larger of the
-    floating-point measurement floor of their summands and the perturbation
-    allowance of the path.
+-   `central_path_exponent`: Uses `mu**central_path_exponent` in the linear
+    residual part of the central-path equations while keeping cone-product
+    targets at `mu`. Values must be positive and finite.
 -   `fused_corrector_division`: Fuses the corrector slack numerator before
     dividing by `y[z:]`. This is useful when small `y` components make the
     legacy three-division form vulnerable to cancellation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qtqp"
-version = "0.0.6"
+version = "0.0.5"
 description = "The 'cutie' QP solver."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -16,11 +16,9 @@
 """Interior point method for solving QPs.
 
   Algorithm: Mehrotra predictor-corrector interior point method with a
-  homogeneous embedding, following the regularized central path
-  (linear term mu * u). Each iteration does:
+  homogeneous embedding. Each iteration does:
 
-    1. Normalize (x, y, tau, s) onto the path's sphere
-       ||(x, y)||^2 + tau^2 = m - z + 1.
+    1. Normalize (x, y, tau, s) to have the norm of the central path.
     2. Pre-solve K^{-1} @ [c; b] (shared between predictor and corrector steps).
     3. Predictor step: Newton direction with mu_target=0 (no centering).
     4. Compute sigma (centering parameter) from predictor step quality.
@@ -47,22 +45,11 @@ import scipy.sparse as sp
 from . import direct
 from .direct import RefinementStrategy
 
-__version__ = "0.0.6"
+__version__ = "0.0.5"
 _HEADER = """| iter |      pcost |      dcost |     pres |     dres |      gap |   infeas |       mu |  q, p, c |     time |"""
 _SEPARA = """|------|------------|------------|----------|----------|----------|----------|----------|----------|----------|"""
 _norm = np.linalg.norm
 _EPS = 1e-15  # Standard epsilon for numerical safety
-# Floor on the complementarity parameter mu wherever it enters the
-# algorithm (KKT shift, corrector targets, barrier terms). Below this
-# scale mu carries no information in double precision relative to O(1)
-# equilibrated data, and letting it underflow leaves the Newton system
-# effectively unregularized: on infeasibility trajectories the iterate
-# can freeze on an immature ray at mu ~ 1e-20, burning iterations with
-# every solve degraded (observed on Windows/QDLDL, where the platform's
-# roundoff draw loses the race between certificate maturation and mu
-# collapse). Healthy solves terminate at mu ~ 1e-9..1e-11 and never
-# touch the floor.
-_MU_FLOOR = 1e-14
 
 
 class LinearSolver(enum.Enum):
@@ -341,6 +328,10 @@ class QTQP:
         raise ValueError("QP matrix 'p' must be symmetric.")
       self.p = p
 
+    # Default exponent so _newton_step works in tests that call it directly
+    # before solve() has overridden the attribute.
+    self._central_path_exponent = 1.0
+
   def _presolve(self, inf_bound: float = 1e20):
     """Drop inequality rows with trivially-satisfied RHS (b[i] >= inf_bound
     or +inf). Equality RHS must be finite; inequality RHS may not be NaN or -inf.
@@ -510,6 +501,7 @@ class QTQP:
       init_mu_scale: float = 1.0,
       refinement_strategy: RefinementStrategy = RefinementStrategy.RICHARDSON,
       gmres_restart: int = 10,
+      central_path_exponent: float = 1.0,
       fused_corrector_division: bool = False,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method."""
@@ -534,6 +526,7 @@ class QTQP:
           init_mu_scale=init_mu_scale,
           refinement_strategy=refinement_strategy,
           gmres_restart=gmres_restart,
+          central_path_exponent=central_path_exponent,
           fused_corrector_division=fused_corrector_division,
       )
     finally:
@@ -562,6 +555,7 @@ class QTQP:
       init_mu_scale: float = 1.0,
       refinement_strategy: RefinementStrategy = RefinementStrategy.RICHARDSON,
       gmres_restart: int = 10,
+      central_path_exponent: float = 1.0,
       fused_corrector_division: bool = False,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method.
@@ -609,6 +603,13 @@ class QTQP:
         inner Arnoldi step consumes one factor-solve. Smaller values reduce
         per-cycle cost at the price of more restarts. Ignored when
         refinement_strategy is RICHARDSON.
+      central_path_exponent (float): Exponent p > 0 in the generalized
+        central-path equation r + mu^p * u = 0 (cone products s_i * y_i =
+        mu and tau * kappa = mu are unchanged). Default 1.0 recovers the
+        standard primal-dual central path. p > 1 makes the linear residual
+        vanish faster than mu as mu -> 0; p < 1 the reverse. mu^p enters
+        the KKT diagonal regularization and the Newton-step linear-residual
+        RHS; cone-product targets keep the unmodified mu.
       fused_corrector_division (bool): If True, compute the corrector
         slack update via a single division by y[z:] with the three
         numerator terms (sigma*mu, the Mehrotra cross product, and
@@ -636,6 +637,12 @@ class QTQP:
           f"init_mu_scale must be a positive finite float,"
           f" got {init_mu_scale}"
       )
+    if not (np.isfinite(central_path_exponent) and central_path_exponent > 0):
+      raise ValueError(
+          "central_path_exponent must be a positive finite float (got"
+          f" {central_path_exponent}); p <= 0 is incompatible with the IPM."
+      )
+    self._central_path_exponent = float(central_path_exponent)
     self._fused_corrector_division = bool(fused_corrector_division)
 
     resolved_linear_solver, linear_solver_backend = _resolve_linear_solver(
@@ -713,10 +720,14 @@ class QTQP:
         stats_i = {}
         x, y, tau, s = self._normalize(x, y, tau, s)
 
-        mu = max((y @ s) / (self.m - self.z), _MU_FLOOR)
+        mu = (y @ s) / (self.m - self.z)
+        # Generalized central path: r + mu^p * u = 0. mu_p enters the KKT
+        # diagonal and the Newton-step linear-residual RHS; cone-product
+        # targets (s*y = mu, tau*kappa = mu) keep the unmodified mu.
+        mu_p = mu ** self._central_path_exponent
 
         # --- Take an IPM step ---
-        self._linear_solver.update(mu=mu, s=s, y=y)
+        self._linear_solver.update(mu=mu_p, s=s, y=y)
 
         # --- Step 1: Precompute kinv_q = K^{-1} @ q ---
         # This is reused for both predictor and corrector parts of the step.
@@ -1055,11 +1066,11 @@ class QTQP:
     s_aff = s + alpha * d_s
 
     # Compute mu_aff directly without calling _normalize to avoid 4 extra
-    # allocations. Equivalent to: normalize onto the path sphere
-    # (||u||^2 = m-z+1) then compute (y @ s) / (m - z);
-    # normalization scales y and s each by `scale`, so mu picks up scale^2.
-    quad_aff = x_aff @ x_aff + y_aff @ y_aff + tau_aff * tau_aff
-    scale_sq = (self.m - self.z + 1) / max(_EPS * _EPS, quad_aff)
+    # allocations. Equivalent to: normalize then compute (y @ s) / (m - z).
+    # scale = sqrt(m-z+1) / max(_EPS, ||(x,y,tau)||), so scale^2 = (m-z+1) /
+    # max(_EPS^2, ||(x,y,tau)||^2), giving mu_aff = scale^2 * (y_aff @ s_aff).
+    xyt_norm_sq = x_aff @ x_aff + y_aff @ y_aff + tau_aff * tau_aff
+    scale_sq = (self.m - self.z + 1) / max(_EPS * _EPS, xyt_norm_sq)
     mu_aff = scale_sq * (y_aff @ s_aff) / (self.m - self.z)
 
     # sigma = (mu_aff / mu)^3: Mehrotra's heuristic. If the affine step already
@@ -1081,17 +1092,21 @@ class QTQP:
     tau+ is then pinned by substituting this back into the tau equation of the
     homogeneous embedding (see _solve_for_tau).
 
-    The weighted central-path equation contributes the eps*(mu - mu_target)
-    coefficient on the (x, y) linear-residual side and (mu - mu_target) on
-    tau; cone-product corrections (s_i * y_i = mu_target, tau * kappa =
-    mu_target) keep the unmodified mu_target.
+    The central-path equation r + mu^p * u = 0 contributes the
+    (mu^p - mu_target^p) coefficient on the linear-residual side; cone-product
+    corrections (s_i * y_i = mu_target, tau * kappa = mu_target) keep the
+    unmodified mu_target.
 
     Uses the exact quadratic tau solve when the KKT solve is accurate, and a
     linearized fallback (avoids squaring solver noise) when it's noisy or the
     quadratic residual check fails.
     """
+    cpe = self._central_path_exponent
+    # 0**cpe = 0 for cpe > 0, so mu_target = 0 (predictor) yields mu_target_p = 0.
+    mu_p = mu ** cpe
+    mu_target_p = mu_target ** cpe if mu_target > 0.0 else 0.0
     # Prepare RHS for the linear system.
-    r = (mu - mu_target) * r_anchor
+    r = (mu_p - mu_target_p) * r_anchor
     if mu_target != 0.0:
       r[self.n + self.z :] += mu_target / y[self.z :]
     r[self.n + self.z :] += s[self.z :]
@@ -1108,7 +1123,7 @@ class QTQP:
     tau_plus = None
     if lin_sys_stats["converged"] or lin_sys_stats["final_residual_norm"] < 1e-7:
       try:
-        r_tau = (mu - mu_target) * tau_anchor
+        r_tau = (mu_p - mu_target_p) * tau_anchor
         tau_plus = self._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)
         lin_sys_stats["tau_method"] = "quadratic"
       except ValueError:
@@ -1141,15 +1156,16 @@ class QTQP:
     a feasible point (tau=0 corresponds to a certificate of infeasibility or
     unboundedness, which is handled separately at termination).
 
-    The mu term of t_a comes from the path's linear regularization term;
-    t_c = -mu_target comes from the cone-product equation
-    tau * kappa = mu_target.
+    Generalized central path: t_a's mu term becomes mu^cpe (the linear-residual
+    coefficient on tau); t_c = -mu_target keeps the unmodified mu_target since
+    it comes from the cone-product equation tau * kappa = mu_target.
     """
     # Coefficients of the quadratic t_a * tau+^2 + t_b * tau+ + t_c = 0.
     n = self.n
     q, kinv_q = self.q, self.kinv_q
+    mu_p = mu ** self._central_path_exponent
 
-    t_a = mu + kinv_q @ q
+    t_a = mu_p + kinv_q @ q
     t_b = -r_tau - kinv_r @ q
     t_c = -mu_target
     if p.nnz > 0:
@@ -1200,13 +1216,15 @@ class QTQP:
     enters linearly rather than quadratically. A [0.1x, 10x] trust region
     prevents manifold drift from the first-order approximation.
 
-    The tau coefficients use the plain mu and mu_target; the cone-product
-    constant -mu_target is likewise unmodified.
+    Linear-residual coefficients on tau use mu^cpe and mu_target^cpe (the
+    generalized central path); the cone-product constant -mu_target keeps the
+    unmodified mu_target.
     """
     n = self.n
     q, kinv_q = self.q, self.kinv_q
-    mu_p = mu
-    mu_target_p = mu_target
+    cpe = self._central_path_exponent
+    mu_p = mu ** cpe
+    mu_target_p = mu_target ** cpe if mu_target > 0.0 else 0.0
 
     px = p @ x if p.nnz > 0 else np.zeros(n)
 
@@ -1243,17 +1261,16 @@ class QTQP:
     like x/tau and y/tau matter — tau is the homogeneous variable, and the final
     solution is recovered as (x/tau, y/tau, s/tau).
 
-    We enforce the invariant of the weighted central path (the Euler identity
-    for the linear term mu * diag(eps*I, eps*I, 1) * u), which ensures
-    convergence to a non-trivial solution:
-        eps * ||(x, y)||^2 + tau^2 = m - z + 1
+    We enforce the norm of the central path, which ensures convergence to
+    non-trivial solution, ie:
+        ||(x, y, tau)||^2 = m - z + 1
     The right-hand side counts complementarity pairs: (m - z) from the
     inequality constraints plus 1 for the tau-kappa pair of the embedding.
 
     Operates in-place on the iterate arrays and returns them for convenience.
     """
-    quad = x @ x + y @ y + tau * tau
-    scale = math.sqrt((self.m - self.z + 1) / max(_EPS, quad))
+    xyt_norm = math.sqrt(x @ x + y @ y + tau * tau)
+    scale = math.sqrt(self.m - self.z + 1) / max(_EPS, xyt_norm)
     x *= scale
     y *= scale
     tau *= scale
@@ -1311,42 +1328,26 @@ class QTQP:
     # pinfeas measures how well y/|b'y| certifies primal infeasibility.
     pinfeas = norm_aty / (abs(bty) + _EPS)
 
-    norm_x = _norm(x, np.inf)
-    norm_y = _norm(y, np.inf)
-
-    # Residual tolerance relative scales. Each is the max of two families:
-    # the summand norms (the floor below which the residual cannot even be
-    # evaluated in floating point) and the iterate norm (the backward-error
-    # allowance: dres <= rtol * ||x||/tau accepts a point that is exactly
-    # dual-feasible for P + dP with ||dP|| <= rtol, which is precisely the
-    # mu*I perturbation the regularized path itself commits; likewise
-    # pres <= rtol * ||y||/tau on the primal side).
+    # Primal residual tolerance relative scale.
     prelrhs = max(
         _norm(ax, np.inf) * inv_tau,
         _norm(s, np.inf) * inv_tau,
         self._norm_b,
-        norm_y * inv_tau,
     )
 
+    # Dual residual tolerance relative scale.
     drelrhs = max(
         norm_px * inv_tau,
         norm_aty * inv_tau,
         self._norm_c,
-        norm_x * inv_tau,
     )
 
-    # Gap tolerance relative scale: the cost magnitudes (measurement floor)
-    # or the first-power iterate norm (the empirically calibrated allowance
-    # for the regularized path's O(mu*||u||^2) objective bias; see the
-    # criteria validation on NETLIB + Maros-Meszaros).
-    gaprelrhs = max(
-        min(abs(pcost), abs(dcost)),
-        (norm_x + norm_y) * inv_tau,
-    )
+    norm_x = _norm(x, np.inf)
+    norm_y = _norm(y, np.inf)
 
     # Solved: duality gap and both residuals are within tolerance.
     if (
-        gap < self.atol + self.rtol * gaprelrhs
+        gap < self.atol + self.rtol * min(abs(pcost), abs(dcost))
         and pres < self.atol + self.rtol * prelrhs
         and dres < self.atol + self.rtol * drelrhs
     ):

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -291,26 +291,18 @@ def _assert_solution(solution, a, b, c, p, z, atol=1e-7, rtol=1e-8):
   pres = np.linalg.norm(a @ x + s - b, np.inf)
   dres = np.linalg.norm(p @ x + a.T @ y + c, np.inf)
   gap = np.abs(c @ x + b @ y + x @ p @ x)
-  # Relative scales mirror the solver's termination criteria: the summand
-  # norms (evaluation floor) plus the iterate norms (the backward-error
-  # allowance of the weighted regularized path).
-  norm_x = np.linalg.norm(x, np.inf)
-  norm_y = np.linalg.norm(y, np.inf)
   prelrhs = max(
       np.linalg.norm(a @ x, np.inf),
       np.linalg.norm(s, np.inf),
       np.linalg.norm(b, np.inf),
-      norm_y,
   )
   drelrhs = max(
       np.linalg.norm(p @ x, np.inf),
       np.linalg.norm(a.T @ y, np.inf),
       np.linalg.norm(c, np.inf),
-      norm_x,
   )
-  gaprelrhs = max(min(abs(pcost), abs(dcost)), norm_x + norm_y)
   assert solution.status == qtqp.SolutionStatus.SOLVED
-  np.testing.assert_array_less(gap, atol + rtol * gaprelrhs)
+  np.testing.assert_array_less(gap, atol + rtol * min(abs(pcost), abs(dcost)))
   np.testing.assert_array_less(pres, atol + rtol * prelrhs)
   np.testing.assert_array_less(dres, atol + rtol * drelrhs)
   np.testing.assert_array_less(-1e-9, np.min(y[z:], initial=0.0))
@@ -1896,7 +1888,7 @@ def test_equilibrate_unequilibrate_roundtrip(strategy):
 # =============================================================================
 
 def test_normalize_invariant():
-  """_normalize enforces ||(x,y)||^2 + tau^2 == m - z + 1."""
+  """Test that _normalize enforces ||(x,y,tau)||^2 == m - z + 1."""
   rng = np.random.default_rng(42)
   m, n, z = 20, 10, 3
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
@@ -1909,8 +1901,8 @@ def test_normalize_invariant():
 
   x_n, y_n, tau_n, _ = solver._normalize(x, y, tau, s)  # pylint: disable=protected-access
 
-  quad = x_n @ x_n + y_n @ y_n + tau_n ** 2
-  np.testing.assert_allclose(quad, m - z + 1, atol=1e-12, rtol=1e-12)
+  xyt_norm_sq = x_n @ x_n + y_n @ y_n + tau_n ** 2
+  np.testing.assert_allclose(xyt_norm_sq, m - z + 1, atol=1e-12, rtol=1e-12)
 
 
 # =============================================================================
@@ -2102,16 +2094,14 @@ def test_complementarity_at_convergence():
 
 def test_iterative_refinement_improves_residual():
   """Test that more refinement steps reduce the final linear system residual."""
-  # QDLDL pinned: the ordering assertion compares residuals at the noise
-  # floor, and the multithreaded backends are not run-to-run stable there.
   rng = np.random.default_rng(42)
   m, n, z = 50, 30, 5
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
-  sol_1 = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(linear_solver=qtqp.LinearSolver.QDLDL, 
+  sol_1 = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
       max_iterative_refinement_steps=1, verbose=True, collect_stats=True
   )
-  sol_50 = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(linear_solver=qtqp.LinearSolver.QDLDL, 
+  sol_50 = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
       max_iterative_refinement_steps=50, verbose=True, collect_stats=True
   )
 
@@ -2870,6 +2860,90 @@ def test_gmres_rollback_on_stalled_refinement():
   # Either we converged immediately, or the returned residual is no worse
   # than what one direct factor-solve from warm_start would give.
   assert stats['final_residual_norm'] < 1e-6
+
+
+# =============================================================================
+# central_path_exponent: generalized central path
+# =============================================================================
+
+@pytest.mark.parametrize('central_path_exponent', [0.5, 1.0, 1.5, 2.0])
+@pytest.mark.parametrize('seed', 6000 + np.arange(3))
+def test_central_path_exponent_solve(central_path_exponent, seed):
+  """All positive exponents must converge to the same optimal solution."""
+  rng = np.random.default_rng(seed)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      central_path_exponent=central_path_exponent, verbose=False,
+  )
+  _assert_solution(solution, a, b, c, p, z)
+
+
+def test_central_path_exponent_default_unchanged():
+  """central_path_exponent=1.0 must give the same solution as the default.
+
+  The two paths drift by ~1 ULP per iteration because mu**1.0 is not
+  bit-identical to mu in IEEE math; this test just guards against any
+  larger semantic divergence on the default path.
+  """
+  rng = np.random.default_rng(6100)
+  m, n, z = 50, 30, 5
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  sol_a = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  sol_b = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      central_path_exponent=1.0, verbose=False
+  )
+  np.testing.assert_allclose(sol_a.x, sol_b.x, atol=1e-6, rtol=1e-6)
+  np.testing.assert_allclose(sol_a.y, sol_b.y, atol=1e-6, rtol=1e-6)
+  np.testing.assert_allclose(sol_a.s, sol_b.s, atol=1e-6, rtol=1e-6)
+
+
+def test_central_path_exponent_solutions_agree():
+  """Different exponents converge to the same QP optimum (within tol)."""
+  rng = np.random.default_rng(6200)
+  m, n, z = 50, 30, 5
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  objs = []
+  for cpe in (0.5, 1.0, 1.5, 2.0):
+    sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+        central_path_exponent=cpe, verbose=False
+    )
+    _assert_solution(sol, a, b, c, p, z)
+    objs.append(c @ sol.x + 0.5 * sol.x @ p @ sol.x)
+  ref = objs[1]  # the p=1 case is the reference
+  for obj in objs:
+    np.testing.assert_allclose(obj, ref, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize('bad_value', [0.0, -1.0, -0.5, float('nan'), float('inf')])
+def test_central_path_exponent_rejects_invalid(bad_value):
+  """Non-positive or non-finite central_path_exponent must raise."""
+  rng = np.random.default_rng(6300)
+  a, b, c, p = _gen_feasible(20, 12, 3, random_state=rng)
+  with pytest.raises(ValueError, match='central_path_exponent'):
+    qtqp.QTQP(a=a, b=b, c=c, z=3, p=p).solve(
+        central_path_exponent=bad_value, verbose=False
+    )
+
+
+def test_central_path_exponent_infeasible():
+  """Non-default exponent must still detect primal infeasibility."""
+  rng = np.random.default_rng(6400)
+  a, b, c, p = _gen_infeasible(40, 25, 5, random_state=rng)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
+      central_path_exponent=1.5, verbose=False
+  )
+  _assert_infeasible(solution, a, b, 5)
+
+
+def test_central_path_exponent_unbounded():
+  """Non-default exponent must still detect primal unboundedness."""
+  rng = np.random.default_rng(6500)
+  a, b, c, p = _gen_unbounded(40, 25, 5, random_state=rng)
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
+      central_path_exponent=0.7, verbose=False
+  )
+  _assert_unbounded(solution, a, c, p, 5)
 
 
 # =============================================================================


### PR DESCRIPTION
Reverts the #79 squash (9a443af): it was landed by the automated cascade shortly before the decision to hold the eps-weighted-path change back and land fixes first. The content is preserved on the work refs for clean re-landing when ready.