### PR TITLE
Review batch: embedding dichotomy gates and numerical-contract fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
   build-and-publish:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [test]
+    needs: [lint, test]
     name: Build & Publish to PyPI
     runs-on: ubuntu-latest
     permissions:

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -313,7 +313,12 @@ class QTQP:
           and np.max(np.abs(asymmetry.data), initial=0.0) > 1e-12 * p_scale
       ):
         raise ValueError("QP matrix 'p' must be symmetric.")
-      self.p = p
+      # Symmetrize the accepted matrix so the factorized triu(P) and the
+      # residual evaluations see the same operator: a within-tolerance
+      # asymmetry concentrated in one block otherwise makes the KKT system
+      # and the termination test disagree. Exactly symmetric inputs are
+      # unchanged (0.5*(a + a) == a in IEEE arithmetic).
+      self.p = ((p + p.T) * 0.5).tocsc()
 
     # Defaults so _check_termination works in tests that call it directly
     # before solve() has initialized the tracking state.
@@ -323,6 +328,10 @@ class QTQP:
   def _presolve(self, inf_bound: float = 1e20):
     """Drop inequality rows with trivially-satisfied RHS (b[i] >= inf_bound
     or +inf). Equality RHS must be finite; inequality RHS may not be NaN or -inf.
+
+    Contract: inequality RHS entries at or above 1e20 are treated as
+    +infinity, per the common dataset convention. Encoding a real finite
+    constraint with b[i] >= 1e20 (e.g. a 1e20-scaled row) is a user error.
     """
     self._presolve_state = None
     if not np.all(np.isfinite(self.b[: self.z])):
@@ -691,8 +700,12 @@ class QTQP:
     assert linear_solver_atol >= 0
     assert linear_solver_rtol >= 0
     self._adaptive_step_size = bool(adaptive_step_size)
-    if max_centrality_correctors < 0:
-      raise ValueError("max_centrality_correctors must be >= 0.")
+    if (max_centrality_correctors < 0
+        or max_centrality_correctors != int(max_centrality_correctors)):
+      raise ValueError(
+          "max_centrality_correctors must be a nonnegative integer, got"
+          f" {max_centrality_correctors!r}."
+      )
     self._max_centrality_correctors = int(max_centrality_correctors)
 
     resolved_linear_solver, linear_solver_backend = _resolve_linear_solver(
@@ -756,7 +769,19 @@ class QTQP:
 
     stats = []
     self.kinv_q = np.zeros_like(self.q)  # K^{-1}q, warm-started across iterations.
-    x, y, s, tau, _ = self._init_variables(a, p, b, c)
+    try:
+      x, y, s, tau, _ = self._init_variables(a, p, b, c)
+    except (ValueError, ArithmeticError, np.linalg.LinAlgError, RuntimeError):
+      # Initialization KKT failures are numeric breakdowns, not user
+      # errors: honor the documented no-raise contract with a FAILED
+      # solution (no iterates exist yet to salvage).
+      logging.exception("Initialization failed; returning FAILED.")
+      nan_y, nan_s = self._postsolve(
+          np.full(self.m, np.nan), np.full(self.m, np.nan), s_dropped=np.nan
+      )
+      return Solution(
+          np.full(self.n, np.nan), nan_y, nan_s, [], SolutionStatus.FAILED
+      )
     self._best_almost_score = math.inf
     self._best_almost_iterate = None
     status = SolutionStatus.UNFINISHED
@@ -776,12 +801,25 @@ class QTQP:
             f" {warm_start_threshold}"
         )
       wx, wy, ws = (np.asarray(v, dtype=float).copy() for v in warm_start)
+      ps = self._presolve_state
+      full_m = self.m + (len(ps.b_dropped) if ps is not None else 0)
+      if (ps is not None and wx.shape == (self.n,)
+          and wy.shape == (full_m,) and ws.shape == (full_m,)):
+        # Full-size vectors (e.g. a previous Solution after postsolve
+        # restored the presolve-dropped rows): slice back to the reduced
+        # internal problem.
+        wy, ws = wy[ps.keep], ws[ps.keep]
       if wx.shape != (self.n,) or wy.shape != (self.m,) or ws.shape != (self.m,):
         raise ValueError(
             "warm_start must be (x, y, s) with shapes"
-            f" ({self.n},), ({self.m},), ({self.m},); got"
-            f" {wx.shape}, {wy.shape}, {ws.shape}"
+            f" ({self.n},), ({self.m},), ({self.m},)"
+            + (f" or ({self.n},), ({full_m},), ({full_m},)"
+               if full_m != self.m else "")
+            + f"; got {wx.shape}, {wy.shape}, {ws.shape}"
         )
