### PR TITLE
Solve z == m (all-equality) problems via the direct KKT path

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,11 @@ Arguments:
     constraint whose RHS approaches `1e20` before calling the solver.
 -   `c`: (n) Cost vector.
 -   `z`: Number of equality constraints (size of the zero cone). Must satisfy
-    `0 ≤ z < m`.
+    `0 ≤ z ≤ m`; `z == m` (all-equality) is solved by a single direct KKT
+    solve, where `SOLVED` certifies the primal and dual residuals (the gap
+    is reported in stats but not tested) and a singular system is reported
+    as `FAILED`. Problems with no variables, or with no constraints left
+    after presolve, are rejected.
 -   `p`: (n×n) QP matrix. If None, treated as the zero matrix (i.e., LP).
 
 This class has a single API method `solve`:
@@ -238,7 +242,8 @@ Key parameters:
     the standard initialization, so warm starting is never worse than a
     cold solve by more than the certificate evaluation (three matvecs per
     shift). After `solve`, the measured `warm_lambda` and the `warm_accepted`
-    decision are attributes on the solver.
+    decision are attributes on the solver. The `z == m` direct solve
+    ignores a warm start.
 -   `warm_start_threshold`: Acceptance threshold for the certified warm
     start (default `100.0`). Poisoned or mis-scaled points measure orders of
     magnitude above it; same-problem re-entries orders of magnitude below.
@@ -280,17 +285,23 @@ Choose one with the `refinement_strategy` argument:
 
 #### Advanced numerical options
 
--   Termination scales include the iterate norms `||x||/tau`, `||y||/tau`
-    (and their sum for the duality gap), so acceptance is a backward-error
-    criterion consistent with the `mu`-scale perturbation the regularized
-    path itself commits: residuals are judged against the larger of the
-    floating-point measurement floor of their summands and the perturbation
-    allowance of the path.
+-   Termination scales are the summand norms of each residual and nothing
+    else: `pres` is judged against `max(||Ax||, ||s||, ||b||tau)/tau`,
+    `dres` against `max(||Px||, ||A'y||, ||c||tau)/tau`, and the duality
+    gap against `min(|pcost|, |dcost|)`. No iterate norm enters the
+    acceptance arithmetic (a bare `||x||` or `||y||` term lets a bad
+    warm start or a divergence inflate its own tolerance). The default
+    tolerances (`atol=1e-7`, `rtol=1e-8`) are calibrated to these scales.
 -   `x`: (n) Primal variable or certificate of unboundedness.
 -   `y`: (m) Dual variable or certificate of infeasibility.
 -   `s`: (m) Slack variable or certificate of unboundedness.
 -   `status`: (`qtqp.SolutionStatus`) One of `SOLVED`, `INFEASIBLE`,
     `UNBOUNDED`, `ALMOST_SOLVED`, `HIT_MAX_ITER`, `FAILED`.
+
+    Inequality rows removed by presolve (RHS at or above the `1e20`
+    infinity sentinel) are restored in `s` as `+inf` with dual `0` on
+    solution outputs, and as `NaN` on certificates; verifiers should mask
+    them.
     `ALMOST_SOLVED` is returned in place of `HIT_MAX_ITER` (or of a
     numerical breakdown of the linear solver, which never raises) when
     the best iterate over the trajectory (by max normalized residual)

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -286,11 +286,11 @@ class QTQP:
           f"0 <= z <= m={self.m}"
       )
 
+    if self.n == 0:
+      raise ValueError("The problem has no variables (n == 0).")
     self._presolve()
-    if self.z == self.m:
-      raise ValueError(
-          "effective z == m after presolve; some rows may have been dropped"
-      )
+    if self.m == 0:
+      raise ValueError("No constraints remain after presolve (m == 0).")
 
     if p is None:
       self.p = sp.csc_matrix((self.n, self.n))
@@ -357,6 +357,37 @@ class QTQP:
     self.b = self.b[keep]
     self.m = int(keep.sum())
 
