### PR TITLE
Remove init_strategy: the CVXOPT initialization is the only init

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,6 @@ solve(
         qtqp.EquilibrationStrategy.RUIZ
     ),
     collect_stats: bool = False,
-    init_strategy: qtqp.InitStrategy = qtqp.InitStrategy.CVXOPT,
-    init_mu_scale: float = 1.0,
     refinement_strategy: qtqp.RefinementStrategy = (
         qtqp.RefinementStrategy.GMRES
     ),
@@ -208,10 +206,6 @@ Key parameters:
     announces itself by tens of orders of magnitude — this diagnostic is
     how corrupted infinity-sentinel bounds were found in the
     Maros-Meszaros benchmark files.
--   `init_strategy`: Choose the initial interior-point iterate. Defaults to
-    `qtqp.InitStrategy.CVXOPT`.
--   `init_mu_scale`: Positive scale used only by `qtqp.InitStrategy.ORTHANT` to
-    set the initial barrier parameter.
 -   `refinement_strategy`: Choose the iterative-refinement method used for KKT
     solves. Defaults to `qtqp.RefinementStrategy.GMRES`.
 -   `gmres_restart`: Restart length for `qtqp.RefinementStrategy.GMRES`.

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -191,44 +191,6 @@ class EquilibrationStrategy(enum.Enum):
   AUGMENTED = "augmented"
 
 
-class InitStrategy(enum.Enum):
-  """Available initialization strategies for the IPM iterates.
-
-  TRIVIAL:
-    Unit vectors: y[z:] = s[z:] = 1, x = 0, tau = 1. Cheap, dimensionless.
-    Default for backward compatibility.
-
-  ORTHANT:
-    Closed-form non-negative orthant centering. Picks mu_0 = mu_scale *
-    ||b[z:]|| (see the init_mu_scale solve() kwarg) and solves the
-    per-component centering condition
-        mu_0 * y_i + b_i - mu_0 / y_i = 0
-    for inequality rows, giving y_i = (-beta_i + sqrt(beta_i^2 + 4)) / 2 with
-    beta = b/mu_0. Strictly interior by construction; cost is O(m).
-
-  CVXOPT:
-    Least-squares initialization (CVXOPT / Clarabel style). For QPs,
-    solves the saddle-point system
-        [P + eps*I,  A^T ] [x]   [-c]
-        [    A,      -I  ] [y] = [ b]
-    treating all rows as equalities; the (2, 2) block is -I, giving the
-    bounded least-squares point y ~ Ax - b. For LPs (P with no
-    nonzeros) the coupled solve is ill-posed, so it splits into two
-    solves with the same factorization - [0; b] for the primal
-    (feasibility only) and [-c; 0] for the dual (optimality only),
-    matching Clarabel's LP initialization. The solves run through the
-    session's DirectKktSolver (same backend, ordering, static
-    regularization, and iterative refinement as the main loop). Then
-    s = b - A @ x, and the inequality blocks of (y, s) are shifted by a
-    uniform constant so min(y[z:]) and min(s[z:]) are at least 1.0
-    (CVXOPT's standard interior-point shift). Default.
-  """
-
-  TRIVIAL = "trivial"
-  ORTHANT = "orthant"
-  CVXOPT = "cvxopt"
-
-
 @dataclasses.dataclass(frozen=True)
 class Solution:
   """Contains the solution to the QP problem.
@@ -453,22 +415,15 @@ class QTQP:
         + t_tau * t_tau / max(_EPS, h_tau)
     )
 
-  def _init_variables(self, strategy, mu_scale, a, p, b, c):
-    """Dispatch to the requested initialization strategy.
+  def _init_variables(self, a, p, b, c):
+    """Produce the initial IPM iterates (CVXOPT-style residual embedding).
 
-    The (a, p, b, c) passed in are the operating-scale problem data: equilibrated
-    if equilibration is on, original otherwise. The selected strategy produces
-    iterates already in that scale, with the exception of TRIVIAL which keeps
-    its historical behavior (build unit iterates and then equilibrate via
-    _equilibrate_iterates) for backward compatibility.
+    The (a, p, b, c) passed in are the operating-scale problem data:
+    equilibrated if equilibration is on, original otherwise. The iterates
+    are produced in that scale. Falls back to the trivial unit init if the
+    initialization KKT solve degenerates (see _init_cvxopt).
     """