+      if not (np.all(np.isfinite(wx)) and np.all(np.isfinite(wy))
+              and np.all(np.isfinite(ws))):
+        raise ValueError("warm_start arrays must be finite.")
       if self.equilibration_strategy is not EquilibrationStrategy.NONE:
         wx, wy, ws = self._equilibrate_iterates(wx, wy, ws)
       best = (math.inf, None)
@@ -932,10 +970,11 @@ class QTQP:
         # point's outlier complementarity products back into a symmetric
         # neighborhood of the target, accept only if the step size improves.
         mu_c = sigma * mu
+        latest_tau_method = corrector_lin_sys_stats.get("tau_method")
         for _ in range(self._max_centrality_correctors):
           if alpha >= 0.9:
             break  # step already good; a corrector cannot pay for itself
-          if corrector_lin_sys_stats.get("tau_method") != "quadratic":
+          if latest_tau_method != "quadratic":
             break  # tau solve degraded; do not stack correctors on it
           alpha_asp = min(1.0, 1.5 * alpha + 0.3)
           v = (y[self.z :] + alpha_asp * d_y[self.z :]) * (
@@ -960,16 +999,19 @@ class QTQP:
               correction=correction_g,
           )
           d_s_g = np.zeros_like(d_s)
+          # Combined-numerator form, matching the primary corrector: the
+          # three-division expression reintroduces exactly the cancellation
+          # the fused corrector exists to avoid, on the difficult steps
+          # where Gondzio correctors fire.
           d_s_g[self.z :] = (
-              mu_c / y[self.z :]
-              + correction_g
-              - y_g[self.z :] * s[self.z :] / y[self.z :]
-          )
+              mu_c - cross_p + (target - v) - y_g[self.z :] * s[self.z :]
+          ) / y[self.z :]
           d_y_g = y_g - y
           alpha_g = self._compute_step_size(y, s, d_y_g, d_s_g)
           if alpha_g <= alpha + 0.1 * (alpha_asp - alpha):
             break
           stats_i["gondzio_lin_sys_stats"] = gondzio_lin_sys_stats
+          latest_tau_method = gondzio_lin_sys_stats.get("tau_method")
           d_x, d_y, d_tau = x_g - x, d_y_g, tau_g - tau
           d_s = d_s_g
           correction = correction_g
@@ -1012,7 +1054,8 @@ class QTQP:
         if collect_stats:
           stats[-1]["status"] = status
 
-    except (ValueError, ArithmeticError, np.linalg.LinAlgError) as exc:
+    except (ValueError, ArithmeticError, np.linalg.LinAlgError,
+            RuntimeError) as exc:
       logging.warning("Numeric failure at iteration %d: %s", self.it, exc)
       status = SolutionStatus.UNFINISHED
       if collect_stats and stats:
@@ -1055,6 +1098,8 @@ class QTQP:
           self._log_footer("Almost solved (best iterate salvage)")
           bx, by, bs = bx / btau, by / btau, bs / btau
           by, bs = self._postsolve(by, bs, s_dropped=self._dropped_slack(bx))
+          if stats:
+            stats[-1]["status"] = SolutionStatus.ALMOST_SOLVED
           return Solution(bx, by, bs, stats, SolutionStatus.ALMOST_SOLVED)
         if status is SolutionStatus.HIT_MAX_ITER:
           self._log_footer("Hit maximum iterations")
@@ -1553,10 +1598,13 @@ class QTQP:
     norm_aty = _norm(aty, np.inf)
     norm_px = _norm(px, np.inf)
     norm_ax_plus_s = _norm(ax_plus_s, np.inf)
