### PR TITLE
Make the fused corrector slack update unconditional; remove the flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@ solve(
         qtqp.RefinementStrategy.GMRES
     ),
     gmres_restart: int = 20,
-    fused_corrector_division: bool = False,
 ) -> qtqp.Solution
 ```
 
@@ -212,9 +211,6 @@ Key parameters:
     Defaults to `20`: one uninterrupted Krylov cycle spanning the full
     refinement budget, avoiding restart stagnation. Ignored by Richardson
     refinement.
--   `fused_corrector_division`: If True, computes the Mehrotra corrector slack
-    update with one fused division. The default False preserves legacy
-    arithmetic.
 -   `max_centrality_correctors`: Maximum Gondzio-style centrality correctors
     per iteration, each one extra back-solve on the existing factorization,
     recentering the aspirational trial point's outlier complementarity
@@ -288,12 +284,6 @@ Choose one with the `refinement_strategy` argument:
     path itself commits: residuals are judged against the larger of the
     floating-point measurement floor of their summands and the perturbation
     allowance of the path.
--   `fused_corrector_division`: Fuses the corrector slack numerator before
-    dividing by `y[z:]`. This is useful when small `y` components make the
-    legacy three-division form vulnerable to cancellation.
-
-This method will return a `qtqp.Solution` object, with fields:
-
 -   `x`: (n) Primal variable or certificate of unboundedness.
 -   `y`: (m) Dual variable or certificate of infeasibility.
 -   `s`: (m) Slack variable or certificate of unboundedness.

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -530,7 +530,6 @@ class QTQP:
       collect_stats: bool = False,
       refinement_strategy: RefinementStrategy = RefinementStrategy.GMRES,
       gmres_restart: int = 20,
-      fused_corrector_division: bool = False,
       warm_start: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
       warm_start_threshold: float = 100.0,
       adaptive_step_size: bool = True,
@@ -556,7 +555,6 @@ class QTQP:
           collect_stats=collect_stats,
           refinement_strategy=refinement_strategy,
           gmres_restart=gmres_restart,
-          fused_corrector_division=fused_corrector_division,
           warm_start=warm_start,
           warm_start_threshold=warm_start_threshold,
           adaptive_step_size=adaptive_step_size,
@@ -586,7 +584,6 @@ class QTQP:
       collect_stats: bool = False,
       refinement_strategy: RefinementStrategy = RefinementStrategy.GMRES,
       gmres_restart: int = 20,
-      fused_corrector_division: bool = False,
       warm_start: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
       warm_start_threshold: float = 100.0,
       adaptive_step_size: bool = True,
@@ -646,14 +643,6 @@ class QTQP:
         stagnation; shorter cycles reduce orthogonalization cost at the
         price of more restarts. Ignored when refinement_strategy is
         RICHARDSON.
-      fused_corrector_division (bool): If True, compute the corrector
-        slack update via a single division by y[z:] with the three
-        numerator terms (sigma*mu, the Mehrotra cross product, and
-        y_c*s) assembled first. Algebraically equivalent to the default
-        three-division formula `sigma*mu/y + correction - y_c*s/y`, but
-        avoids catastrophic cancellation when y_i is small and the
-        terms have similar magnitudes with opposing signs. Default False
-        preserves the legacy bit-for-bit behavior.
       warm_start (tuple | None): Optional (x, y, s) from a nearby problem
         (original scale, e.g. a previous Solution's arrays). The point is
         equilibrated into the operating scale, embedded interior at a few
@@ -705,7 +694,6 @@ class QTQP:
     if max_centrality_correctors < 0:
       raise ValueError("max_centrality_correctors must be >= 0.")
     self._max_centrality_correctors = int(max_centrality_correctors)
-    self._fused_corrector_division = bool(fused_corrector_division)
 
     resolved_linear_solver, linear_solver_backend = _resolve_linear_solver(
         linear_solver
@@ -884,11 +872,9 @@ class QTQP:
         # target=0: (y + d_y)(s + d_s) ≈ 0 => d_s = -(y + d_y)*s/y = -y_p*s/y.
         d_s[self.z :] = -y_p[self.z :] * s[self.z :] / y[self.z :]
 
-        # Pre-compute the Mehrotra cross term in un-divided form only when the
-        # fused-corrector path will consume it (otherwise stay on the legacy
-        # `-d_s * d_y_p / y` formulation verbatim).
-        if self._fused_corrector_division:
-          cross_p = d_s[self.z :] * d_y_p[self.z :]
+        # The Mehrotra cross term in un-divided form; consumed by the
+        # corrector RHS and by the fused slack update below.
+        cross_p = d_s[self.z :] * d_y_p[self.z :]
 
         # Compute predictor step size and resulting centering parameter (sigma)
         alpha_p = self._compute_step_size(y, s, d_y_p, d_s)
@@ -906,10 +892,7 @@ class QTQP:
         # feed the predictor's cross-term d_y_p*d_s_p back into the corrector RHS
         # (divided by y because the KKT complementarity block is scaled by 1/y),
         # so the corrector step can incorporate it to land closer to the target.
-        if self._fused_corrector_division:
-          correction = -cross_p / y[self.z :]
-        else:
-          correction = -d_s[self.z :] * d_y_p[self.z :] / y[self.z :]
+        correction = -cross_p / y[self.z :]
         xy[: self.n] = x_p
         xy[self.n :] = y_p
         x_c, y_c, tau_c, corrector_lin_sys_stats = self._newton_step(
@@ -928,22 +911,19 @@ class QTQP:
 
         # --- Step 4: Update Iterates ---
         d_x, d_y, d_tau = x_c - x, y_c - y, tau_c - tau
-        if self._fused_corrector_division:
-          # Combined-numerator corrector slack step. Algebraically equivalent
-          # to `sigma*mu/y + correction - y_c*s/y`, but assembles the
-          # numerator before the single division by y[z:], avoiding
-          # catastrophic cancellation when y_i is small and the three terms
-          # have similar magnitudes with opposing signs.
-          d_s[self.z :] = (
-              sigma * mu - cross_p - y_c[self.z :] * s[self.z :]
-          ) / y[self.z :]
-        else:
-          # Legacy three-division formula.
-          d_s[self.z :] = (
-              sigma * mu / y[self.z :]
-              + correction
-              - y_c[self.z :] * s[self.z :] / y[self.z :]
-          )
+        # Combined-numerator corrector slack step: assemble the numerator
+        # before the single division by y[z:], avoiding catastrophic
+        # cancellation when y_i is small and the three terms have similar
+        # magnitudes with opposing signs — the regime the adaptive endgame
+        # deliberately operates in (boundary margins ~1e-4). The legacy
+        # three-division form (sigma*mu/y + correction - y_c*s/y) rounds
+        # each quotient before the cancellation, amplifying the error by
+        # 1/y_i; at corpus scale the two are indistinguishable, but the
+        # fused form is correct by construction and occasionally prevents
+        # corrector directions that instantly exit the cone.
+        d_s[self.z :] = (
+            sigma * mu - cross_p - y_c[self.z :] * s[self.z :]
+        ) / y[self.z :]
 
         alpha = self._compute_step_size(y, s, d_y, d_s)
         # --- Gondzio multiple centrality correctors ---

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -2773,61 +2773,17 @@ def test_gmres_rollback_on_stalled_refinement():
 
 
 # =============================================================================
-# fused_corrector_division: single-division Mehrotra corrector
+# Fused (single-division) Mehrotra corrector slack update
 # =============================================================================
 
 
-def test_fused_corrector_off_is_bitwise_legacy():
-  """Default (flag absent) and explicit fused_corrector_division=False must
-  produce bit-for-bit identical solutions on a deterministic backend: the
-  legacy code path stays untouched. Pin the backend to SCIPY because the
-  AUTO/Accelerate path has multi-threaded BLAS reductions that aren't
-  bit-deterministic across consecutive calls."""
-  rng = np.random.default_rng(8100)
-  a, b, c, p = _gen_feasible(50, 30, 5, random_state=rng)
-
-  kwargs = dict(verbose=False, linear_solver=qtqp.LinearSolver.SCIPY)
-  sol_default = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(**kwargs)
-  sol_explicit = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
-      **kwargs, fused_corrector_division=False
-  )
-
-  np.testing.assert_array_equal(sol_default.x, sol_explicit.x)
-  np.testing.assert_array_equal(sol_default.y, sol_explicit.y)
-  np.testing.assert_array_equal(sol_default.s, sol_explicit.s)
-
-
-def test_fused_corrector_on_matches_off_on_well_conditioned():
-  """Flag-on and flag-off must produce KKT-equivalent solutions on a
-  well-conditioned problem: the refactor is algebraically equivalent, so
-  the only differences come from float round-off and are tiny."""
-  rng = np.random.default_rng(8200)
-  m, n, z = 50, 30, 5
-  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
-
-  sol_off = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=False, fused_corrector_division=False
-  )
-  sol_on = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=False, fused_corrector_division=True
-  )
-
-  assert sol_off.status == qtqp.SolutionStatus.SOLVED
-  assert sol_on.status == qtqp.SolutionStatus.SOLVED
-  _assert_solution(sol_off, a, b, c, p, z)
-  _assert_solution(sol_on, a, b, c, p, z)
-  obj_off = c @ sol_off.x + 0.5 * sol_off.x @ p @ sol_off.x
-  obj_on = c @ sol_on.x + 0.5 * sol_on.x @ p @ sol_on.x
-  np.testing.assert_allclose(obj_on, obj_off, rtol=1e-10, atol=1e-10)
-
-
 @pytest.mark.parametrize('seed', 8300 + np.arange(3))
-def test_fused_corrector_on_feasible_battery(seed):
-  """Flag-on must solve a feasible QP to optimality."""
+def test_fused_corrector_feasible_battery(seed):
+  """The fused corrector must solve a feasible QP to optimality."""
   rng = np.random.default_rng(seed)
   a, b, c, p = _gen_feasible(80, 50, 10, random_state=rng)
   solution = qtqp.QTQP(a=a, b=b, c=c, z=10, p=p).solve(
-      verbose=False, fused_corrector_division=True
+      verbose=False
   )
   _assert_solution(solution, a, b, c, p, 10)
 
@@ -2837,7 +2793,7 @@ def test_fused_corrector_on_infeasible():
   rng = np.random.default_rng(8400)
   a, b, c, p = _gen_infeasible(40, 25, 5, random_state=rng)
   solution = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
-      verbose=False, fused_corrector_division=True
+      verbose=False
   )
   _assert_infeasible(solution, a, b, 5)
 
@@ -2847,7 +2803,7 @@ def test_fused_corrector_on_unbounded():
   rng = np.random.default_rng(8401)
   a, b, c, p = _gen_unbounded(40, 25, 5, random_state=rng)
   solution = qtqp.QTQP(a=a, b=b, c=c, z=5, p=p).solve(
-      verbose=False, fused_corrector_division=True
+      verbose=False
   )
   _assert_unbounded(solution, a, c, p, 5)
 
@@ -2870,7 +2826,6 @@ def test_fused_corrector_handles_tiny_y():
   # near optimality, which is the regime the refactor protects against.
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
       verbose=False,
-      fused_corrector_division=True,
       collect_stats=True,
   )
   assert solution.status == qtqp.SolutionStatus.SOLVED


### PR DESCRIPTION
The cancellation-free combined-numerator corrector becomes the only path. Corpus validation: exact parity in total solves (377=377) with a small reshuffle (MIPLIB 161 vs 160; dfl001 returns to an honest almost), no detection changes, no false certificates. With the corpus indistinguishable, the numerically-correct formula wins per validated-levers-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)