### PR TITLE
Certify warm starts before the cold initialization

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -765,7 +765,6 @@ class QTQP:
 
     stats = []
     self.kinv_q = np.zeros_like(self.q)  # K^{-1}q, warm-started across iterations.
-    x, y, s, tau, _ = self._init_variables(a, p, b, c)
     self._best_almost_score = math.inf
     self._best_almost_iterate = None
     status = SolutionStatus.UNFINISHED
@@ -822,12 +821,20 @@ class QTQP:
       self.warm_lambda = best[0]
       if best[0] <= warm_start_threshold:
         cx, cy, cs, ctau = best[1]
-        x, y, s, tau = cx, cy, cs, ctau
         self.warm_accepted = True
       logging.debug(
           "warm start: lambda = %e, accepted = %s",
           self.warm_lambda, self.warm_accepted,
       )
+
+    if self.warm_accepted:
+      x, y, s, tau = cx, cy, cs, ctau
+    else:
+      # Cold start: the initialization factorization and solves run only
+      # when no warm start was given or the certificate vetoed it - an
+      # accepted warm start skips them entirely (certification costs three
+      # matvecs per centering shift, no factorization).
+      x, y, s, tau, _ = self._init_variables(a, p, b, c)
 
     # Initial-point diagnostic: the local-norm distance-to-path measure at
     # the starting iterate (warm or configured init), before the first

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -3728,3 +3728,29 @@ def test_weak_separation_ray_not_certified():
   assert status != qtqp.SolutionStatus.INFEASIBLE, status
 
 
+def test_accepted_warm_start_skips_cold_init(monkeypatch):
+  """An accepted warm start must not pay for the cold initialization: the
+  init factorization and solves run only on cold or vetoed-warm solves."""
+  rng = np.random.default_rng(5100)
+  m, n, z = 40, 25, 5
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  base = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=False)
+
+  calls = {"n": 0}
+  original = qtqp.QTQP._init_cvxopt
+  def counting(self, *args, **kwargs):
+    calls["n"] += 1
+    return original(self, *args, **kwargs)
+  monkeypatch.setattr(qtqp.QTQP, "_init_cvxopt", counting)
+
+  solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
+  warm = solver.solve(verbose=False, warm_start=(base.x, base.y, base.s))
+  assert solver.warm_accepted
+  assert warm.status == qtqp.SolutionStatus.SOLVED
+  assert calls["n"] == 0, "accepted warm start ran the cold init"
+
+  solver2 = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
+  junk = (1e12 * np.ones(n), 1e12 * np.ones(m), np.ones(m))
+  solver2.solve(verbose=False, warm_start=junk, warm_start_threshold=1.0)
+  assert not solver2.warm_accepted
+  assert calls["n"] == 1, "vetoed warm start must fall back to the cold init"


### PR DESCRIPTION
An accepted warm start no longer pays for the cold initialization: the initialization factorization and solves run only when no warm start was given or the certificate vetoed it. Certification itself costs three matvecs per centering shift and no factorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)