-    dinfeas_a = norm_ax_plus_s / (self._norm_a_inf * norm_x + _EPS)
-    dinfeas_p = norm_px / (self._norm_p_inf * norm_x + _EPS)
+    # A zero operator norm means the corresponding homogeneous condition
+    # is judged per unit ray (any violation is absolute): fall back to a
+    # unit scale instead of letting the epsilon denominator veto exact rays.
+    dinfeas_a = norm_ax_plus_s / ((self._norm_a_inf or 1.0) * norm_x + _EPS)
+    dinfeas_p = norm_px / ((self._norm_p_inf or 1.0) * norm_x + _EPS)
     dinfeas = max(dinfeas_a, dinfeas_p)
-    pinfeas = norm_aty / (self._norm_a_one * norm_y + _EPS)
+    pinfeas = norm_aty / ((self._norm_a_one or 1.0) * norm_y + _EPS)
 
     # Residual tolerance relative scales. Each is the max of two families:
     # the summand norms (the floor below which the residual cannot even be
@@ -1588,9 +1636,21 @@ class QTQP:
         (norm_x + norm_y) * inv_tau,
     )
 
+    # Embedding dichotomy gate: at the limit, tau > 0, kappa = 0 is a
+    # solution and tau = 0, kappa > 0 is a certificate; kappa = mu/tau, so
+    # kappa < tau (mu < tau^2) demands the iterate be on the solution side
+    # before residual arithmetic gets a say, and kappa > tau the certificate
+    # side. This closes the acceptance laundering where a diverging
+    # iterate's own norm inflates the relative tolerance scales until an
+    # unbounded or infeasible problem exits SOLVED (and, symmetrically,
+    # gives false certificates a second structural guard).
+    on_solution_side = mu_hat < tau * tau
+    on_certificate_side = mu_hat > tau * tau
+
     # Solved: duality gap and both residuals are within tolerance.
     if (
-        gap < self.atol + self.rtol * gaprelrhs
+        on_solution_side
+        and gap < self.atol + self.rtol * gaprelrhs
         and pres < self.atol + self.rtol * prelrhs
         and dres < self.atol + self.rtol * drelrhs
     ):
@@ -1610,14 +1670,16 @@ class QTQP:
     # data-scaled denominator vanishes while the numerator retains the
     # O(1) slack s, so dinfeas diverges and nothing is certified.
     elif (
-        ctx < -(self.rtol_infeas * self._norm_c * norm_x + _EPS)
+        on_certificate_side
+        and ctx < -(self.rtol_infeas * self._norm_c * norm_x + _EPS)
         and dinfeas < self.atol_infeas
         and max(norm_ax_plus_s, norm_px)
         < self.atol_infeas * abs(ctx) + self.rtol_infeas * norm_x
     ):
       status = SolutionStatus.UNBOUNDED
     elif (
-        bty < -(self.rtol_infeas * self._norm_b * norm_y + _EPS)
+        on_certificate_side
+        and bty < -(self.rtol_infeas * self._norm_b * norm_y + _EPS)
         and pinfeas < self.atol_infeas
         and norm_aty < self.atol_infeas * abs(bty) + self.rtol_infeas * norm_y
     ):
@@ -1636,7 +1698,7 @@ class QTQP:
         pres / (almost_atol + almost_rtol * prelrhs),
         dres / (almost_atol + almost_rtol * drelrhs),
     )
-    if almost_score < self._best_almost_score:
+    if on_solution_side and almost_score < self._best_almost_score:
       self._best_almost_score = almost_score
       self._best_almost_iterate = (x.copy(), y.copy(), s.copy(), tau)
 

--- a/src/qtqp/direct.py
+++ b/src/qtqp/direct.py
@@ -276,10 +276,12 @@ class DirectKktSolver:
       try:
         self._solver.factorize()
         break
-      except ValueError:
+      except (ValueError, RuntimeError, np.linalg.LinAlgError):
         if attempt == 2:
           raise
-        clamp *= 1e4
+        # A permitted zero regularization would stay zero under pure
+        # scaling; jump to a sane floor so the retry is effective.
+        clamp = clamp * 1e4 if clamp > 0.0 else 1e-8
         logging.debug(
             "Factorization breakdown; retrying with clamp %.1e", clamp
         )
@@ -373,15 +375,21 @@ class DirectKktSolver:
     status, solves = "non-converged", 0
     # max_iterative_refinement_steps >= 1 so we always do at least one solve.
     for solves in range(1, self.max_iterative_refinement_steps + 1):
