### PR TITLE
Adopt backward-error termination criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ Choose one with the `refinement_strategy` argument:
 
 #### Advanced numerical options
 
+-   Termination scales include the iterate norms `||x||/tau`, `||y||/tau`
+    (and their sum for the duality gap), so acceptance is a backward-error
+    criterion consistent with the `mu`-scale perturbation the regularized
+    path itself commits: residuals are judged against the larger of the
+    floating-point measurement floor of their summands and the perturbation
+    allowance of the path.
 -   `fused_corrector_division`: Fuses the corrector slack numerator before
     dividing by `y[z:]`. This is useful when small `y` components make the
     legacy three-division form vulnerable to cancellation.

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -1465,26 +1465,42 @@ class QTQP:
     # pinfeas measures how well y/|b'y| certifies primal infeasibility.
     pinfeas = norm_aty / (abs(bty) + _EPS)
 
-    # Primal residual tolerance relative scale.
+    norm_x = _norm(x, np.inf)
+    norm_y = _norm(y, np.inf)
+
+    # Residual tolerance relative scales. Each is the max of two families:
+    # the summand norms (the floor below which the residual cannot even be
+    # evaluated in floating point) and the iterate norm (the backward-error
+    # allowance: dres <= rtol * ||x||/tau accepts a point that is exactly
+    # dual-feasible for P + dP with ||dP|| <= rtol, which is precisely the
+    # mu*I perturbation the regularized path itself commits; likewise
+    # pres <= rtol * ||y||/tau on the primal side).
     prelrhs = max(
         _norm(ax, np.inf) * inv_tau,
         _norm(s, np.inf) * inv_tau,
         self._norm_b,
+        norm_y * inv_tau,
     )
 
-    # Dual residual tolerance relative scale.
     drelrhs = max(
         norm_px * inv_tau,
         norm_aty * inv_tau,
         self._norm_c,
+        norm_x * inv_tau,
     )
 
-    norm_x = _norm(x, np.inf)
-    norm_y = _norm(y, np.inf)
+    # Gap tolerance relative scale: the cost magnitudes (measurement floor)
+    # or the first-power iterate norm (the empirically calibrated allowance
+    # for the regularized path's O(mu*||u||^2) objective bias; see the
+    # criteria validation on NETLIB + Maros-Meszaros).
+    gaprelrhs = max(
+        min(abs(pcost), abs(dcost)),
+        (norm_x + norm_y) * inv_tau,
+    )
 
     # Solved: duality gap and both residuals are within tolerance.
     if (
-        gap < self.atol + self.rtol * min(abs(pcost), abs(dcost))
+        gap < self.atol + self.rtol * gaprelrhs
         and pres < self.atol + self.rtol * prelrhs
         and dres < self.atol + self.rtol * drelrhs
     ):
@@ -1509,7 +1525,7 @@ class QTQP:
     almost_atol = _ALMOST_FACTOR * self.atol
     almost_rtol = _ALMOST_FACTOR * self.rtol
     almost_score = max(
-        gap / (almost_atol + almost_rtol * min(abs(pcost), abs(dcost))),
+        gap / (almost_atol + almost_rtol * gaprelrhs),
         pres / (almost_atol + almost_rtol * prelrhs),
         dres / (almost_atol + almost_rtol * drelrhs),
     )

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -291,18 +291,26 @@ def _assert_solution(solution, a, b, c, p, z, atol=1e-7, rtol=1e-8):
   pres = np.linalg.norm(a @ x + s - b, np.inf)
   dres = np.linalg.norm(p @ x + a.T @ y + c, np.inf)
   gap = np.abs(c @ x + b @ y + x @ p @ x)
+  # Relative scales mirror the solver's termination criteria: the summand
+  # norms (evaluation floor) plus the iterate norms (the backward-error
+  # allowance of the regularized path).
+  norm_x = np.linalg.norm(x, np.inf)
+  norm_y = np.linalg.norm(y, np.inf)
   prelrhs = max(
       np.linalg.norm(a @ x, np.inf),
       np.linalg.norm(s, np.inf),
       np.linalg.norm(b, np.inf),
+      norm_y,
   )
   drelrhs = max(
       np.linalg.norm(p @ x, np.inf),
       np.linalg.norm(a.T @ y, np.inf),
       np.linalg.norm(c, np.inf),
+      norm_x,
   )