-    if strategy is InitStrategy.TRIVIAL:
-      return self._init_trivial()
-    if strategy is InitStrategy.ORTHANT:
-      return self._init_orthant(b, mu_scale)
-    if strategy is InitStrategy.CVXOPT:
-      return self._init_cvxopt(a, p, b, c)
-    raise ValueError(f"Unknown init strategy: {strategy}")
+    return self._init_cvxopt(a, p, b, c)
 
   def _init_trivial(self):
     """Unit-vector init: y[z:] = s[z:] = 1, x = 0, tau = 1."""
@@ -480,31 +435,6 @@ class QTQP:
     if self.equilibration_strategy is not EquilibrationStrategy.NONE:
       x, y, s = self._equilibrate_iterates(x, y, s)
     return x, y, s, 1.0, {}
-
-  def _init_orthant(self, b, mu_scale):
-    """Closed-form non-negative orthant init (see InitStrategy.ORTHANT)."""
-    m, n, z = self.m, self.n, self.z
-    x = np.zeros(n)
-    y = np.zeros(m)
-    s = np.zeros(m)
-
-    b_ineq = b[z:]
-    norm_b = _norm(b_ineq, 2)
-    if norm_b == 0.0:
-      mu_0 = max(mu_scale, np.finfo(np.float64).tiny)
-      y[z:] = 1.0
-      s[z:] = mu_0  # complementarity y_i * s_i = mu_0 with y_i = 1.
-    else:
-      mu_0 = mu_scale * norm_b
-      beta = b_ineq / mu_0
-      sq = np.sqrt(beta * beta + 4.0)
-      # Branch-selected stable form: cancellation-free for both signs of beta.
-      y_ineq = np.where(beta <= 0, 0.5 * (-beta + sq), 2.0 / (beta + sq))
-      assert np.all(y_ineq > 0), "orthant init produced non-positive y component"
-      y[z:] = y_ineq
-      s[z:] = mu_0 / y_ineq
-
-    return x, y, s, 1.0, {"mu_0": mu_0}
 
   def _init_cvxopt(self, a, p, b, c, reg=1e-8, interior_margin=1.0):
     """CVXOPT-style init: solve regularized saddle-point KKT, then shift."""
@@ -598,8 +528,6 @@ class QTQP:
       verbose: bool = True,
       equilibration_strategy: EquilibrationStrategy = EquilibrationStrategy.RUIZ,
       collect_stats: bool = False,
-      init_strategy: InitStrategy = InitStrategy.CVXOPT,
-      init_mu_scale: float = 1.0,
       refinement_strategy: RefinementStrategy = RefinementStrategy.GMRES,
       gmres_restart: int = 20,
       fused_corrector_division: bool = False,
@@ -626,8 +554,6 @@ class QTQP:
           verbose=verbose,
           equilibration_strategy=equilibration_strategy,
           collect_stats=collect_stats,
-          init_strategy=init_strategy,
-          init_mu_scale=init_mu_scale,
           refinement_strategy=refinement_strategy,
           gmres_restart=gmres_restart,
           fused_corrector_division=fused_corrector_division,
@@ -658,8 +584,6 @@ class QTQP:
       verbose: bool = True,
       equilibration_strategy: EquilibrationStrategy = EquilibrationStrategy.RUIZ,
       collect_stats: bool = False,
-      init_strategy: InitStrategy = InitStrategy.CVXOPT,
-      init_mu_scale: float = 1.0,
       refinement_strategy: RefinementStrategy = RefinementStrategy.GMRES,
       gmres_restart: int = 20,
       fused_corrector_division: bool = False,
@@ -706,13 +630,6 @@ class QTQP:
         statistics, complementarity, etc.) and return them in Solution.stats.
         Defaults to False for faster throughput; set True when per-iteration
         diagnostics are needed.
-      init_strategy (InitStrategy): Which initialization to use for (x, y, s,
-        tau). See InitStrategy for descriptions. Defaults to TRIVIAL.
-      init_mu_scale (float): Multiplier on ||b[z:]|| that sets the initial
-        barrier parameter mu_0 = init_mu_scale * ||b[z:]|| for
-        InitStrategy.ORTHANT. Larger values produce iterates closer to the
-        canonical center; smaller values produce more aggressive starts. Must
-        be positive and finite. Ignored for other strategies.
       refinement_strategy (RefinementStrategy): Which iterative-refinement
         scheme drives each KKT solve. See RefinementStrategy for
         descriptions. Defaults to GMRES: at a full-budget restart length