-      # Perform correction step using the linear system solver.
+      # Perform correction step using the linear system solver. The update
+      # rebinds rather than mutates so sol_prev snapshots the pre-step
+      # iterate: backends are allowed to return (and reuse) an internal
+      # buffer for both solve() and the @ matvec, so the correction array
+      # itself is NOT stable across the residual evaluation below and must
+      # never be used for rollback.
       old_residual_norm = residual_norm
-      correction = self._solver.solve(residual)
-      sol += correction
+      sol_prev = sol
+      sol = sol + self._solver.solve(residual)
       residual = self._kkt_rhs - self._solver @ sol + self._diag_correction * sol
       residual_norm = np.linalg.norm(residual, np.inf)
 
-      # Check for convergence.
-      if residual_norm < tolerance:
+      # Check for convergence (<= so an exact zero residual converges even
+      # under zero tolerances instead of being labeled stalled).
+      if residual_norm <= tolerance:
         status = "converged"
         break
 
@@ -405,7 +413,7 @@ class DirectKktSolver:
         # that regime and are calibrated to the legacy behavior, and the
         # two iterates are numerically equivalent there anyway.
         if residual_norm > _STALL_ROLLBACK_FACTOR * old_residual_norm:
-          sol -= correction
+          sol = sol_prev
           residual_norm = old_residual_norm
         status = "stalled"
         break
@@ -587,12 +595,14 @@ class DirectKktSolver:
       # New Givens rotation to zero out h[j+1, j].
       rho = float(np.hypot(h[j, j], h[j + 1, j]))
       if rho == 0.0:
-        # Breakdown with a zero pivot: both entries vanish, so the
-        # rotation is arbitrary; the identity keeps everything finite.
-        cs[j], sn[j] = 1.0, 0.0
-      else:
-        cs[j] = h[j, j] / rho
-        sn[j] = h[j + 1, j] / rho
+        # Zero pivot: the new column contributes nothing the least-squares
+        # solve can use, and keeping it would make the triangular solve
+        # singular. Exit the cycle with the columns accumulated so far
+        # (possibly none) - a lucky/structural breakdown, not an error.
+        j_done = j
+        break
+      cs[j] = h[j, j] / rho
+      sn[j] = h[j + 1, j] / rho
       h[j, j] = rho
       h[j + 1, j] = 0.0
 
@@ -609,8 +619,9 @@ class DirectKktSolver:
     # sol += M^{-1}(V.T @ y), but consumes no additional factor-solve at
     # cycle exit -- which keeps each cycle's apply count equal to the
     # number of Arnoldi steps performed.
-    y = solve_triangular(h[:j_done, :j_done], g[:j_done])
-    sol += z[:j_done].T @ y
+    if j_done:
+      y = solve_triangular(h[:j_done, :j_done], g[:j_done])
+      sol += z[:j_done].T @ y
     return j_done
 
   def free(self):

--- a/src/qtqp/solvers_gpu.py
+++ b/src/qtqp/solvers_gpu.py
@@ -62,7 +62,6 @@ class CuDssSolver(LinearSolver):
     self._cp.copyto(self._kkt_diag_gpu, diag_gpu)
 
   def factorize(self):
-    cp = self._cp
     if self._solver is None:
       sparse_system_type = (
           self.nvmath.sparse.advanced.DirectSolverMatrixType.SYMMETRIC
@@ -79,8 +78,8 @@ class CuDssSolver(LinearSolver):
           logger=logger,
       )
       n = self._kkt_gpu.shape[1]
-      self._x_gpu = cp.empty(n, dtype=cp.float64)
-      self._rhs_gpu = cp.empty(n, order="F", dtype=cp.float64)
+      self._x_gpu = self._cp.empty(n, dtype=self._cp.float64)
+      self._rhs_gpu = self._cp.empty(n, order="F", dtype=self._cp.float64)
       self._solver = self.nvmath.sparse.advanced.DirectSolver(
           self._kkt_gpu, self._rhs_gpu, options=options
       )
@@ -133,86 +132,80 @@ class CupyDenseSolver(LinearSolver):
     self._m = 0
 
   def set_dims(self, n: int, m: int, z: int) -> None:
-    cp = self._cp
     self._n = n
     self._m = m
     self._A_gpu = None
     self._P_offdiag_gpu = None