+  def _validate_warm_start(self, warm_start, warm_start_threshold):
+    """Validate a warm start; returns reduced-size float copies or None."""
+    if warm_start is None:
+      return None
+    if not (np.isfinite(warm_start_threshold) and warm_start_threshold > 0):
+      raise ValueError(
+          "warm_start_threshold must be a positive finite float, got"
+          f" {warm_start_threshold}"
+      )
+    wx, wy, ws = (np.asarray(v, dtype=float).copy() for v in warm_start)
+    ps = self._presolve_state
+    full_m = self.m + (len(ps.b_dropped) if ps is not None else 0)
+    if (ps is not None and wx.shape == (self.n,)
+        and wy.shape == (full_m,) and ws.shape == (full_m,)):
+      # Full-size vectors (e.g. a previous Solution after postsolve
+      # restored the presolve-dropped rows): slice back to the reduced
+      # internal problem.
+      wy, ws = wy[ps.keep], ws[ps.keep]
+    if wx.shape != (self.n,) or wy.shape != (self.m,) or ws.shape != (self.m,):
+      raise ValueError(
+          "warm_start must be (x, y, s) with shapes"
+          f" ({self.n},), ({self.m},), ({self.m},)"
+          + (f" or ({self.n},), ({full_m},), ({full_m},)"
+             if full_m != self.m else "")
+          + f"; got {wx.shape}, {wy.shape}, {ws.shape}"
+      )
+    if not (np.all(np.isfinite(wx)) and np.all(np.isfinite(wy))
+            and np.all(np.isfinite(ws))):
+      raise ValueError("warm_start arrays must be finite.")
+    return wx, wy, ws
+
   def _postsolve(self, y, s, y_dropped=0.0, s_dropped=np.nan):
     """Restore full-sized (y, s) after presolve dropped rows.
 
@@ -378,11 +409,17 @@ class QTQP:
     return y_full, s_full
 
   def _dropped_slack(self, x):
-    """Slack b - A @ x for dropped rows; 0.0 (harmless scalar) if none."""
-    ps = self._presolve_state
-    if ps is None:
-      return 0.0
-    return ps.b_dropped - ps.a_dropped @ x
+    """Slack restored for presolve-dropped rows: +inf BY CONTRACT.
+
+    Presolve declared these rows non-binding for every x (RHS at or above
+    the infinity sentinel), so their slack is +infinity by definition.
+    Computing b_dropped - A_dropped @ x instead produced inf - inf = NaN
+    for literal-inf RHS and could overflow to -inf for finite-sentinel
+    rows at extreme x; a constant +inf is the documented, maskable value
+    in both cases.
+    """
+    del x
+    return np.inf
 
   def _lambda_local(self, x, y, s, tau, a, p, b, c):
     """Local-norm distance-to-path measure at a working-scale point.
@@ -422,6 +459,95 @@ class QTQP:
         + float((t_y * t_y) @ (1.0 / h_y))
         + t_tau * t_tau / max(_EPS, h_tau)
     )
