### PR TITLE
Gate acceptance on the embedding dichotomy; summand-only scales

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ This class has a single API method `solve`:
 ```python
 solve(
     *,
-    atol: float = 1e-9,
-    rtol: float = 1e-9,
+    atol: float = 1e-7,
+    rtol: float = 1e-8,
     atol_infeas: float = 1e-8,
     rtol_infeas: float = 1e-9,
     max_iter: int = 100,
@@ -295,7 +295,8 @@ Choose one with the `refinement_strategy` argument:
     numerical breakdown of the linear solver, which never raises) when
     the best iterate over the trajectory (by max normalized residual)
     meets the solved-criteria form at tolerances `1000x` looser than the
-    requested `atol`/`rtol` (so `1e-6` at the defaults): the returned
+    requested `atol`/`rtol` (so `1e-4` absolute and `1e-5` relative at
+    the defaults): the returned
     solution is that best iterate, honestly labeled as not meeting the
     full `SOLVED` contract. `SOLVED` semantics are unchanged. A
     breakdown whose best iterate does not qualify returns `FAILED`.

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -53,13 +53,14 @@ _EPS = 1e-15  # Standard epsilon for numerical safety
 # ALMOST_SOLVED acceptance: on HIT_MAX_ITER or numerical breakdown, the
 # best iterate seen is returned as ALMOST_SOLVED when it meets the same
 # criteria form at tolerances this factor looser than the user-requested
-# atol/rtol (at the 1e-9 defaults: 1e-6-grade, still a usable solution).
+# atol/rtol (at the current defaults: 1e-4 absolute / 1e-5 relative,
+# still a usable near-solution).
 _ALMOST_FACTOR = 1000.0
 # Floor on the complementarity parameter mu wherever it enters the
 # algorithm (KKT shift, corrector targets, barrier terms). Below this
 # scale mu carries no information in double precision relative to O(1)
 # equilibrated data, and letting it underflow leaves the Newton system
-# effectively unregularized: at the 1e-9 default tolerances the endgame
+# effectively unregularized: at the default tolerance scale the endgame
 # reaches depths where an underflowed mu makes the KKT factorization
 # effectively singular (observed: CHOLMOD NotPositiveDefinite on
 # Windows). Healthy solves terminate at mu ~ 1e-9..1e-11 and never
@@ -521,8 +522,8 @@ class QTQP:
   def solve(
       self,
       *,
-      atol: float = 1e-9,
-      rtol: float = 1e-9,
+      atol: float = 1e-7,
+      rtol: float = 1e-8,
       atol_infeas: float = 1e-8,
       rtol_infeas: float = 1e-9,
       max_iter: int = 100,
@@ -575,8 +576,8 @@ class QTQP:
   def _solve_impl(
       self,
       *,
-      atol: float = 1e-9,
-      rtol: float = 1e-9,
+      atol: float = 1e-7,
+      rtol: float = 1e-8,
       atol_infeas: float = 1e-8,
       rtol_infeas: float = 1e-9,
       max_iter: int = 100,
@@ -605,14 +606,15 @@ class QTQP:
       atol_infeas (float): Certificate-quality tolerance for infeasibility
         and unboundedness detection. A candidate ray u must be good in two
         complementary senses: its relative backward error (violations over
-        ||operator|| * ||u||) must be below atol_infeas, AND its violations
-        must be below atol_infeas * |objective slope| + rtol_infeas * ||u||.
-        The first rejects large-slope pseudo-rays, the second rejects
-        huge-norm near-solutions; each guards the other's blind spot.
-      rtol_infeas (float): Ray-relative slack in the slope-scaled
-        certificate test, and the margin by which the certificate's
-        objective slope (c'x or b'y) must be negative relative to the data
-        and ray norms.
+        ||operator|| * ||u||) must be at most atol_infeas, AND its
+        violations must be at most atol_infeas * |objective slope| (the
+        pure-slope sense: quality judged absolutely on the slope-normalized
+        ray, with no ray-norm slack). The first rejects large-slope
+        pseudo-rays, the second rejects huge-norm weakly separating
+        near-solutions; each guards the other's blind spot.
+      rtol_infeas (float): The margin by which the certificate's objective
+        slope (c'x or b'y) must be negative relative to the data and ray
+        norms.
       max_iter (int): Maximum number of iterations before stopping.
       step_size_scale (float): A factor in (0, 1) to scale the step size,
         ensuring iterates remain strictly interior.
@@ -1589,39 +1591,29 @@ class QTQP:
     dinfeas = max(dinfeas_a, dinfeas_p)
     pinfeas = norm_aty / (self._norm_a_one * norm_y + _EPS)
 
-    # Residual tolerance relative scales. Each is the max of two families:
-    # the summand norms (the floor below which the residual cannot even be
-    # evaluated in floating point) and the iterate norm (the backward-error
-    # allowance: dres <= rtol * ||x||/tau accepts a point that is exactly
-    # dual-feasible for P + dP with ||dP|| <= rtol, which is precisely the
-    # mu*I perturbation the regularized path itself commits; likewise
-    # pres <= rtol * ||y||/tau on the primal side).
+    # Residual tolerance relative scales: the summand norms of each
+    # residual and nothing else. No iterate norm enters, so a bad warm
+    # start or a divergence cannot inflate its own tolerance.
     prelrhs = max(
-        _norm(ax, np.inf) * inv_tau,
-        _norm(s, np.inf) * inv_tau,
-        self._norm_b,
-        norm_y * inv_tau,
+        _norm(ax, np.inf) * inv_tau, _norm(s, np.inf) * inv_tau, self._norm_b
     )
+    drelrhs = max(norm_px * inv_tau, norm_aty * inv_tau, self._norm_c)
+    # Gap tolerance relative scale: the cost magnitudes.
+    gaprelrhs = min(abs(pcost), abs(dcost))
 
-    drelrhs = max(
-        norm_px * inv_tau,
-        norm_aty * inv_tau,
-        self._norm_c,
-        norm_x * inv_tau,
-    )
-
-    # Gap tolerance relative scale: the cost magnitudes (measurement floor)
-    # or the first-power iterate norm (the empirically calibrated allowance
-    # for the regularized path's O(mu*||u||^2) objective bias; see the
-    # criteria validation on NETLIB + Maros-Meszaros).
-    gaprelrhs = max(
-        min(abs(pcost), abs(dcost)),
-        (norm_x + norm_y) * inv_tau,
-    )
+    # Embedding dichotomy gate: kappa < tau (equivalently y's < nu * tau^2
+    # with nu = m - z) puts the iterate on the solution side, kappa > tau
+    # on the certificate side. A pure number, so a divergence cannot
+    # launder it: y's grows with the iterate while nu * tau^2 does not.
+    yts_ret = float(y @ s)
+    nu_tau_sq = float(self.m - self.z) * tau * tau
+    on_solution_side = yts_ret < nu_tau_sq
+    on_certificate_side = yts_ret > nu_tau_sq
 
     # Solved: duality gap and both residuals are within tolerance.
     if (
-        gap < self.atol + self.rtol * gaprelrhs
+        on_solution_side
+        and gap < self.atol + self.rtol * gaprelrhs
         and pres < self.atol + self.rtol * prelrhs
         and dres < self.atol + self.rtol * drelrhs
     ):
@@ -1632,25 +1624,27 @@ class QTQP:
     #     rejects large-slope pseudo-rays whose |c'x| buys unbounded slack
     #     in the slope-scaled test (e.g. NETLIB dfl001, where a direction
     #     violating the constraints at 5-9% of ||A|| ||x|| was certified);
-    #   - slope-scaled (violations < atol_infeas * |slope| + rtol_infeas *
-    #     ||ray||): rejects huge-norm near-solutions, whose data-scaled
+    #   - pure-slope (violations < atol_infeas * |slope|): rejects
+    #     huge-norm weakly separating near-solutions, whose data-scaled
     #     quality becomes small automatically (A'y ~ -c*tau with enormous
     #     ||y|| makes ||A'y|| / (||A||_1 ||y||) tiny while y is nothing
-    #     like a ray; e.g. NETLIB fit1p, tuff, vtp.base, fffff800).
+    #     like a ray; e.g. NETLIB fit1p, tuff, vtp.base, fffff800, and
+    #     the miplib physiciansched6-2 false-infeasibility class).
     # The quality measures need no zero-ray guard: as ||x|| -> 0 the
     # data-scaled denominator vanishes while the numerator retains the
     # O(1) slack s, so dinfeas diverges and nothing is certified.
     elif (
-        ctx < -(self.rtol_infeas * self._norm_c * norm_x + _EPS)
+        on_certificate_side
+        and ctx < -(self.rtol_infeas * self._norm_c * norm_x + _EPS)
         and dinfeas < self.atol_infeas
-        and max(norm_ax_plus_s, norm_px)
-        < self.atol_infeas * abs(ctx) + self.rtol_infeas * norm_x
+        and max(norm_ax_plus_s, norm_px) < self.atol_infeas * abs(ctx)
     ):
       status = SolutionStatus.UNBOUNDED
     elif (
-        bty < -(self.rtol_infeas * self._norm_b * norm_y + _EPS)
+        on_certificate_side
+        and bty < -(self.rtol_infeas * self._norm_b * norm_y + _EPS)
         and pinfeas < self.atol_infeas
-        and norm_aty < self.atol_infeas * abs(bty) + self.rtol_infeas * norm_y
+        and norm_aty < self.atol_infeas * abs(bty)
     ):
       status = SolutionStatus.INFEASIBLE
     else:
@@ -1667,7 +1661,10 @@ class QTQP:
         pres / (almost_atol + almost_rtol * prelrhs),
         dres / (almost_atol + almost_rtol * drelrhs),
     )
-    if almost_score < self._best_almost_score:
+    new_best_almost = (
+        on_solution_side and almost_score < self._best_almost_score
+    )
+    if new_best_almost:
       self._best_almost_score = almost_score
       self._best_almost_iterate = (x.copy(), y.copy(), s.copy(), tau)
 

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -2836,16 +2836,19 @@ def test_fused_corrector_handles_tiny_y():
     assert stats_i['alpha'] > 0.0, stats_i
 
 
-def test_default_tolerances_are_1e9():
+def test_default_tolerances_match_summand_only_criteria():
+  '''Defaults are calibrated to the summand-only termination scales: the
+  pre-tightening tier (atol=1e-7, rtol=1e-8) that the original criteria
+  were validated with.'''
   import inspect
   sig = inspect.signature(qtqp.QTQP.solve)
-  assert sig.parameters['atol'].default == 1e-9
-  assert sig.parameters['rtol'].default == 1e-9
+  assert sig.parameters['atol'].default == 1e-7
+  assert sig.parameters['rtol'].default == 1e-8
 
 
 def test_almost_solved_near_cap():
   """Capping one iteration below the solve count returns the best iterate
-  with ALMOST_SOLVED (it meets the 1e-6 criteria form), while a very early
+  with ALMOST_SOLVED (it meets the 1000x-loosened criteria form), while a very early
   cap still returns HIT_MAX_ITER."""
   rng = np.random.default_rng(9600)
   m, n, z = 60, 40, 8
@@ -3598,16 +3601,19 @@ def test_noncanonical_int64_duplicates_wrap_is_caught_for_p():
 
 
 def test_almost_solved_stats_status_consistent():
-  """When salvage returns ALMOST_SOLVED, the last stats row must agree."""
+  '''When salvage returns ALMOST_SOLVED, the last stats row must agree.
+  Unreachable tolerances with a full budget make the salvage fire
+  deterministically (the 1e-9-quality best iterate meets the
+  _ALMOST_FACTOR-loosened bar while 1e-15 never converges).'''
   rng = np.random.default_rng(4800)
   m, n, z = 60, 40, 8
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
   sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=False, collect_stats=True, max_iter=4,
+      verbose=False, collect_stats=True, atol=1e-15, rtol=1e-15,
+      linear_solver=qtqp.LinearSolver.SCIPY,
   )
-  if sol.status == qtqp.SolutionStatus.ALMOST_SOLVED:
-    assert sol.stats[-1]["status"] == qtqp.SolutionStatus.ALMOST_SOLVED
-
+  assert sol.status == qtqp.SolutionStatus.ALMOST_SOLVED
+  assert sol.stats[-1]["status"] == qtqp.SolutionStatus.ALMOST_SOLVED
 
 def test_sentinel_threshold_matches_contract():
   '''Only representation-noise-level deviations from 1e20 are sentinels:
@@ -3642,6 +3648,83 @@ def test_stats_mu_is_current_complementarity():
     # by tau^2); mu is the embedded iterate's mean s'y. The defining
     # relation ties them through tau exactly.
     np.testing.assert_allclose(
-        st["mu"] * (m - z) / max(st["tau"], 1e-15) ** 2,
+        st["mu"] * (m - z) / st["tau"] ** 2,
         st["complementarity"], rtol=1e-9, atol=1e-30,
     )
+def test_unbounded_lp_not_reported_solved():
+  """An unbounded LP must never exit SOLVED, even from an adversarial
+  warm start: the kappa < tau gate blocks acceptance once the iterate
+  diverges (mu/tau^2 explodes), regardless of how the iterate norm
+  inflates the relative tolerance scales."""
+  a = sparse.csc_matrix(np.array([[0.0]]))
+  b = np.array([1.0])
+  c = np.array([-1.0])
+  strategies = (qtqp.EquilibrationStrategy.RUIZ,
+                qtqp.EquilibrationStrategy.NONE,
+                qtqp.EquilibrationStrategy.AUGMENTED)
+  for equil in strategies:
+    for warm in (None, (np.array([1e6]), np.array([1e-6]), np.array([1.0]))):
+      sol = qtqp.QTQP(a=a, b=b, c=c, z=0).solve(
+          verbose=False, equilibration_strategy=equil, warm_start=warm,
+      )
+      assert sol.status != qtqp.SolutionStatus.SOLVED, (equil, warm)
+      assert sol.status != qtqp.SolutionStatus.ALMOST_SOLVED, (equil, warm)
+
+
+def test_infeasible_qp_not_solved_via_quadratic_bar():
+  """The dichotomy gate must be the pure-number comp < nu comparison: a
+  tolerance-scaled bar is launderable because QP objective values grow
+  quadratically along a divergence (reviewer repro: an infeasible QP
+  exited SOLVED with comp ~ 2.5e6 against an inflated 5e10 bar)."""
+  a = sparse.csc_matrix(np.array([[0.0]]))
+  b = np.array([-1.0])
+  c = np.array([-1e10])
+  p = sparse.csc_matrix(np.array([[1.0]]))
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=0, p=p).solve(
+      verbose=False,
+      equilibration_strategy=qtqp.EquilibrationStrategy.AUGMENTED,
+      warm_start=(np.array([1e10]), np.array([1e10]), np.array([1e-12])),
+  )
+  assert sol.status != qtqp.SolutionStatus.SOLVED
+  assert sol.status != qtqp.SolutionStatus.ALMOST_SOLVED
+
+
+def test_weak_separation_ray_not_certified():
+  """Round-7 root cause of the physiciansched6-2 false INFEASIBLE: a ray
+  with excellent relative dual residual but separation |b'y| / ||y|| far
+  below its violation level must not be certified - the pure-slope sense
+  requires ||A'y|| <= atol_infeas * |b'y|, with no rtol * ||ray|| slack
+  for the ray's own norm to launder."""
+  m, z = 3, 0
+  a = sparse.csc_matrix(np.eye(3, 2))
+  b = np.array([-0.05, -0.05, 0.0])
+  c = np.zeros(2)
+  solver = qtqp.QTQP(a=a, b=b, c=c, z=z)
+  solver.atol, solver.rtol = 1e-7, 1e-8
+  solver.atol_infeas, solver.rtol_infeas = 1e-8, 1e-9
+  solver.equilibration_strategy = qtqp.EquilibrationStrategy.NONE
+  solver._norm_b = np.linalg.norm(b, np.inf)
+  solver._norm_c = 0.0
+  abs_a = abs(solver.a)
+  solver._norm_a_inf = float(abs_a.sum(axis=1).max())
+  solver._norm_a_one = float(abs_a.sum(axis=0).max())
+  solver._norm_p_inf = 0.0
+  solver.it = 0
+  solver.start_time = 0.0
+  # y >= 0 with its mass in null(A') (the b_3 = 0 row): b'y = -1 while
+  # ||y|| = 1e10, so separation per unit norm is 1e-10; ||A'y|| = 10 is
+  # residual-level relative to ||A||*||y|| (1e-9, passes data-scaled) and
+  # sits just under the OLD slope bar 1e-8 + 1e-9 * 1e10 ~ 10.00000001 -
+  # exactly the physiciansched regime. The pure-slope bar is 1e-8 * 1.
+  y = np.array([10.0, 10.0, 1e10])
+  assert float(b @ y) == pytest.approx(-1.0)
+  x = np.zeros(2)
+  s = np.full(m, 1e-9)
+  tau = 1e-9  # certificate side: y's >> nu * tau^2
+  status = solver._check_termination(  # pylint: disable=protected-access
+      x, y, tau, s, alpha=0.5, mu=1.0, sigma=0.5, stats_i={},
+      collect_stats=False,
+  )
+  assert status != qtqp.SolutionStatus.INFEASIBLE, status
+
+


### PR DESCRIPTION
- **Termination scales** are the summand norms of each residual and nothing else: `pres` against `max(||Ax||, ||s||, ||b||)`, `dres` against `max(||Px||, ||A'y||, ||c||)`, the gap against `min(|pcost|, |dcost|)`. Iterate norms no longer enter, so a warm start or a divergence cannot inflate its own tolerance. Defaults move to `atol=1e-7`, `rtol=1e-8`, the tier the original criteria were validated with.
- **Dichotomy gate**: SOLVED (and the ALMOST salvage) require the iterate on the solution side of the embedding, `y's < nu * tau^2`; both certificate branches require the certificate side. A pure number, so it cannot be laundered.
- **Certificates** use the pure-slope sense, `violations < atol_infeas * |slope|`, with no `rtol * ||ray||` slack: that slack let a weakly separating near-solution certify (the physiciansched6-2 false INFEASIBLE). The data-scaled sense is unchanged.

Note: these scales are stricter than main's at the same numeric tolerance, so several corpus problems now run to the iteration cap at the defaults and return ALMOST_SOLVED (with better raw residuals than main's SOLVED). A retune follows separately.

Scope note: overflow-safe ray scaling, revalidating finalizers, two-step ratios, and multiplication-form grading for tau below 1e-15 were dropped as out of scope; grading uses main's clamped-inverse form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)