-    self._R_x_gpu = cp.empty(n, dtype=cp.float64)
-    self._R_y_gpu = cp.empty(m, dtype=cp.float64)
-    self._inv_R_y_gpu = cp.empty(m, dtype=cp.float64)
-    self._inv_sqrt_R_y_gpu = cp.empty(m, dtype=cp.float64)
-    self._G_gpu = cp.empty((n, n), dtype=cp.float64)
-    self._diag_idx = cp.arange(n)
-    self._result_gpu = cp.empty(n + m, dtype=cp.float64)
-    self._x_gpu = cp.empty(n + m, dtype=cp.float64)
-    self._rhs_gpu = cp.empty(n + m, dtype=cp.float64)
-    self._g_gpu = cp.empty(n, dtype=cp.float64)
+    self._R_x_gpu = self._cp.empty(n, dtype=self._cp.float64)
+    self._R_y_gpu = self._cp.empty(m, dtype=self._cp.float64)
+    self._inv_R_y_gpu = self._cp.empty(m, dtype=self._cp.float64)
+    self._inv_sqrt_R_y_gpu = self._cp.empty(m, dtype=self._cp.float64)
+    self._G_gpu = self._cp.empty((n, n), dtype=self._cp.float64)
+    self._diag_idx = self._cp.arange(n)
+    self._result_gpu = self._cp.empty(n + m, dtype=self._cp.float64)
+    self._x_gpu = self._cp.empty(n + m, dtype=self._cp.float64)
+    self._rhs_gpu = self._cp.empty(n + m, dtype=self._cp.float64)
+    self._g_gpu = self._cp.empty(n, dtype=self._cp.float64)
     self._L = None  # Lower-triangular Cholesky factor
 
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     super().set_kkt(kkt)
-    cp = self._cp
     n = self._n
     kkt_dense = kkt.toarray()
-    self._A_gpu = cp.asarray(kkt_dense[:n, n:].T, dtype=cp.float64)
+    self._A_gpu = self._cp.asarray(kkt_dense[:n, n:].T, dtype=self._cp.float64)
     P_block = kkt_dense[:n, :n]
     P_block = P_block + P_block.T - np.diag(np.diag(P_block))
     np.fill_diagonal(P_block, 0.0)
-    self._P_offdiag_gpu = cp.asarray(P_block, dtype=cp.float64)
+    self._P_offdiag_gpu = self._cp.asarray(P_block, dtype=self._cp.float64)
 
   def update_diag(self, diag: np.ndarray) -> None:
-    cp = self._cp
     self._R_x_gpu.set(diag[:self._n])
     self._R_y_gpu.set(-diag[self._n:])
-    cp.divide(1.0, self._R_y_gpu, out=self._inv_R_y_gpu)
-    cp.sqrt(self._inv_R_y_gpu, out=self._inv_sqrt_R_y_gpu)
+    self._cp.divide(1.0, self._R_y_gpu, out=self._inv_R_y_gpu)
+    self._cp.sqrt(self._inv_R_y_gpu, out=self._inv_sqrt_R_y_gpu)
 
   def factorize(self) -> None:
-    cp = self._cp
     idx = self._diag_idx
-    cp.copyto(self._G_gpu, self._P_offdiag_gpu)
+    self._cp.copyto(self._G_gpu, self._P_offdiag_gpu)
     self._G_gpu[idx, idx] += self._R_x_gpu
     A_scaled = self._A_gpu * self._inv_sqrt_R_y_gpu[:, None]
     self._G_gpu += A_scaled.T @ A_scaled
     # Same numerical perturbation as ScipyDenseSolver.factorize.
-    self._G_gpu[idx, idx] += 1e-14 * cp.max(self._G_gpu[idx, idx])
-    self._L = cp.linalg.cholesky(self._G_gpu)
+    self._G_gpu[idx, idx] += 1e-14 * self._cp.max(self._G_gpu[idx, idx])
+    self._L = self._cp.linalg.cholesky(self._G_gpu)
 
   def __matmul__(self, x: np.ndarray) -> np.ndarray:
     """Note: `x` must not alias the returned buffer."""
-    cp = self._cp
     n = self._n
     self._x_gpu.set(x)
     x_x, x_y = self._x_gpu[:n], self._x_gpu[n:]
     result = self._result_gpu