+
+  def _solve_equality_only(self, b, c, collect_stats):
+    """Direct solve for z == m: one refined solve of [P, A'; A, 0][x; y] = [-c; b].
+
+    With no inequality rows there are no complementarity pairs, so the
+    interior-point iteration reduces to this single saddle-point system.
+    The result is graded with the main loop's summand-anchored residual
+    scales (tau = 1, s = 0) and returns SOLVED, ALMOST_SOLVED, or FAILED;
+    a singular system (inconsistent or unbounded) is reported as FAILED.
+    """
+    self.warm_lambda = None
+    self.warm_accepted = False
+    self.lambda_init = None
+    try:
+      # mu = 0 so refinement targets the true equality system; the
+      # additive shift keeps a rank-deficient P factorizable.
+      self._linear_solver.update(
+          mu=0.0, s=np.zeros(self.m), y=np.ones(self.m),
+          additive_regularization=True,
+      )
+      sol, lin_stats = self._linear_solver.solve(
+          rhs=np.concatenate([-c, -b]), warm_start=np.zeros(self.n + self.m)
+      )
+    except (ValueError, ArithmeticError, np.linalg.LinAlgError, RuntimeError):
+      logging.exception("Equality-only KKT solve failed; returning FAILED.")
+      full_m = self.m + (
+          len(self._presolve_state.b_dropped)
+          if self._presolve_state is not None else 0
+      )
+      return Solution(
+          np.full(self.n, np.nan), np.full(full_m, np.nan),
+          np.full(full_m, np.nan), [], SolutionStatus.FAILED
+      )
+    x, y = sol[: self.n], sol[self.n :]
+    svec = np.zeros(self.m)
+    if self.equilibration_strategy is not EquilibrationStrategy.NONE:
+      x, y, svec = self._unequilibrate_iterates(x, y, svec)
+
+    ax = self.a @ x
+    aty = self.a.T @ y
+    px = self.p @ x if self.p.nnz else np.zeros(self.n)
+    ctx = float(self.c @ x)
+    bty = float(self.b @ y)
+    xpx = float(x @ px)
+    pres = _norm(ax - self.b, np.inf)
+    dres = _norm(px + aty + self.c, np.inf)
+    gap = abs(ctx + bty + xpx)
+    pcost = ctx + 0.5 * xpx
+    dcost = -bty - 0.5 * xpx
+    # Summand scales, as in the main loop: no iterate norms.
+    prelrhs = max(_norm(ax, np.inf), self._norm_b)
+    drelrhs = max(_norm(px, np.inf), _norm(aty, np.inf), self._norm_c)
+
+    def _meets(f):
+      return (pres < f * self.atol + f * self.rtol * prelrhs
+              and dres < f * self.atol + f * self.rtol * drelrhs)
+
+    if _meets(1.0):
+      status = SolutionStatus.SOLVED
+      self._log_footer("Solved (equality-only direct solve)")
+    elif _meets(_ALMOST_FACTOR):
+      status = SolutionStatus.ALMOST_SOLVED
+      self._log_footer("Almost solved (equality-only direct solve)")
+    else:
+      status = SolutionStatus.FAILED
+      self._log_footer("Failed (equality-only direct solve)")
+
+    stats = []
+    if collect_stats:
+      norm_x = _norm(x, np.inf)
+      norm_y = _norm(y, np.inf)
+      dinfeas_a = _norm(ax, np.inf) / (self._norm_a_inf * norm_x + _EPS)
+      dinfeas_p = _norm(px, np.inf) / (self._norm_p_inf * norm_x + _EPS)
+      stats.append({
+          "iter": 0, "pres": pres, "dres": dres, "gap": gap,
+          "pcost": pcost, "dcost": dcost, "status": status,
+          "mu": 0.0, "complementarity": 0.0, "tau": 1.0,
+          "sigma": 0.0, "alpha": 1.0,
+          "norm_x": norm_x, "norm_y": norm_y, "norm_s": 0.0,
+          "prelrhs": prelrhs, "drelrhs": drelrhs,
+          "pinfeas": _norm(aty, np.inf) / (self._norm_a_one * norm_y + _EPS),
+          "dinfeas": max(dinfeas_a, dinfeas_p),
+          "dinfeas_a": dinfeas_a, "dinfeas_p": dinfeas_p,
+          "ctx": ctx, "bty": bty,
+          "time": timeit.default_timer() - self.start_time,
+          "q_lin_sys_stats": lin_stats,
+      })
+    y, svec = self._postsolve(y, svec, s_dropped=self._dropped_slack(x))
+    return Solution(x, y, svec, stats, status)
 
   def _init_variables(self, a, p, b, c):
     """Produce the initial IPM iterates (CVXOPT-style residual embedding).
@@ -704,14 +830,15 @@ class QTQP:
       raise ValueError("max_centrality_correctors must be >= 0.")
     self._max_centrality_correctors = int(max_centrality_correctors)
 
-    resolved_linear_solver, linear_solver_backend = _resolve_linear_solver(
-        linear_solver
-    )
     self.start_time = timeit.default_timer()
     self.atol, self.rtol = atol, rtol
     self.atol_infeas, self.rtol_infeas = atol_infeas, rtol_infeas
     self.verbose = verbose
     self.equilibration_strategy = equilibration_strategy
+
+    resolved_linear_solver, linear_solver_backend = _resolve_linear_solver(
+        linear_solver
+    )
     if verbose:
       print(
           f"| QTQP v{__version__}:"
@@ -719,7 +846,6 @@ class QTQP:
           f" nnz(P)={self.p.nnz}, linear_solver={resolved_linear_solver.name},"
           f" equilibration={equilibration_strategy.name}"
       )
-
     if equilibration_strategy is EquilibrationStrategy.NONE:
       a, p, b, c = self.a, self.p, self.b, self.c
       self.d, self.e, self.sigma_eq = None, None, 1.0
@@ -763,6 +889,11 @@ class QTQP:
         gmres_restart=gmres_restart,
     )
 
+    if self.z == self.m:
+      # All-equality problem: no complementarity pairs, so the IPM
+      # reduces to one saddle-point solve. A warm start is ignored.
+      return self._solve_equality_only(b, c, collect_stats)
+
     stats = []
     self.kinv_q = np.zeros_like(self.q)  # K^{-1}q, warm-started across iterations.
     self._best_almost_score = math.inf
@@ -777,32 +908,9 @@ class QTQP:
     # warm starting safe, which heuristic IPM warm starts are not.
     self.warm_lambda = None
     self.warm_accepted = False
-    if warm_start is not None:
-      if not (np.isfinite(warm_start_threshold) and warm_start_threshold > 0):
-        raise ValueError(
-            "warm_start_threshold must be a positive finite float, got"
-            f" {warm_start_threshold}"
-        )
-      wx, wy, ws = (np.asarray(v, dtype=float).copy() for v in warm_start)
-      ps = self._presolve_state
-      full_m = self.m + (len(ps.b_dropped) if ps is not None else 0)
-      if (ps is not None and wx.shape == (self.n,)
-          and wy.shape == (full_m,) and ws.shape == (full_m,)):
-        # Full-size vectors (e.g. a previous Solution after postsolve
-        # restored the presolve-dropped rows): slice back to the reduced
-        # internal problem.
-        wy, ws = wy[ps.keep], ws[ps.keep]
-      if wx.shape != (self.n,) or wy.shape != (self.m,) or ws.shape != (self.m,):
-        raise ValueError(
-            "warm_start must be (x, y, s) with shapes"
-            f" ({self.n},), ({self.m},), ({self.m},)"
-            + (f" or ({self.n},), ({full_m},), ({full_m},)"
-               if full_m != self.m else "")
-            + f"; got {wx.shape}, {wy.shape}, {ws.shape}"
-        )
-      if not (np.all(np.isfinite(wx)) and np.all(np.isfinite(wy))
-              and np.all(np.isfinite(ws))):
-        raise ValueError("warm_start arrays must be finite.")
+    validated_warm = self._validate_warm_start(warm_start, warm_start_threshold)
+    if validated_warm is not None:
+      wx, wy, ws = validated_warm
       if self.equilibration_strategy is not EquilibrationStrategy.NONE:
         wx, wy, ws = self._equilibrate_iterates(wx, wy, ws)
       best = (math.inf, None)

--- a/src/qtqp/direct.py
+++ b/src/qtqp/direct.py
@@ -238,7 +238,10 @@ class DirectKktSolver:
     self._kkt_rhs = np.empty(self.n + self.m, dtype=np.float64)    # RHS with cone block negated
     self._diag_correction = np.zeros(self.n + self.m, dtype=np.float64)  # reg - true
 
-  def update(self, mu: float, s: np.ndarray, y: np.ndarray):
+  def update(
+      self, mu: float, s: np.ndarray, y: np.ndarray,
+      additive_regularization: bool = False,
+  ):
     """Forms the KKT matrix diagonals and factorizes it.
 
     Computes regularized diagonals (clamped to min_static_regularization) for
