### PR TITLE
Add certified warm starts via the distance-to-path certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,18 @@ Key parameters:
 -   `fused_corrector_division`: If True, computes the Mehrotra corrector slack
     update with one fused division. The default False preserves legacy
     arithmetic.
+-   `warm_start`: Optional `(x, y, s)` from a nearby problem (original scale,
+    e.g. a previous solution's arrays). The point is equilibrated into the
+    operating scale, embedded interior at a few centering shifts, and the
+    best embedding is accepted only when the distance-to-path certificate
+    measures `lambda <= warm_start_threshold`; a vetoed point falls back to
+    the configured `init_strategy`, so warm starting is never worse than a
+    cold solve by more than the certificate evaluation (three matvecs per
+    shift). After `solve`, the measured `warm_lambda` and the `warm_accepted`
+    decision are attributes on the solver.
+-   `warm_start_threshold`: Acceptance threshold for the certified warm
+    start (default `100.0`). Poisoned or mis-scaled points measure orders of
+    magnitude above it; same-problem re-entries orders of magnitude below.
 
 #### Equilibration strategies
 

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -414,6 +414,34 @@ class QTQP:
       return 0.0
     return ps.b_dropped - ps.a_dropped @ x
 
+  def _lambda_local(self, x, y, s, tau, a, p, b, c):
+    """Local-norm distance-to-path measure at a working-scale point.
+
+    lambda = ||T_mu(u)||_{H^-1} with H = mu*I + mu*hess(Phi) (diagonal),
+    evaluated at the point's own complementarity mu = y's/(m-z). Three
+    matvecs. Certified-distance semantics when small; a scaled residual
+    score when large. Returns inf when the point has no positive
+    complementarity to define a barrier parameter at (e.g. junk warm
+    points with sign-mixed y), which reads as maximally far from the path.
+    """
+    mu0 = float(y @ s) / (self.m - self.z)
+    if not np.isfinite(mu0) or mu0 <= 0.0:
+      return math.inf
+    t_x0 = p @ x + a.T @ y + c * tau + mu0 * x
+    t_y0 = -(a @ x) + b * tau + mu0 * y
+    t_y0[self.z :] -= mu0 / y[self.z :]
+    px0_ = float(x @ (p @ x)) if p.nnz else 0.0
+    t_t0 = (-(float(c @ x) + float(b @ y)) - px0_ / max(_EPS, tau)
+            + mu0 * (tau - 1.0 / max(_EPS, tau)))
+    h_y0 = np.full(self.m, mu0)
+    h_y0[self.z :] += mu0 / (y[self.z :] * y[self.z :])
+    h_t0 = mu0 + mu0 / max(_EPS, tau * tau)
+    return math.sqrt(
+        float(t_x0 @ t_x0) / max(_EPS, mu0)
+        + float((t_y0 * t_y0) @ (1.0 / h_y0))
+        + t_t0 * t_t0 / max(_EPS, h_t0)
+    )
+
   def _init_variables(self, strategy, mu_scale, a, p, b, c):
     """Dispatch to the requested initialization strategy.
 
@@ -564,6 +592,8 @@ class QTQP:
       refinement_strategy: RefinementStrategy = RefinementStrategy.RICHARDSON,
       gmres_restart: int = 10,
       fused_corrector_division: bool = False,
+      warm_start: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
+      warm_start_threshold: float = 100.0,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method."""
     self._linear_solver = None
@@ -588,6 +618,8 @@ class QTQP:
           refinement_strategy=refinement_strategy,
           gmres_restart=gmres_restart,
           fused_corrector_division=fused_corrector_division,
+          warm_start=warm_start,
+          warm_start_threshold=warm_start_threshold,
       )
     finally:
       if self._linear_solver is not None:
@@ -616,6 +648,8 @@ class QTQP:
       refinement_strategy: RefinementStrategy = RefinementStrategy.RICHARDSON,
       gmres_restart: int = 10,
       fused_corrector_division: bool = False,
+      warm_start: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
+      warm_start_threshold: float = 100.0,
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method.
 
@@ -670,6 +704,19 @@ class QTQP:
         avoids catastrophic cancellation when y_i is small and the
         terms have similar magnitudes with opposing signs. Default False
         preserves the legacy bit-for-bit behavior.