@@ -784,11 +701,6 @@ class QTQP:
     assert max_iterative_refinement_steps >= 1
     assert linear_solver_atol >= 0
     assert linear_solver_rtol >= 0
-    if not (np.isfinite(init_mu_scale) and init_mu_scale > 0):
-      raise ValueError(
-          f"init_mu_scale must be a positive finite float,"
-          f" got {init_mu_scale}"
-      )
     self._adaptive_step_size = bool(adaptive_step_size)
     if max_centrality_correctors < 0:
       raise ValueError("max_centrality_correctors must be >= 0.")
@@ -856,9 +768,7 @@ class QTQP:
 
     stats = []
     self.kinv_q = np.zeros_like(self.q)  # K^{-1}q, warm-started across iterations.
-    x, y, s, tau, _ = self._init_variables(
-        init_strategy, init_mu_scale, a, p, b, c
-    )
+    x, y, s, tau, _ = self._init_variables(a, p, b, c)
     self._best_almost_score = math.inf
     self._best_almost_iterate = None
     status = SolutionStatus.UNFINISHED

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1492,17 +1492,15 @@ def test_infeasible_lp(equilibration, seed, linear_solver, record_iterations):
   m, n, z = 50, 30, 5
   a, b, c, _ = _gen_infeasible(m, n, z, random_state=rng)
 
-  # init_strategy pinned: under the CVXOPT init the EIGEN/seed-4145/
-  # unequilibrated cell freezes near the certificate on Windows (the ray
-  # forms - infeasibility measure 1e-10 - but repeated linear-solver
-  # breakdowns at mu ~ 2e-9 stall the declaration and the solve hits the
-  # cap; macOS certifies the same cell in 6 iterations). Real
-  # certificate-endgame fragility, tracked alongside the held-out
-  # infeasibility misses; this test pins the trivial init so it keeps
-  # exercising detection across the full backend matrix meanwhile.
+  # Historical note: under the pre-#110 certificate judging this cell
+  # (EIGEN/seed-4145/unequilibrated) froze near the certificate on
+  # Windows under the CVXOPT init, and was pinned to the trivial init as
+  # mitigation. The trivial init is gone (CVXOPT is the only init); the
+  # data-scaled certificate rework and the GMRES refinement default both
+  # postdate the fragility - watch this cell on Windows CI.
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z).solve(
       equilibration_strategy=equilibration, linear_solver=linear_solver, collect_stats=True,
-      verbose=True, init_strategy=qtqp.InitStrategy.TRIVIAL,
+      verbose=True,
   )
 
   record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
@@ -2134,20 +2132,16 @@ def test_iterative_refinement_improves_residual():
   """Test that more refinement steps reduce the final linear system residual."""
   # QDLDL pinned: the ordering assertion compares residuals at the noise
   # floor; multithreaded backends are not run-to-run stable there.
-  # init_strategy pinned: the test asserts properties of the refinement
-  # behavior on its calibrated (trivial-init) trajectory.
   rng = np.random.default_rng(42)
   m, n, z = 50, 30, 5
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   sol_1 = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
       linear_solver=qtqp.LinearSolver.SCIPY,
-      init_strategy=qtqp.InitStrategy.TRIVIAL,
       max_iterative_refinement_steps=1, verbose=True, collect_stats=True
   )
   sol_50 = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
       linear_solver=qtqp.LinearSolver.SCIPY,
-      init_strategy=qtqp.InitStrategy.TRIVIAL,
       max_iterative_refinement_steps=50, verbose=True, collect_stats=True
   )
 
@@ -2209,13 +2203,11 @@ def test_raise_error_negative_z():
 
 def test_stats_monotonicity():
   """Test that mu decreases and time increases across iterations."""
-  # init_strategy pinned: this test asserts properties of the
-  # stats bookkeeping on its calibrated (trivial-init) trajectory.
   rng = np.random.default_rng(42)
   m, n, z = 50, 30, 5
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(init_strategy=qtqp.InitStrategy.TRIVIAL, 
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
       verbose=True, collect_stats=True
   )
 
@@ -2226,13 +2218,15 @@ def test_stats_monotonicity():
   times = [s['time'] for s in solution.stats]
   alphas = [s['alpha'] for s in solution.stats]
 