@@ -250,6 +253,8 @@ class DirectKktSolver:
       mu: The barrier parameter.
       s: The slack variables.
       y: The dual variables for the conic constraints.
+      additive_regularization: Add the clamp to the factorized diagonals
+        instead of flooring with it (for mu = 0 callers).
     """
     # Fill true diagonals: [p_diags + mu, h + mu] where h = [[0]*z; s/y].
     # KKT form: [P+mu*I, A'; A, -(D+mu*I)]
@@ -263,11 +268,18 @@ class DirectKktSolver:
     self._true_diags[self.n :] = -np.abs(self._true_diags[self.n :])
     self._true_diags[: self.n] = np.abs(self._true_diags[: self.n])
 
-    # Inject regularized diagonals (clamped to min_static_regularization)
-    # and factorize. Iterative refinement applies diag_correction against
-    # the TRUE diagonals, so the clamp costs refinement steps, never
-    # accuracy - the refined solution still solves the true system.
-    np.maximum(abs_true, self.min_static_regularization, out=self._reg_diags)
+    # Inject regularized diagonals and factorize. Iterative refinement
+    # applies diag_correction against the TRUE diagonals, so the shift
+    # costs refinement steps, never accuracy.
+    if additive_regularization:
+      # Add the clamp instead of flooring with it: a floor cannot
+      # regularize a rank-deficient block with a healthy diagonal, which
+      # the mu = 0 direct path needs (the main loop has P + mu*I).
+      np.add(abs_true, self.min_static_regularization, out=self._reg_diags)
+    else:
+      np.maximum(
+          abs_true, self.min_static_regularization, out=self._reg_diags
+      )
     self._reg_diags[self.n :] *= -1.0
     self._solver.update_diag(self._reg_diags)
     self._solver.factorize()

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -291,24 +291,20 @@ def _assert_solution(solution, a, b, c, p, z, atol=1e-7, rtol=1e-8):
   pres = np.linalg.norm(a @ x + s - b, np.inf)
   dres = np.linalg.norm(p @ x + a.T @ y + c, np.inf)
   gap = np.abs(c @ x + b @ y + x @ p @ x)
-  # Relative scales mirror the solver's termination criteria: the summand
-  # norms (evaluation floor) plus the iterate norms (the backward-error
-  # allowance of the regularized path).
-  norm_x = np.linalg.norm(x, np.inf)
-  norm_y = np.linalg.norm(y, np.inf)
+  # Relative scales mirror the solver's termination criteria exactly:
+  # the summand norms of each residual and nothing else (no iterate
+  # norms anywhere - those were the round-5/7 laundering channels).
   prelrhs = max(
       np.linalg.norm(a @ x, np.inf),
       np.linalg.norm(s, np.inf),
       np.linalg.norm(b, np.inf),
-      norm_y,
   )
   drelrhs = max(
       np.linalg.norm(p @ x, np.inf),
       np.linalg.norm(a.T @ y, np.inf),
       np.linalg.norm(c, np.inf),
-      norm_x,
   )
-  gaprelrhs = max(min(abs(pcost), abs(dcost)), norm_x + norm_y)
+  gaprelrhs = min(abs(pcost), abs(dcost))
   assert solution.status == qtqp.SolutionStatus.SOLVED
   np.testing.assert_array_less(gap, atol + rtol * gaprelrhs)
   np.testing.assert_array_less(pres, atol + rtol * prelrhs)
@@ -326,16 +322,18 @@ def _assert_infeasible(solution, a, b, z, atol=1e-8, rtol=1e-9):
   # Certificate quality is judged as relative backward error, mirroring the
   # solver's detection contract: violations over ||A||_1 * ||y||.
   norm_a_one = float(abs(a).sum(axis=0).max())
-  pinfeas = np.linalg.norm(a.T @ y, np.inf) / (
-      norm_a_one * np.linalg.norm(y, np.inf) + 1e-300
-  )
+  norm_aty = np.linalg.norm(a.T @ y, np.inf)
+  pinfeas = norm_aty / (norm_a_one * np.linalg.norm(y, np.inf) + 1e-300)
 
   assert solution.status == qtqp.SolutionStatus.INFEASIBLE
   np.testing.assert_array_equal(np.isnan(x), True)
   np.testing.assert_array_equal(np.isnan(s), True)
   np.testing.assert_allclose(b @ y, -1.0, atol=atol, rtol=rtol)
   np.testing.assert_array_less(-1e-9, np.min(y[z:], initial=0.0))
+  # BOTH public gates: data-scaled quality AND the pure-slope sense
+  # (violations at most atol * |b'y|).
   np.testing.assert_array_less(pinfeas, atol)
+  assert norm_aty <= atol * abs(float(b @ y)) + 1e-300
 
 
 def _assert_unbounded(solution, a, c, p, z, atol=1e-8, rtol=1e-9):
@@ -350,15 +348,19 @@ def _assert_unbounded(solution, a, c, p, z, atol=1e-8, rtol=1e-9):
   norm_x = np.linalg.norm(x, np.inf)
   norm_a_inf = float(abs(a).sum(axis=1).max())
   norm_p_inf = float(abs(p).sum(axis=1).max()) if p.nnz else 0.0
-  dinfeas_a = np.linalg.norm(a @ x + s, np.inf) / (norm_a_inf * norm_x + 1e-300)
-  dinfeas_p = np.linalg.norm(p @ x, np.inf) / (norm_p_inf * norm_x + 1e-300)
+  norm_axs = np.linalg.norm(a @ x + s, np.inf)
+  norm_pxc = np.linalg.norm(p @ x, np.inf)
+  dinfeas_a = norm_axs / (norm_a_inf * norm_x + 1e-300)
+  dinfeas_p = norm_pxc / (norm_p_inf * norm_x + 1e-300)
 
   assert solution.status == qtqp.SolutionStatus.UNBOUNDED
   np.testing.assert_array_equal(np.isnan(y), True)
   np.testing.assert_allclose(c @ x, -1.0, atol=atol, rtol=rtol)
   np.testing.assert_array_less(-1e-9, np.min(s[z:], initial=0.0))
+  # BOTH public gates: data-scaled quality AND the pure-slope sense.
   np.testing.assert_array_less(dinfeas_a, atol)
   np.testing.assert_array_less(dinfeas_p, atol)
+  assert max(norm_axs, norm_pxc) <= atol * abs(float(c @ x)) + 1e-300
 
 
 @pytest.mark.parametrize('equilibration', [qtqp.EquilibrationStrategy.RUIZ, qtqp.EquilibrationStrategy.NONE])
@@ -515,20 +517,29 @@ def _append_dropped_inequalities(a, b, n_extra, random_state, rhs_value):
 @pytest.mark.parametrize('seed', 1542 + np.arange(10))
 @pytest.mark.parametrize('mn', ((5, 10), (30, 50), (80, 100)))
 def test_equality_only_solve(equilibration, seed, mn):
-  """Equality-only QP (z == m) is currently rejected."""
+  """Equality-only QP (z == m): solved by the direct KKT path, with
+  primal/dual residuals meeting the reported status."""
   rng = np.random.default_rng(seed)
   m, n = mn
   z = m
   a, b, c, p = _gen_equality_only(m, n, random_state=rng)
-  with pytest.raises(ValueError, match='effective z == m'):
-    _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-        verbose=True, equilibration_strategy=equilibration,
-    )
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      verbose=True, equilibration_strategy=equilibration,
+  )
+  assert sol.status == qtqp.SolutionStatus.SOLVED
+  np.testing.assert_array_less(
+      np.linalg.norm(a @ sol.x - b, np.inf),
+      1e-7 * max(1.0, np.linalg.norm(b, np.inf)),
+  )
+  np.testing.assert_array_less(
+      np.linalg.norm(p @ sol.x + a.T @ sol.y + c, np.inf),
+      1e-7 * max(1.0, np.linalg.norm(c, np.inf), np.linalg.norm(sol.x, np.inf)),
+  )
 
 
 @pytest.mark.parametrize('seed', 2042 + np.arange(5))
 def test_equality_only_lp(seed):
-  """Equality-only LP (P=0, z=m) is currently rejected.
+  """Equality-only LP (P=0, z=m): solved by the direct KKT path.
 
   Uses n == m (square A) so the KKT system is non-singular with P=0.
   """
