### PR TITLE
Contracts: sentinel threshold, stats consistency, documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
   build-and-publish:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [test]
+    needs: [lint, test]
     name: Build & Publish to PyPI
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -136,7 +136,11 @@ QTQP(
 Arguments:
 
 -   `a`: (m×n) Constraint matrix.
--   `b`: (m) RHS vector.
+-   `b`: (m) RHS vector. For inequality rows, values at or above
+    `1e20 * (1 - 1e-9)` are reserved: they are treated as `+inf` (the row is
+    unbounded and removed by presolve, with its dual fixed to 0). Finite data
+    in that range is therefore discarded by design — rescale any genuine
+    constraint whose RHS approaches `1e20` before calling the solver.
 -   `c`: (n) Cost vector.
 -   `z`: Number of equality constraints (size of the zero cone). Must satisfy
     `0 ≤ z < m`.
@@ -167,6 +171,10 @@ solve(
         qtqp.RefinementStrategy.GMRES
     ),
     gmres_restart: int = 20,
+    max_centrality_correctors: int = 1,
+    adaptive_step_size: bool = True,
+    warm_start: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
+    warm_start_threshold: float = 100.0,
 ) -> qtqp.Solution
 ```
 
@@ -227,7 +235,7 @@ Key parameters:
     operating scale, embedded interior at a few centering shifts, and the
     best embedding is accepted only when the distance-to-path certificate
     measures `lambda <= warm_start_threshold`; a vetoed point falls back to
-    the configured `init_strategy`, so warm starting is never worse than a
+    the standard initialization, so warm starting is never worse than a
     cold solve by more than the certificate evaluation (three matvecs per
     shift). After `solve`, the measured `warm_lambda` and the `warm_accepted`
     decision are attributes on the solver.
@@ -248,21 +256,15 @@ Choose one with the `equilibration_strategy` argument:
     ill-scaled instances.
 -   `qtqp.EquilibrationStrategy.NONE`: Disable equilibration.
 
-#### Initialization strategies
+#### Initialization
 
-Choose one with the `init_strategy` argument:
-
--   `qtqp.InitStrategy.TRIVIAL`: Starts from `x = 0`, `tau = 1`, and
-    unit inequality components for `y` and `s`.
--   `qtqp.InitStrategy.ORTHANT`: Closed-form non-negative orthant centering. It
-    uses `init_mu_scale * ||b[z:]||_2` as the initial barrier parameter and is
-    cheap to compute.
--   `qtqp.InitStrategy.CVXOPT`: Default. Least-squares initialization in
-    the CVXOPT / Clarabel style: one saddle-point solve for QPs (two, with a
-    shared factorization, for LPs - primal from feasibility, dual from
-    optimality), run through the same linear-solver backend, ordering, static
-    regularization, and iterative refinement as the main loop, then shifted
-    into the strict interior.
+The initial iterate is a least-squares initialization in the CVXOPT /
+Clarabel style: one saddle-point solve for QPs (two, with a shared
+factorization, for LPs - primal from feasibility, dual from optimality),
+run through the same linear-solver backend, ordering, static
+regularization, and iterative refinement as the main loop, then shifted
+into the strict interior. If the initialization solve produces
+non-finite values, the solver falls back to a trivial unit start.
 
 #### Refinement strategies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.11"
 
 # Runtime deps (install-time)
 dependencies = [
-  "numpy>=1.23",
+  "numpy>=1.25.2",
   "scipy>=1.16",
   "py-mkl-pardiso; (platform_system == 'Linux' or platform_system == 'Windows') and platform_machine == 'x86_64'",
   "macldlt; platform_system == 'Darwin' and platform_machine == 'arm64'",

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -324,6 +324,12 @@ class QTQP:
   def _presolve(self, inf_bound: float = 1e20):
     """Drop inequality rows with trivially-satisfied RHS (b[i] >= inf_bound
     or +inf). Equality RHS must be finite; inequality RHS may not be NaN or -inf.
+
+    Contract: inequality RHS entries at or above 1e20 (within 1e-9
+    relative, absorbing decimal-round-trip representation noise like
+    9.999999999999998e19) are treated as +infinity, per the common
+    dataset convention. Encoding a real finite constraint with b[i] in
+    that range (e.g. a 1e20-scaled row) is a user error.
     """
     self._presolve_state = None
     if not np.all(np.isfinite(self.b[: self.z])):
@@ -339,7 +345,7 @@ class QTQP:
     # 9.999999999999998e19), which a strict >= comparison classifies as a
     # genuine finite bound -- materializing a 1e20-magnitude row that
     # silently poisons equilibration and residual scales.
-    drop[self.z :] = ineq_b >= inf_bound * (1.0 - 1e-6)
+    drop[self.z :] = ineq_b >= inf_bound * (1.0 - 1e-9)
     if not np.any(drop):
       return
     keep = ~drop
@@ -650,7 +656,7 @@ class QTQP:
         centering shifts, and the best embedding is accepted only when the
         distance-to-path certificate measures lambda <=
         warm_start_threshold; otherwise the solve falls back to the
-        configured init_strategy. After solve, `warm_lambda` (the measured
+        standard initialization. After solve, `warm_lambda` (the measured
         lambda, or None when no warm start was given) and `warm_accepted`
         are available as attributes on the solver.
       warm_start_threshold (float): Acceptance threshold for the certified
@@ -1034,7 +1040,8 @@ class QTQP:
         if collect_stats:
           stats[-1]["status"] = status
 
-    except (ValueError, ArithmeticError, np.linalg.LinAlgError) as exc:
+    except (ValueError, ArithmeticError, np.linalg.LinAlgError,
+            RuntimeError) as exc:
       logging.warning("Numeric failure at iteration %d: %s", self.it, exc)
       status = SolutionStatus.UNFINISHED
       if collect_stats and stats:
@@ -1077,6 +1084,8 @@ class QTQP:
           self._log_footer("Almost solved (best iterate salvage)")
           bx, by, bs = bx / btau, by / btau, bs / btau
           by, bs = self._postsolve(by, bs, s_dropped=self._dropped_slack(bx))
+          if stats:
+            stats[-1]["status"] = SolutionStatus.ALMOST_SOLVED
           return Solution(bx, by, bs, stats, SolutionStatus.ALMOST_SOLVED)
         if status is SolutionStatus.HIT_MAX_ITER:
           self._log_footer("Hit maximum iterations")
@@ -1295,7 +1304,7 @@ class QTQP:
     tau+ is then pinned by substituting this back into the tau equation of the
     homogeneous embedding (see _solve_for_tau).
 
-    The central-path equation r + mu^p * u = 0 contributes the
+    The central-path equation r + mu * u = 0 contributes the
     (mu - mu_target) coefficient on the linear-residual side; cone-product
     corrections (s_i * y_i = mu_target, tau * kappa = mu_target) keep the
     unmodified mu_target.
@@ -1675,7 +1684,7 @@ class QTQP:
         "dinfeas": dinfeas,
         "dinfeas_a": dinfeas_a,
         "dinfeas_p": dinfeas_p,
-        "mu": mu,
+        "mu": float(y @ s) / (self.m - self.z),
         "sigma": sigma,
         "alpha": alpha,
         "tau": tau,

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -3597,3 +3597,51 @@ def test_noncanonical_int64_duplicates_wrap_is_caught_for_p():
     qtqp.QTQP(a=a, b=np.ones(2), c=np.zeros(2), z=0, p=p)
 
 
+def test_almost_solved_stats_status_consistent():
+  """When salvage returns ALMOST_SOLVED, the last stats row must agree."""
+  rng = np.random.default_rng(4800)
+  m, n, z = 60, 40, 8
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      verbose=False, collect_stats=True, max_iter=4,
+  )
+  if sol.status == qtqp.SolutionStatus.ALMOST_SOLVED:
+    assert sol.stats[-1]["status"] == qtqp.SolutionStatus.ALMOST_SOLVED
+
+
+def test_sentinel_threshold_matches_contract():
+  '''Only representation-noise-level deviations from 1e20 are sentinels:
+  a finite RHS meaningfully below 1e20 is a real constraint.'''
+  a = sparse.csc_matrix(np.array([[1e20], [1.0]]))
+  b = np.array([9.999995e19, 2.0])
+  c = np.array([-1.0])
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=0).solve(verbose=False)
+  # The first row (a real bound, x <= 0.9999995) must be respected: the
+  # pre-fix sentinel dropped it and returned x = 2 with slack -1e20.
+  if sol.status == qtqp.SolutionStatus.SOLVED:
+    assert sol.x[0] <= 0.9999995 + 1e-6
+  # An actual round-trip-noise sentinel is still dropped.
+  b2 = np.array([9.999999999999998e19, 2.0])
+  sol2 = qtqp.QTQP(a=a, b=b2, c=c, z=0).solve(verbose=False)
+  assert sol2.status == qtqp.SolutionStatus.SOLVED
+  assert sol2.x[0] == pytest.approx(2.0, abs=1e-6)
+
+
+def test_stats_mu_is_current_complementarity():
+  '''stats["mu"] must equal the CURRENT iterate's mean complementarity
+  (the defining equation), not the pre-step value.'''
+  rng = np.random.default_rng(5800)
+  m, n, z = 40, 25, 5
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      verbose=False, collect_stats=True,
+      linear_solver=qtqp.LinearSolver.SCIPY,
+  )
+  for st in sol.stats:
+    # The complementarity stat is the RETURNED point's total s'y (divided
+    # by tau^2); mu is the embedded iterate's mean s'y. The defining
+    # relation ties them through tau exactly.
+    np.testing.assert_allclose(
+        st["mu"] * (m - z) / max(st["tau"], 1e-15) ** 2,
+        st["complementarity"], rtol=1e-9, atol=1e-30,
+    )


### PR DESCRIPTION
- Presolve treats an inequality RHS within 1e-9 (was 1e-6) of the 1e20 infinity sentinel as infinite; the wider band silently discarded genuine finite bounds.
- The main loop's numeric-failure handler also catches `RuntimeError`, which some backends raise on factorization breakdown.
- `stats["mu"]` reports the current iterate's mean complementarity, and the last stats row agrees with an ALMOST_SOLVED salvage.
- README: the `solve()` signature lists every argument; the initialization section describes the single CVXOPT-style init.
- pyproject: numpy floor raised to 1.25.2, which scipy>=1.16 requires anyway. Publishing also depends on the lint job.

Scope note: an earlier revision converted backend-setup and initialization exceptions into FAILED solutions and added a minimum-NumPy CI job; both were dropped to keep behavior identical to main there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)