-    cp.dot(self._P_offdiag_gpu, x_x, out=result[:n])
-    cp.multiply(self._R_x_gpu, x_x, out=self._g_gpu)
+    self._cp.dot(self._P_offdiag_gpu, x_x, out=result[:n])
+    self._cp.multiply(self._R_x_gpu, x_x, out=self._g_gpu)
     result[:n] += self._g_gpu
-    cp.dot(self._A_gpu.T, x_y, out=self._g_gpu)
+    self._cp.dot(self._A_gpu.T, x_y, out=self._g_gpu)
     result[:n] += self._g_gpu
-    cp.dot(self._A_gpu, x_x, out=result[n:])
+    self._cp.dot(self._A_gpu, x_x, out=result[n:])
     result[n:] -= self._R_y_gpu * x_y
-    return cp.asnumpy(result)
+    return self._cp.asnumpy(result)
 
   def solve(self, rhs: np.ndarray) -> np.ndarray:
     """Note: `rhs` must not alias the returned buffer."""
-    cp = self._cp
     n = self._n
     self._rhs_gpu.set(rhs)
     inv_R_y = self._inv_R_y_gpu
-    cp.multiply(inv_R_y, self._rhs_gpu[n:], out=self._result_gpu[n:])
-    cp.dot(self._A_gpu.T, self._result_gpu[n:], out=self._g_gpu)
+    self._cp.multiply(inv_R_y, self._rhs_gpu[n:], out=self._result_gpu[n:])
+    self._cp.dot(self._A_gpu.T, self._result_gpu[n:], out=self._g_gpu)
     self._g_gpu += self._rhs_gpu[:n]
     # Solve L L' x = g via triangular solves.
     x = self._cupyx_linalg.solve_triangular(self._L, self._g_gpu, lower=True)
     x = self._cupyx_linalg.solve_triangular(self._L, x, lower=True, trans='C')
     result = self._result_gpu
     result[:n] = x
-    cp.dot(self._A_gpu, x, out=result[n:])
+    self._cp.dot(self._A_gpu, x, out=result[n:])
     result[n:] -= self._rhs_gpu[n:]
     result[n:] *= inv_R_y
-    return cp.asnumpy(result)
+    return self._cp.asnumpy(result)
 
   def format(self) -> Literal["csr"]:
     return "csr"

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -3351,3 +3351,195 @@ def test_certificate_rejects_large_slope_pseudo_ray():
   assert status != qtqp.SolutionStatus.INFEASIBLE
 
 