@@ -540,12 +551,16 @@ def test_equality_only_lp(seed):
   y_star = rng.normal(size=m)
   b = a @ x_star
   c = -(a.T @ y_star)
-  with pytest.raises(ValueError, match='effective z == m'):
-    _ = qtqp.QTQP(a=a, b=b, c=c, z=z).solve(verbose=True)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z).solve(verbose=True)
+  assert sol.status == qtqp.SolutionStatus.SOLVED
+  np.testing.assert_array_less(np.linalg.norm(a @ sol.x - b, np.inf), 1e-7)
+  np.testing.assert_array_less(
+      np.linalg.norm(a.T @ sol.y + c, np.inf), 1e-7
+  )
 
 
 def test_equality_only_inconsistent():
-  """Inconsistent equality-only problems are rejected before solve."""
+  """Inconsistent equality-only problems must not be reported SOLVED."""
   n, m, z = 5, 3, 3
   # All rows of A are identical -> Ax = b can only be satisfied if all b_i
   # are equal. Since they are not, the problem is primal infeasible.
@@ -553,12 +568,13 @@ def test_equality_only_inconsistent():
   b = np.array([1.0, 2.0, 3.0])
   c = np.ones(n)
   p = sparse.csc_matrix((n, n))
-  with pytest.raises(ValueError, match='effective z == m'):
-    _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
+  assert sol.status != qtqp.SolutionStatus.SOLVED
 
 
 def test_presolve_drops_all_inequalities():
