### PR TITLE
Log delta_path_local and lambda_init: barrier-metric path diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,16 @@ Key parameters:
     at the current `mu` (from the strong monotonicity of the regularized path
     map); it is informative when small, conservative for aggressively
     centered iterates, and saturates at the floating-point floor in the
-    final iterations.
+    final iterations. Its local-norm companion `delta_path_local` measures
+    the same residual in the barrier metric `H = mu*I + mu*hess(Phi)`
+    (a Newton-decrement analogue): it weights each component by the
+    curvature resisting it and remains informative for aggressive
+    iterates. `lambda_init` (also an attribute on the solver) is the same
+    measure at the deterministic initial point, before the first step:
+    healthy problems measure small, while pathologically scaled data
+    announces itself by tens of orders of magnitude — this diagnostic is
+    how corrupted infinity-sentinel bounds were found in the
+    Maros-Meszaros benchmark files.
 -   `init_strategy`: Choose the initial interior-point iterate. Defaults to
     `qtqp.InitStrategy.CVXOPT`.
 -   `init_mu_scale`: Positive scale used only by `qtqp.InitStrategy.ORTHANT` to

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -769,6 +769,30 @@ class QTQP:
     self._best_almost_score = math.inf
     self._best_almost_iterate = None
     status = SolutionStatus.UNFINISHED
+
+    # Initial-point diagnostic: the local-norm distance-to-path measure
+    # lambda = ||T_mu(u)||_{H^-1} (H = mu*I + mu*hess(Phi)) evaluated at
+    # the deterministic initial iterate, before the first step. Three
+    # matvecs. Healthy problems measure small (<= ~1e7 across NETLIB +
+    # Maros-Meszaros); pathologically scaled data announces itself here
+    # by tens of orders of magnitude — this diagnostic is how corrupted
+    # infinity-sentinel bounds in the benchmark datasets were found.
+    mu0 = float(y @ s) / (self.m - self.z)
+    t_x0 = p @ x + a.T @ y + c * tau + mu0 * x
+    t_y0 = -(a @ x) + b * tau + mu0 * y
+    t_y0[self.z :] -= mu0 / y[self.z :]
+    px0_ = float(x @ (p @ x)) if p.nnz else 0.0
+    t_t0 = (-(float(c @ x) + float(b @ y)) - px0_ / max(_EPS, tau)
+            + mu0 * (tau - 1.0 / max(_EPS, tau)))
+    h_y0 = np.full(self.m, mu0)
+    h_y0[self.z :] += mu0 / (y[self.z :] * y[self.z :])
+    h_t0 = mu0 + mu0 / max(_EPS, tau * tau)
+    self.lambda_init = math.sqrt(
+        float(t_x0 @ t_x0) / max(_EPS, mu0)
+        + float((t_y0 * t_y0) @ (1.0 / h_y0))
+        + t_t0 * t_t0 / max(_EPS, h_t0)
+    )
+
     self._log_header()
 
     # Pre-allocate [x; y] and d_s to avoid repeated allocation each iteration.
@@ -787,6 +811,8 @@ class QTQP:
       # self.it counts IPM steps already taken.
       for self.it in range(max_iter):
         stats_i = {}
+        if self.it == 0:
+          stats_i["lambda_init"] = self.lambda_init
         x, y, tau, s = self._normalize(x, y, tau, s)
 
         mu = max((y @ s) / (self.m - self.z), _MU_FLOOR)
@@ -1441,6 +1467,22 @@ class QTQP:
         float(t_x @ t_x) + float(t_y @ t_y) + t_tau * t_tau
     )
     stats_i["delta_path"] = t_norm / max(_EPS, mu_hat)
+    # Local-norm proximity measure (diagnostic): the same T vector weighted
+    # by the inverse of H = mu*I + mu*diag(hess barrier), the barrier's
+    # local metric. Deflates the barrier rows that make the Euclidean
+    # certificate conservative on aggressively centered iterates
+    # (Newton-decrement flavor), and remains informative for aggressive
+    # iterates where the Euclidean bound saturates.
+    h_x = mu_hat
+    h_y = np.full(self.m, mu_hat)
+    h_y[self.z :] += mu_hat / (y_w[self.z :] * y_w[self.z :])
+    h_tau = mu_hat + mu_hat / max(_EPS, tau * tau)
+    lam_sq = (
+        float(t_x @ t_x) / max(_EPS, h_x)
+        + float((t_y * t_y) @ (1.0 / h_y))
+        + t_tau * t_tau / max(_EPS, h_tau)
+    )
+    stats_i["delta_path_local"] = math.sqrt(max(0.0, lam_sq))
 
     # Infeasibility certificates (Farkas-type, from the embedding structure).
     # If the primal is unbounded (dual infeasible) this produces a ray x with

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -3199,3 +3199,30 @@ def test_delta_path_small_near_path():
   deltas = [st['delta_path'] for st in sol.stats]
   diameter = 2.0 * np.sqrt(m - z + 1)
   assert min(deltas) < 100.0 * diameter
+
+
+@pytest.mark.parametrize('equilibration', [
+    qtqp.EquilibrationStrategy.RUIZ, qtqp.EquilibrationStrategy.NONE,
+])
+def test_delta_path_local_logged(equilibration):
+  """delta_path_local is present, finite, and positive every iteration."""
+  rng = np.random.default_rng(9200)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      verbose=False, collect_stats=True, equilibration_strategy=equilibration,
+  )
+  lams = [st['delta_path_local'] for st in sol.stats]
+  assert all(np.isfinite(v) and v > 0 for v in lams)
+
+
+def test_lambda_init_logged():
+  """lambda_init is computed at the initial point and surfaced in stats."""
+  rng = np.random.default_rng(9300)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
+  sol = solver.solve(verbose=False, collect_stats=True)
+  assert np.isfinite(solver.lambda_init) and solver.lambda_init > 0
+  assert sol.stats[0]['lambda_init'] == solver.lambda_init
+  assert 'lambda_init' not in sol.stats[1]


### PR DESCRIPTION
Successor to #85, which was auto-closed when its base branch (delta-logging, #84's head) was deleted on merge and cannot be reopened. Identical content: the barrier-metric local-norm companion to delta_path and the initial-point diagnostic lambda_init. Locally gated by the full 2,485-test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)