-  # mu is the complementarity of the current iterate and should decrease
-  # strictly as the IPM drives iterates toward the central path.
-  assert mus[0] > 0.0
-  for i in range(1, len(mus)):
-    assert mus[i] < mus[i - 1], (
-        f"mu not decreasing: mu[{i}]={mus[i]} >= mu[{i-1}]={mus[i-1]}"
-    )
+  # mu is the complementarity of the current iterate. Per-iteration strict
+  # monotonicity was a property of the retired trivial-init trajectory,
+  # not an algorithm invariant: the CVXOPT init starts near the path and
+  # the first Mehrotra step can legitimately recenter mu upward. The
+  # contract is positivity and overall convergence.
+  assert all(m_ > 0.0 for m_ in mus)
+  assert mus[-1] < 1e-6 * mus[0], (
+      f"mu did not converge: mu[0]={mus[0]}, mu[-1]={mus[-1]}"
+  )
 
   # Time should be monotonically non-decreasing.
   for i in range(1, len(times)):
@@ -2401,135 +2395,8 @@ def test_nonfinite_p_rejected():
 
 
 # =============================================================================
-# InitStrategy: ORTHANT and CVXOPT-style initialization
+# CVXOPT-style initialization
 # =============================================================================
-
-_INIT_STRATEGIES = [
-    qtqp.InitStrategy.TRIVIAL,
-    qtqp.InitStrategy.ORTHANT,
-    qtqp.InitStrategy.CVXOPT,
-]
-
-
-@pytest.mark.parametrize('init_strategy', _INIT_STRATEGIES)
-@pytest.mark.parametrize('equilibration', [qtqp.EquilibrationStrategy.RUIZ, qtqp.EquilibrationStrategy.NONE])
-@pytest.mark.parametrize('seed', 42 + np.arange(3))
-def test_init_strategy_solve(init_strategy, equilibration, seed):
-  """Every init strategy must solve a feasible QP to optimality."""
-  rng = np.random.default_rng(seed)
-  m, n, z = 50, 30, 5
-  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      equilibration_strategy=equilibration,
-      init_strategy=init_strategy,
-      verbose=False,
-  )
-  _assert_solution(solution, a, b, c, p, z)
-
-
-@pytest.mark.parametrize('init_strategy', _INIT_STRATEGIES)
-def test_init_strategy_infeasible(init_strategy):
-  """Every init strategy must still detect primal infeasibility."""
-  rng = np.random.default_rng(142)
-  a, b, c, p = _gen_infeasible(50, 30, 5, random_state=rng)
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
-      init_strategy=init_strategy, verbose=False
-  )
-  _assert_infeasible(solution, a, b, 5)
-
-
-@pytest.mark.parametrize('init_strategy', _INIT_STRATEGIES)
-def test_init_strategy_unbounded(init_strategy):
-  """Every init strategy must still detect primal unboundedness."""
-  rng = np.random.default_rng(242)
-  a, b, c, p = _gen_unbounded(50, 30, 5, random_state=rng)
-  solution = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
-      init_strategy=init_strategy, verbose=False
-  )
-  _assert_unbounded(solution, a, c, p, 5)
-
-
-@pytest.mark.parametrize('mu_scale', [0.1, 1.0, 5.0])
-def test_init_orthant_centering(mu_scale):
-  """ORTHANT init must satisfy the closed-form centering condition exactly.
-
-  For each inequality row i:  mu_0 * y_i + b_i - mu_0 / y_i  ==  0
-  with mu_0 = mu_scale * ||b[z:]||_2 and y_i computed from the closed form.
-  """
-  rng = np.random.default_rng(7)
-  m, n, z = 40, 25, 5
-  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
-  solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
-  solver.equilibration_strategy = qtqp.EquilibrationStrategy.NONE  # _init_trivial branch needs the attribute
-  x, y, s, tau, meta = solver._init_orthant(b, mu_scale)
-
-  assert tau == 1.0
-  assert np.all(x == 0.0)
-  assert np.all(y[z:] > 0)
-  assert np.all(s[z:] > 0)
-  mu_0 = meta['mu_0']
-  expected_mu = mu_scale * np.linalg.norm(b[z:], 2)
-  np.testing.assert_allclose(mu_0, expected_mu, rtol=1e-12)
-  # Middle-block centering residual.
-  resid = mu_0 * y[z:] + b[z:] - mu_0 / y[z:]
-  np.testing.assert_allclose(
-      resid, 0.0, atol=1e-10 * (np.linalg.norm(b[z:]) + mu_0)
-  )
-  # Complementarity: y * s == mu_0 componentwise.
-  np.testing.assert_allclose(y[z:] * s[z:], mu_0, rtol=1e-12)
-
-
-def test_init_orthant_zero_b():
-  """ORTHANT init must handle b[z:] == 0 without dividing by zero."""
-  m, n, z = 6, 4, 2
-  a = sparse.eye(m, n, format='csc')
-  b = np.zeros(m)
-  c = np.zeros(n)
-  solver = qtqp.QTQP(a=a, b=b, c=c, z=z)
-  solver.equilibration_strategy = qtqp.EquilibrationStrategy.NONE
-  x, y, s, tau, meta = solver._init_orthant(b, mu_scale=1.0)
-  assert tau == 1.0
-  assert np.all(x == 0.0)
-  np.testing.assert_array_equal(y[z:], 1.0)
-  np.testing.assert_array_equal(s[z:], meta['mu_0'])
-
-
-@pytest.mark.parametrize('bad_value', [0.0, -1.0, float('nan'), float('inf')])
-def test_init_orthant_rejects_invalid_mu_scale(bad_value):
-  """Non-positive or non-finite init_mu_scale must raise a clear error."""
-  rng = np.random.default_rng(0)
-  a, b, c, p = _gen_feasible(20, 12, 3, random_state=rng)
-  with pytest.raises(ValueError, match='init_mu_scale'):
-    qtqp.QTQP(a=a, b=b, c=c, z=3, p=p).solve(
-        init_strategy=qtqp.InitStrategy.ORTHANT,
-        init_mu_scale=bad_value,
-        verbose=False,
-    )
-
-
-def test_init_orthant_stable_for_large_positive_beta():
-  """The branch-selected formula must avoid catastrophic cancellation.
-
-  Small mu_scale drives beta = b / (mu_scale * ||b||) to large magnitudes; for
-  beta >> 0 the naive form 0.5*(-beta + sqrt(beta^2+4)) loses all precision,
-  while the alternate form 2/(beta + sqrt(beta^2+4)) does not. The centering
-  residual stays at machine epsilon either way only with the branched form.
-  """
-  m, n, z = 4, 2, 0
-  c = np.zeros(n)
-  b = np.array([10.0, 1.0, 0.5, 2.0])
-  solver = qtqp.QTQP(a=sparse.eye(m, n, format='csc'), b=b, c=c, z=z)
-  solver.equilibration_strategy = qtqp.EquilibrationStrategy.NONE
-  mu_scale = 1e-7  # forces beta to ~1e6 in magnitude
-  _, y, s, _, meta = solver._init_orthant(b, mu_scale=mu_scale)
-  mu_0 = meta['mu_0']
-  # Centering residual must remain near machine precision (the naive
-  # cancellation-prone form would blow this up by ~beta^2 ~ 1e12).
-  resid = mu_0 * y + b - mu_0 / y
-  np.testing.assert_allclose(resid / mu_0, 0.0, atol=1e-7)
-  assert np.all(y > 0)
-  assert np.all(s > 0)
-
 
 def test_init_cvxopt_strict_interior():
   """CVXOPT init must produce strictly interior y[z:] and s[z:]."""