+
+
+# =============================================================================
+# Review batch: embedding dichotomy gates and numerical-contract fixes
+# =============================================================================
+
+def test_unbounded_lp_not_reported_solved():
+  """An unbounded LP must never exit SOLVED, even from an adversarial
+  warm start: the kappa < tau gate blocks acceptance once the iterate
+  diverges (mu/tau^2 explodes), regardless of how the iterate norm
+  inflates the relative tolerance scales."""
+  a = sparse.csc_matrix(np.array([[0.0]]))
+  b = np.array([1.0])
+  c = np.array([-1.0])
+  for equil in (qtqp.EquilibrationStrategy.RUIZ, qtqp.EquilibrationStrategy.NONE):
+    for warm in (None, (np.array([1e6]), np.array([1e-6]), np.array([1.0]))):
+      sol = qtqp.QTQP(a=a, b=b, c=c, z=0).solve(
+          verbose=False, equilibration_strategy=equil, warm_start=warm,
+      )
+      assert sol.status != qtqp.SolutionStatus.SOLVED, (equil, warm)
+      assert sol.status != qtqp.SolutionStatus.ALMOST_SOLVED, (equil, warm)
+
+
+def test_richardson_rollback_returns_genuine_iterate_dense():
+  """The rollback must restore the pre-correction iterate even when the
+  backend reuses one buffer for solve() and the matvec (dense backends):
+  the reported residual must belong to the returned vector."""
+  rng = np.random.default_rng(4400)
+  m, n, z = 20, 12, 3
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  mu = 0.5
+  s = rng.uniform(size=m)
+  y = rng.uniform(size=m)
+  s[:z] = 0.0
+
+  class _CorruptSecond:
+    def __init__(self, inner):
+      self._inner = inner
+      self._calls = 0
+    def __getattr__(self, name):
+      return getattr(self._inner, name)
+    def __matmul__(self, other):
+      return self._inner @ other
+    def solve(self, rhs):
+      self._calls += 1
+      out = self._inner.solve(rhs)
+      if self._calls == 2:
+        out = out + 1e8 * np.ones_like(out)
+      return out
+
+  solver = qtqp.direct.DirectKktSolver(
+      a=a, p=p, z=z, min_static_regularization=1e-8,
+      max_iterative_refinement_steps=10, atol=0.0, rtol=0.0,
+      solver=_CorruptSecond(qtqp.direct.ScipyDenseSolver()),
+      refinement_strategy=qtqp.RefinementStrategy.RICHARDSON,
+  )
+  solver.update(mu=mu, s=s, y=y)
+  q = np.concatenate([c, b])
+  sol, stats = solver.solve(rhs=q, warm_start=np.zeros(n + m))
+  assert stats["status"] == "stalled"
+  # Recompute the true residual of the returned vector; it must match the
+  # reported one (the aliasing bug produced residuals ~1e50 here).
+  kkt_rhs = q.copy()
+  kkt_rhs[n:] *= -1.0
+  true_res = np.linalg.norm(
+      kkt_rhs - solver._solver @ sol + solver._diag_correction * sol, np.inf
+  )
+  np.testing.assert_allclose(true_res, stats["final_residual_norm"], rtol=1e-6)
+
+
+def test_near_symmetric_p_is_symmetrized():
+  """A within-tolerance asymmetry must not leave the factorized triu(P)
+  and the residual evaluations disagreeing: accepted P is symmetrized."""
+  rng = np.random.default_rng(4500)
+  m, n, z = 20, 6, 2
+  a, b, c, _ = _gen_feasible(m, n, z, random_state=rng)
+  # Asymmetry within the global tolerance (1e-12 * max|P|) yet material
+  # for its own tiny block: the check accepts it, so the accepted matrix
+  # must be symmetrized before factorization.
+  p = np.diag(np.full(n, 1e14))
+  p[0, 1], p[1, 0] = 5e1, 1e1
+  p = sparse.csc_matrix(p)
+  solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
+  asym = abs(solver.p - solver.p.T)
+  assert asym.max() if asym.nnz else 0.0 == 0.0
+  sol = solver.solve(verbose=False)
+  assert sol.status == qtqp.SolutionStatus.SOLVED
+
+
+def test_warm_start_accepts_postsolved_solution():
+  """A returned solution (postsolve-restored rows included) must be
+  accepted as a warm start when presolve dropped rows."""
+  rng = np.random.default_rng(4600)
+  m, n, z = 20, 12, 3
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  b2 = np.concatenate([b, [1e20]])
+  a2 = sparse.vstack([a, sparse.csc_matrix(rng.normal(size=(1, n)))]).tocsc()
+  base = qtqp.QTQP(a=a2, b=b2, c=c, z=z, p=p).solve(verbose=False)
+  assert base.status == qtqp.SolutionStatus.SOLVED
+  assert base.y.shape == (m + 1,)  # postsolve restored the dropped row
+  solver = qtqp.QTQP(a=a2, b=b2, c=c, z=z, p=p)
+  warm = solver.solve(
+      verbose=False, warm_start=(base.x, base.y, base.s)
+  )
+  assert warm.status == qtqp.SolutionStatus.SOLVED
+  assert solver.warm_accepted
+
+
+def test_gmres_zero_operator_breakdown_returns():
+  """A zero operator must produce a clean return (lucky breakdown), not a
+  singular triangular solve."""
+  n_, m_ = 3, 4
+  a = sparse.csc_matrix((m_, n_))
+  p = sparse.csc_matrix((n_, n_))
+  solver = qtqp.direct.DirectKktSolver(
+      a=a, p=p, z=0, min_static_regularization=1e-8,
+      max_iterative_refinement_steps=8, atol=1e-12, rtol=1e-12,
+      solver=qtqp.direct.ScipySolver(),
+      refinement_strategy=qtqp.RefinementStrategy.GMRES, gmres_restart=8,
+  )
+  solver.update(mu=1.0, s=np.ones(m_), y=np.ones(m_))
+  sol, stats = solver.solve(rhs=np.zeros(n_ + m_), warm_start=np.zeros(n_ + m_))
+  assert np.all(np.isfinite(sol))
+  assert stats["status"] in ("converged", "stalled", "non-converged")
+
+
+def test_factorization_retry_recovers_from_zero_regularization():
+  """With min_static_regularization=0 the retry clamp must escape zero,
+  and non-ValueError backend failures must also be retried."""
+  rng = np.random.default_rng(4700)
+  m, n, z = 20, 12, 3
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+
+  class _FailTwice:
+    def __init__(self, inner):
+      self._inner = inner
+      self._fails = 0
+    def __getattr__(self, name):
+      return getattr(self._inner, name)
+    def __matmul__(self, other):
+      return self._inner @ other
+    def factorize(self):
+      if self._fails < 2:
+        self._fails += 1
+        raise RuntimeError("synthetic factorization failure")
+      return self._inner.factorize()
+
+  solver = qtqp.direct.DirectKktSolver(
+      a=a, p=p, z=z, min_static_regularization=0.0,
+      max_iterative_refinement_steps=10, atol=1e-12, rtol=1e-12,
+      solver=_FailTwice(qtqp.direct.ScipySolver()),
+  )
+  solver.update(mu=0.5, s=np.ones(m), y=np.ones(m))  # must not raise
+  sol, stats = solver.solve(
+      rhs=np.concatenate([c, b]), warm_start=np.zeros(n + m)
+  )
+  assert np.all(np.isfinite(sol))
+
+
+def test_almost_solved_stats_status_consistent():
+  """When salvage returns ALMOST_SOLVED, the last stats row must agree."""
+  rng = np.random.default_rng(4800)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      verbose=False, collect_stats=True, max_iter=4,
+  )
+  if sol.status == qtqp.SolutionStatus.ALMOST_SOLVED:
+    assert sol.stats[-1]["status"] == qtqp.SolutionStatus.ALMOST_SOLVED
+
+
+def test_fractional_centrality_correctors_rejected():
+  rng = np.random.default_rng(4900)
+  a, b, c, p = _gen_feasible(20, 12, 3, random_state=rng)
+  with pytest.raises(ValueError, match="max_centrality_correctors"):
+    qtqp.QTQP(a=a, b=b, c=c, z=3, p=p).solve(
+        verbose=False, max_centrality_correctors=1.5
+    )
+
+
+def test_init_failure_returns_failed(monkeypatch):
+  """A numeric failure inside initialization must honor the no-raise
+  contract and return FAILED with NaN outputs."""
+  rng = np.random.default_rng(5000)
+  m, n, z = 20, 12, 3
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  def boom(self, *args, **kwargs):
+    raise RuntimeError("synthetic init breakdown")
+  monkeypatch.setattr(qtqp.QTQP, "_init_cvxopt", boom)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+  assert sol.status == qtqp.SolutionStatus.FAILED
+  assert np.all(np.isnan(sol.x))