+  gaprelrhs = max(min(abs(pcost), abs(dcost)), norm_x + norm_y)
   assert solution.status == qtqp.SolutionStatus.SOLVED
-  np.testing.assert_array_less(gap, atol + rtol * min(abs(pcost), abs(dcost)))
+  np.testing.assert_array_less(gap, atol + rtol * gaprelrhs)
   np.testing.assert_array_less(pres, atol + rtol * prelrhs)
   np.testing.assert_array_less(dres, atol + rtol * drelrhs)
   np.testing.assert_array_less(-1e-9, np.min(y[z:], initial=0.0))
@@ -1903,7 +1911,7 @@ def test_equilibrate_unequilibrate_roundtrip(strategy):
 # =============================================================================
 
 def test_normalize_invariant():
-  """Test that _normalize enforces ||(x,y,tau)||^2 == m - z + 1."""
+  """_normalize enforces ||(x,y)||^2 + tau^2 == m - z + 1."""
   rng = np.random.default_rng(42)
   m, n, z = 20, 10, 3
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
@@ -1916,8 +1924,8 @@ def test_normalize_invariant():
 
   x_n, y_n, tau_n, _ = solver._normalize(x, y, tau, s)  # pylint: disable=protected-access
 
-  xyt_norm_sq = x_n @ x_n + y_n @ y_n + tau_n ** 2
-  np.testing.assert_allclose(xyt_norm_sq, m - z + 1, atol=1e-12, rtol=1e-12)
+  quad = x_n @ x_n + y_n @ y_n + tau_n ** 2
+  np.testing.assert_allclose(quad, m - z + 1, atol=1e-12, rtol=1e-12)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Adopts backward-error termination criteria. **This is the decision PR for the re-land of reverted #79** — opened for visibility; not to be merged until the corpus re-baseline on landed main gives the fresh marginal numbers.

**The criteria.** Each residual tolerance scale becomes the maximum of two families:

- the **measurement floor**: the norms of the residual's summands, below which the residual cannot even be evaluated in floating point (the classical scale), and
- the **perturbation allowance**: the iterate norms `||x||/tau`, `||y||/tau` (their first-power sum for the duality gap). Accepting `dres <= rtol * ||x||/tau` accepts a point exactly dual-feasible for `P + dP` with `||dP|| <= rtol` — the Rigal–Gaches normwise backward error — which is precisely the order of the mu-scale perturbation the regularized path itself commits. Judging iterates by a stricter standard than the path can satisfy is what caused the chronic NETLIB failures: the path pins `dres = mu*||x||`, so on large-norm instances the legacy criteria demanded residuals the trajectory structurally cannot produce at any iteration count.

The ALMOST_SOLVED salvage score is aligned to the same scales, so near-solutions are graded by the same standard as solutions.

## Validation (lineage evidence — refresh pending)

On the pre-revert lineage, measured on NETLIB feasible (91) + Maros–Mészáros (93 supported, clean data): legacy criteria **172/184**; with these criteria **182/184** (remaining: dfl001's false-UNBOUNDED certificate — the #80-class fix — and YAO at max-iter, rescued by Gondzio correctors). Accuracy price: a documented tail (~4e-3 objective disagreement on modszk1/tuff) from the first-power gap allowance.

These numbers predate the fixes-first landings: today's main has the CVXOPT init (#99, which independently rescued part of the same failure class) and 1e-9 defaults (#97/#98, which make the pinning bite harder). The corpus re-baseline on landed main, then a criteria arm on top of it, gives the real marginal value — that measurement is the merge gate.

## History

- Re-land of the criteria portion of #79 (squash 9a443af, reverted by #103), ported over #97/#98/#99/#96 and the #84/#85 diagnostics.
- The **eps-weighted path** that named the original branch was removed before #79 first landed (controlled validation: the criteria alone fix all twelve legacy failures; eps was flat) and remains out.
- The **central_path_exponent removal** is split into #104 and lands independently.

Stacked on #104; the diff collapses as parents merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