-  """Dropping all inequalities in presolve yields an unsupported equality-only problem."""
+  """Presolve reducing to equality-only routes to the direct KKT path,
+  and postsolve restores the dropped rows."""
   rng = np.random.default_rng(842)
   m_eq, n = 5, 20
   m_ineq = 5
@@ -567,8 +583,10 @@ def test_presolve_drops_all_inequalities():
   a, b = _append_dropped_inequalities(
       a, b, n_extra=m_ineq, random_state=rng, rhs_value=1e21,
   )
-  with pytest.raises(ValueError, match='effective z == m'):
-    _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
+  assert sol.status == qtqp.SolutionStatus.SOLVED
+  assert sol.y.shape == (m_eq + m_ineq,)
+  np.testing.assert_array_equal(sol.y[m_eq:], 0.0)
 
 
 def test_presolve_restores_infeasible_certificate():
@@ -609,17 +627,19 @@ def test_presolve_restores_unbounded_certificate():
 
 
 def test_presolve_accepts_posinf_inequalities():
-  """Literal +inf inequality RHS may reduce the problem to unsupported equality-only."""
+  """Literal +inf inequality RHS reduces to equality-only, which now
+  solves via the direct KKT path either way."""
   rng = np.random.default_rng(2042)
   m_eq, n, z = 5, 20, 5
   a, b, c, p = _gen_equality_only(m_eq, n, random_state=rng)
-  with pytest.raises(ValueError, match='effective z == m'):
-    _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
+  assert sol.status == qtqp.SolutionStatus.SOLVED
   a_full, b_full = _append_dropped_inequalities(
       a, b, n_extra=3, random_state=rng, rhs_value=np.inf,
   )
-  with pytest.raises(ValueError, match='effective z == m'):
-    _ = qtqp.QTQP(a=a_full, b=b_full, c=c, z=z, p=p).solve(verbose=True)
+  sol = qtqp.QTQP(a=a_full, b=b_full, c=c, z=z, p=p).solve(verbose=True)
+  assert sol.status == qtqp.SolutionStatus.SOLVED
+  assert sol.y.shape == (m_eq + 3,)
 
 
 def test_raise_error_nonfinite_equality_rhs():
@@ -634,18 +654,18 @@ def test_raise_error_nonfinite_equality_rhs():
 @pytest.mark.parametrize('linear_solver', _SOLVERS)
 @pytest.mark.parametrize('seed', 3042 + np.arange(5))
 def test_equality_only_all_backends(linear_solver, seed):
-  """Equality-only QP is rejected before choosing a backend-specific path."""
+  """Equality-only QP solves through every backend's direct KKT path."""
   rng = np.random.default_rng(seed)
   m, n, z = 20, 40, 20
   a, b, c, p = _gen_equality_only(m, n, random_state=rng)
-  with pytest.raises(ValueError, match='effective z == m'):
-    _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-        verbose=True, linear_solver=linear_solver,
-    )
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      verbose=True, linear_solver=linear_solver,
+  )
+  assert sol.status == qtqp.SolutionStatus.SOLVED
 
 
 def test_equality_only_recovers_known_solution():