### PR DESCRIPTION
Addresses all applicable findings from the external review of main, one commit, each reviewer repro converted to a regression test.

**Acceptance semantics (finding 1):** SOLVED requires kappa < tau (mu < tau^2) and certificates require kappa > tau — the homogeneous embedding's dichotomy enforced before residual arithmetic, closing the acceptance laundering (unbounded-LP-as-SOLVED repro now a test). ALMOST salvage carries the same gate; zero operator norms fall back to per-unit-ray certificate scales.

**Numerics:** Richardson rollback snapshots the pre-correction iterate (dense-backend buffer aliasing corrupted rollbacks; finding 3); accepted near-symmetric P symmetrized once (finding 4); Gondzio correctors use the fused slack numerator and gate stacking on the freshest tau_method (finding 8); GMRES exits cleanly on a zero Givens pivot and exact-zero residuals converge (finding 7); factorization retry escapes zero regularization and retries RuntimeError/LinAlgError (finding 9).

**Contracts:** init failures return FAILED per the no-raise contract and the iteration boundary catches RuntimeError (finding 5); warm starts accept postsolve-restored full-size vectors sliced through the presolve mask (finding 6); ALMOST updates the final stats row (finding 10); publish gates on [lint, test] (finding 11); fractional max_centrality_correctors rejected; CuPy backend uniformly self._cp, ruff E9/F clean (finding from review 1); presolve 1e20 sentinel documented as the contract per maintainer decision (finding 2).

**Status:** full-suite gate and a four-dataset acceptance-semantics sweep (MM + NETLIB feasible/infeasible + MIPLIB<20MB vs current main) run before merge; results will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)