@@ -2548,18 +2415,13 @@ def test_init_cvxopt_strict_interior():
   assert np.min(s[z:]) >= 1.0 - 1e-12
 
 
-def test_init_strategy_mostly_equality_problem():
-  """All strategies must work when most rows are equalities (z close to m)."""
+def test_init_mostly_equality_problem():
+  """The init must work when most rows are equalities (z close to m)."""
   rng = np.random.default_rng(21)
   m, n, z = 25, 30, 22  # 22 equality rows + 3 inequality rows
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
-  for strat in _INIT_STRATEGIES:
-    solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-        init_strategy=strat, verbose=False
-    )
-    assert solution.status == qtqp.SolutionStatus.SOLVED, (
-        f"strategy {strat} failed on mostly-equality problem"
-    )
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  assert solution.status == qtqp.SolutionStatus.SOLVED
 
 
 # =============================================================================


### PR DESCRIPTION
The initialization showdown was decided by campaign evidence and CVXOPT has been the default since #99. Removes the InitStrategy enum, the init_strategy and init_mu_scale kwargs, the orthant init and its tests, and the trivial-init test pins; the trivial path survives as the internal fallback for degenerate initialization KKT solves. The stats-monotonicity test now asserts the true contract (mu positivity + overall convergence) rather than the trivial-trajectory property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)