-  """Equality-only QP with known solution is currently rejected."""
+  """Equality-only strictly convex QP recovers the planted KKT point."""
   rng = np.random.default_rng(7742)
   m, n, z = 10, 20, 10
   x_star = rng.normal(size=n)
@@ -656,21 +676,26 @@ def test_equality_only_recovers_known_solution():
   p = sparse.csc_matrix(q.T @ q * 0.01)
   b = a @ x_star
   c = -(p @ x_star + a.T @ y_star)
-  with pytest.raises(ValueError, match='effective z == m'):
-    _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(verbose=True)
+  assert sol.status == qtqp.SolutionStatus.SOLVED
+  np.testing.assert_array_less(
+      np.linalg.norm(a @ sol.x - b, np.inf),
+      1e-7 * max(1.0, np.linalg.norm(b, np.inf)),
+  )
 
 
 def test_equality_only_verbose(capsys):
-  """Equality-only QP is rejected before any iteration logging."""
+  """The equality-only direct path reports a footer and one stats row."""
   rng = np.random.default_rng(8842)
   m, n, z = 5, 10, 5
   a, b, c, p = _gen_equality_only(m, n, random_state=rng)
-  with pytest.raises(ValueError, match='effective z == m'):
-    _ = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-        verbose=True, collect_stats=True
-    )
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
+      verbose=True, collect_stats=True
+  )
+  assert sol.status == qtqp.SolutionStatus.SOLVED
+  assert len(sol.stats) == 1
   captured = capsys.readouterr().out
-  assert captured == ''
+  assert "equality-only" in captured
 
 
 def test_equality_only_sparse_p():
@@ -690,10 +715,10 @@ def test_equality_only_sparse_p():
   p = (p.T @ p) * 0.01  # Make PSD.
   b = a @ x_star
   c = -(p @ x_star + a.T @ y_star)
-  with pytest.raises(ValueError, match='effective z == m'):
-    _ = qtqp.QTQP(
-        a=sparse.csc_matrix(a), b=b, c=c, z=z, p=sparse.csc_matrix(p),
-    ).solve(verbose=True)
+  sol = qtqp.QTQP(
+      a=sparse.csc_matrix(a), b=b, c=c, z=z, p=sparse.csc_matrix(p),
+  ).solve(verbose=True)
+  assert sol.status == qtqp.SolutionStatus.SOLVED
 
 
 def test_raise_error_negative_invalid_shapes():
@@ -3754,3 +3779,109 @@ def test_accepted_warm_start_skips_cold_init(monkeypatch):
   solver2.solve(verbose=False, warm_start=junk, warm_start_threshold=1.0)
   assert not solver2.warm_accepted
   assert calls["n"] == 1, "vetoed warm start must fall back to the cold init"