+      warm_start (tuple | None): Optional (x, y, s) from a nearby problem
+        (original scale, e.g. a previous Solution's arrays). The point is
+        equilibrated into the operating scale, embedded interior at a few
+        centering shifts, and the best embedding is accepted only when the
+        distance-to-path certificate measures lambda <=
+        warm_start_threshold; otherwise the solve falls back to the
+        configured init_strategy. After solve, `warm_lambda` (the measured
+        lambda, or None when no warm start was given) and `warm_accepted`
+        are available as attributes on the solver.
+      warm_start_threshold (float): Acceptance threshold for the certified
+        warm start. Default 100.0: poisoned or mis-scaled points measure
+        orders of magnitude above it, same-problem re-entries orders of
+        magnitude below.
 
     Returns:
       A Solution object containing the solution and solve stats.
@@ -751,28 +798,59 @@ class QTQP:
     self._best_almost_iterate = None
     status = SolutionStatus.UNFINISHED
 
-    # Initial-point diagnostic: the local-norm distance-to-path measure
-    # lambda = ||T_mu(u)||_{H^-1} (H = mu*I + mu*hess(Phi)) evaluated at
-    # the deterministic initial iterate, before the first step. Three
-    # matvecs. Healthy problems measure small (<= ~1e7 across NETLIB +
+    # Certified warm start: ingest a caller-supplied (x, y, s) from a
+    # nearby problem, embed it interior at a few centering shifts, and
+    # accept the best embedding only when the certificate says it is
+    # actually near the path (lambda <= warm_start_threshold). A vetoed
+    # warm start falls back to the configured init: the certificate makes
+    # warm starting safe, which heuristic IPM warm starts are not.
+    self.warm_lambda = None
+    self.warm_accepted = False
+    if warm_start is not None:
+      if not (np.isfinite(warm_start_threshold) and warm_start_threshold > 0):
+        raise ValueError(
+            "warm_start_threshold must be a positive finite float, got"
+            f" {warm_start_threshold}"
+        )
+      wx, wy, ws = (np.asarray(v, dtype=float).copy() for v in warm_start)
+      if wx.shape != (self.n,) or wy.shape != (self.m,) or ws.shape != (self.m,):
+        raise ValueError(
+            "warm_start must be (x, y, s) with shapes"
+            f" ({self.n},), ({self.m},), ({self.m},); got"
+            f" {wx.shape}, {wy.shape}, {ws.shape}"
+        )
+      if self.equilibration_strategy is not EquilibrationStrategy.NONE:
+        wx, wy, ws = self._equilibrate_iterates(wx, wy, ws)
+      best = (math.inf, None)
+      for eta in (1e-6, 1e-4, 1e-2, 1.0):
+        cx = wx.copy()
+        cy = wy.copy()
+        cs = ws.copy()
+        cy[self.z :] = np.maximum(cy[self.z :], eta)
+        cs[self.z :] = np.maximum(cs[self.z :], eta)
+        cs[: self.z] = 0.0
+        ctau = 1.0
+        cx, cy, ctau, cs = self._normalize(cx, cy, ctau, cs)
+        lam = self._lambda_local(cx, cy, cs, ctau, a, p, b, c)
+        if lam < best[0]:
+          best = (lam, (cx, cy, cs, ctau))
+      self.warm_lambda = best[0]
+      if best[0] <= warm_start_threshold:
+        cx, cy, cs, ctau = best[1]
+        x, y, s, tau = cx, cy, cs, ctau
+        self.warm_accepted = True
+      logging.debug(
+          "warm start: lambda = %e, accepted = %s",
+          self.warm_lambda, self.warm_accepted,
+      )
+
+    # Initial-point diagnostic: the local-norm distance-to-path measure at
+    # the starting iterate (warm or configured init), before the first
+    # step. Healthy problems measure small (<= ~1e7 across NETLIB +
     # Maros-Meszaros); pathologically scaled data announces itself here
     # by tens of orders of magnitude — this diagnostic is how corrupted
     # infinity-sentinel bounds in the benchmark datasets were found.
-    mu0 = float(y @ s) / (self.m - self.z)
-    t_x0 = p @ x + a.T @ y + c * tau + mu0 * x
-    t_y0 = -(a @ x) + b * tau + mu0 * y
-    t_y0[self.z :] -= mu0 / y[self.z :]
-    px0_ = float(x @ (p @ x)) if p.nnz else 0.0
-    t_t0 = (-(float(c @ x) + float(b @ y)) - px0_ / max(_EPS, tau)
-            + mu0 * (tau - 1.0 / max(_EPS, tau)))
-    h_y0 = np.full(self.m, mu0)
-    h_y0[self.z :] += mu0 / (y[self.z :] * y[self.z :])
-    h_t0 = mu0 + mu0 / max(_EPS, tau * tau)
-    self.lambda_init = math.sqrt(
-        float(t_x0 @ t_x0) / max(_EPS, mu0)
-        + float((t_y0 * t_y0) @ (1.0 / h_y0))
-        + t_t0 * t_t0 / max(_EPS, h_t0)
-    )
+    self.lambda_init = self._lambda_local(x, y, s, tau, a, p, b, c)
 
     self._log_header()
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -3232,3 +3232,106 @@ def test_richardson_stall_rollback_regimes():
   np.testing.assert_array_equal(
       sol_keep, np.zeros(n + m) + mild.returned[0] + mild.returned[1]
   )
+
+
+# =============================================================================
+# warm_start: certified warm starts via the distance-to-path certificate
+# =============================================================================
+
+@pytest.mark.parametrize('equilibration', [
+    qtqp.EquilibrationStrategy.RUIZ, qtqp.EquilibrationStrategy.NONE,
+])
+def test_warm_start_same_problem_accepted_and_fast(equilibration):
+  """Re-solving from a solution certifies near-path and cuts iterations."""
+  rng = np.random.default_rng(9400)
+  m, n, z = 80, 50, 10
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  cold = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      verbose=False, collect_stats=True, equilibration_strategy=equilibration
+  )
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      verbose=False, equilibration_strategy=equilibration
+  )
+  solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
+  warm = solver.solve(
+      verbose=False, collect_stats=True, warm_start=(sol.x, sol.y, sol.s),
+      equilibration_strategy=equilibration,
+  )
+  _assert_solution(warm, a, b, c, p, z)
+  assert solver.warm_accepted
+  assert solver.warm_lambda < 10.0
+  assert len(warm.stats) < len(cold.stats)
+
+
+def test_warm_start_perturbed_problem_accepted():
+  """The intended use: warm-starting a perturbed problem from the previous
+  solution is certified, converges, and does not cost iterations over cold."""
+  rng = np.random.default_rng(9450)
+  m, n, z = 80, 50, 10
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  base = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  c2 = c * (1.0 + 0.01 * rng.normal(size=n))
+  cold = qtqp.QTQP(a=a, b=b, c=c2, z=z, p=p).solve(
+      verbose=False, collect_stats=True
+  )
+  solver = qtqp.QTQP(a=a, b=b, c=c2, z=z, p=p)
+  warm = solver.solve(
+      verbose=False, collect_stats=True,
+      warm_start=(base.x, base.y, base.s),
+  )
+  _assert_solution(warm, a, b, c2, p, z)
+  assert solver.warm_accepted
+  assert np.isfinite(solver.warm_lambda) and solver.warm_lambda > 0
+  assert len(warm.stats) <= len(cold.stats)
+
+
+def test_warm_start_junk_vetoed():
+  """A junk warm point is vetoed by the certificate; solve falls back to
+  the configured init and still converges."""
+  rng = np.random.default_rng(9500)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  junk = (1e12 * rng.normal(size=n), 1e12 * rng.normal(size=m),
+          np.abs(rng.normal(size=m)))
+  solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
+  warm = solver.solve(
+      verbose=False, collect_stats=True, warm_start=junk,
+      warm_start_threshold=10.0,
+  )
+  _assert_solution(warm, a, b, c, p, z)
+  assert not solver.warm_accepted
+  assert solver.warm_lambda > 10.0
+
+
+def test_warm_start_tiny_threshold_vetoes_good_point():
+  """The threshold is the gate: even a same-problem re-entry is vetoed
+  under an absurdly small threshold, and the solve still converges cold."""
+  rng = np.random.default_rng(9550)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
+  warm = solver.solve(
+      verbose=False, warm_start=(sol.x, sol.y, sol.s),
+      warm_start_threshold=1e-12,
+  )
+  _assert_solution(warm, a, b, c, p, z)
+  assert not solver.warm_accepted
+  assert solver.warm_lambda > 1e-12
+
+
+def test_warm_start_bad_inputs_raise():
+  """Wrong shapes and invalid thresholds raise clear ValueErrors."""
+  rng = np.random.default_rng(9600)
+  m, n, z = 30, 20, 4
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  good = (np.zeros(n), np.ones(m), np.ones(m))
+  with pytest.raises(ValueError, match='warm_start'):
+    qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+        verbose=False, warm_start=(np.zeros(n + 1), np.ones(m), np.ones(m))
+    )
+  for bad in (0.0, -1.0, float('nan')):
+    with pytest.raises(ValueError, match='warm_start_threshold'):
+      qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+          verbose=False, warm_start=good, warm_start_threshold=bad
+      )


### PR DESCRIPTION
Successor to #86, which was auto-closed when its base branch was deleted during the #85/#106 merge and cannot be reopened. Port of the certified-warm-start work onto current main, plus: input validation (shapes, threshold) with clear ValueErrors, full API documentation (docstring + README), and test coverage extended to the perturbed-problem entry path, both equilibration modes, the threshold gate, and invalid inputs. Full suite: 2,471 passed.

See #86 for the design rationale and the experimental record (1.99x aggregate iteration reduction on perturbation sequences; certified-vs-naive adversarial results; Clarabel comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)