+
+
+def test_equality_only_qp_unique_solution():
+  """Equality-constrained strictly convex QP: the direct path recovers
+  the unique KKT solution."""
+  rng = np.random.default_rng(5200)
+  m, n = 6, 12
+  a = sparse.csc_matrix(rng.normal(size=(m, n)))
+  L = rng.normal(size=(n, n))
+  p = sparse.csc_matrix(L @ L.T + 0.5 * np.eye(n))
+  x_star = rng.normal(size=n)
+  y_star = rng.normal(size=m)
+  b = a @ x_star
+  c = -(p @ x_star + a.T @ y_star)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=m, p=p).solve(verbose=False)
+  assert sol.status == qtqp.SolutionStatus.SOLVED
+  np.testing.assert_allclose(sol.x, x_star, atol=1e-6, rtol=1e-6)
+
+
+def test_equality_only_impossible_zero_row_not_solved():
+  """Reviewer repro: 0 = 1 with a tiny cost must not be SOLVED — the
+  regularized singular solve returns enormous iterates which must not
+  inflate the acceptance thresholds (data/summand scales only)."""
+  a = sparse.csc_matrix(np.array([[0.0]]))
+  sol = qtqp.QTQP(a=a, b=np.array([1.0]), c=np.array([1e-12]), z=1).solve(
+      verbose=False
+  )
+  assert sol.status != qtqp.SolutionStatus.SOLVED
+  assert sol.status != qtqp.SolutionStatus.ALMOST_SOLVED
+
+
+def test_equality_only_large_scale_refines_true_system():
+  """Reviewer repro: A=[1], b=1e10, c=0 must return x=1e10, y=0 — a mu
+  floor baked into the 'true' diagonals is never refined away and
+  visibly perturbs large-scale duals; the direct path uses mu = 0."""
+  a = sparse.csc_matrix(np.array([[1.0]]))
+  sol = qtqp.QTQP(a=a, b=np.array([1e10]), c=np.array([0.0]), z=1).solve(
+      verbose=False
+  )
+  assert sol.status == qtqp.SolutionStatus.SOLVED
+  np.testing.assert_allclose(sol.x, [1e10], rtol=1e-9)
+  np.testing.assert_allclose(sol.y, [0.0], atol=1e-6)
+
+
+def test_empty_problems_rejected():
+  """No variables, or no constraints left after presolve, is rejected."""
+  with pytest.raises(ValueError, match="no variables"):
+    qtqp.QTQP(a=sparse.csc_matrix((1, 0)), b=np.zeros(1), c=np.zeros(0), z=1)
+  with pytest.raises(ValueError, match="No constraints"):
+    qtqp.QTQP(
+        a=sparse.csc_matrix(np.array([[1.0]])), b=np.array([np.inf]),
+        c=np.array([-2.0]), z=0, p=sparse.csc_matrix(np.array([[1.0]])),
+    )
+
+def test_equality_only_update_failure_returns_failed(monkeypatch):
+  """A backend whose factorization fails through every retry must return
+  FAILED (with an all-NaN full-size payload), not raise."""
+  rng = np.random.default_rng(5900)
+  m, n = 5, 10
+  a, b, c, p = _gen_equality_only(m, n, random_state=rng)
+  def boom(self, *args, **kwargs):
+    raise RuntimeError("forced persistent factorization failure")
+  monkeypatch.setattr(qtqp.direct.DirectKktSolver, "update", boom)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=m, p=p).solve(verbose=False)
+  assert sol.status == qtqp.SolutionStatus.FAILED
+  assert np.all(np.isnan(sol.x)) and np.all(np.isnan(sol.y))
+
+
+def test_equality_only_stats_schema_matches_main_loop():
+  """Round-5: the equality-only stats row must satisfy the same schema as
+  main-loop rows so generic stats consumers do not fail only on equality
+  problems."""
+  rng = np.random.default_rng(6100)
+  m, n = 6, 12
+  a, b, c, p = _gen_equality_only(m, n, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=m, p=p).solve(
+      verbose=False, collect_stats=True
+  )
+  assert sol.status == qtqp.SolutionStatus.SOLVED
+  base_keys = {
+      "iter", "pcost", "dcost", "pres", "dres", "gap", "mu", "sigma",
+      "alpha", "tau", "norm_x", "norm_y", "status", "time",
+      "prelrhs", "drelrhs", "pinfeas", "dinfeas",
+      "dinfeas_a", "dinfeas_p", "ctx", "bty",
+      "complementarity", "norm_s",
+  }
+  missing = base_keys - sol.stats[0].keys()
+  assert not missing, f"equality stats row missing {missing}"
+
+
+def test_semidefinite_p_direct_path_solves_on_every_backend():
+  """The z == m direct path solves at mu = 0, so the factorized primal block
+  is exactly P. P = [[1, 1], [1, 1]] is singular along the constraint's
+  null space, so a magnitude floor leaves the KKT matrix singular and the
+  outcome depended on the backend; the additive shift makes every backend
+  solve it."""
+  p = sparse.csc_matrix(np.array([[1.0, 1.0], [1.0, 1.0]]))
+  a = sparse.csc_matrix(np.array([[1.0, 1.0]]))
+  c = np.array([-1.0, -1.0])
+  for linear_solver in _SOLVERS:
+    sol = qtqp.QTQP(a=a, b=np.array([1.0]), c=c, z=1, p=p).solve(
+        verbose=False, linear_solver=linear_solver
+    )
+    assert sol.status == qtqp.SolutionStatus.SOLVED, (linear_solver, sol.status)
+    assert float(sol.x.sum()) == pytest.approx(1.0, rel=1e-7)
+    assert np.linalg.norm(p @ sol.x + a.T @ sol.y + c, np.inf) < 1e-6


### PR DESCRIPTION
With no inequality rows there are no complementarity pairs, so the interior-point iteration reduces to the single saddle-point system `[P, A'; A, 0][x; y] = [-c; b]`. It is solved directly with the same backend, static regularization, and iterative refinement as the main loop, and graded with the main loop's summand-anchored residual scales. The solve runs at `mu = 0` so refinement targets the true system, and the regularization is **added** to the factorized diagonals rather than floored, because a floor cannot regularize a rank-deficient `P` whose diagonal is already healthy (the semidefinite `P = [[1,1],[1,1]]` previously solved or failed depending on the backend). A singular system is reported as FAILED.

Problems with no variables, or with no constraints left after presolve, are rejected up front rather than special-cased. Presolve-dropped rows restore their slack as `+inf` by contract. Warm-start validation is shared through one helper; the direct path ignores a warm start.

Scope note: an earlier revision added a no-variables path, residual-built certificates on the direct path, and overflow-stable cost arithmetic near DBL_MAX. All were dropped as corner-case handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)