### PR TITLE
Remove the unproven factorization retry ladder

### DIFF
--- a/src/qtqp/direct.py
+++ b/src/qtqp/direct.py
@@ -263,26 +263,14 @@ class DirectKktSolver:
     self._true_diags[self.n :] = -np.abs(self._true_diags[self.n :])
     self._true_diags[: self.n] = np.abs(self._true_diags[: self.n])
 
-    # Inject regularized diagonals and factorize; on a factorization
-    # breakdown at extreme conditioning, retry with a boosted clamp.
-    # Iterative refinement applies diag_correction against the TRUE
-    # diagonals, so a larger clamp costs refinement steps, never
+    # Inject regularized diagonals (clamped to min_static_regularization)
+    # and factorize. Iterative refinement applies diag_correction against
+    # the TRUE diagonals, so the clamp costs refinement steps, never
     # accuracy - the refined solution still solves the true system.
-    clamp = self.min_static_regularization
-    for attempt in range(3):
-      np.maximum(abs_true, clamp, out=self._reg_diags)
-      self._reg_diags[self.n :] *= -1.0
-      self._solver.update_diag(self._reg_diags)
-      try:
-        self._solver.factorize()
-        break
-      except ValueError:
-        if attempt == 2:
-          raise
-        clamp *= 1e4
-        logging.debug(
-            "Factorization breakdown; retrying with clamp %.1e", clamp
-        )
+    np.maximum(abs_true, self.min_static_regularization, out=self._reg_diags)
+    self._reg_diags[self.n :] *= -1.0
+    self._solver.update_diag(self._reg_diags)
+    self._solver.factorize()
     np.subtract(self._reg_diags, self._true_diags, out=self._diag_correction)
 
   def update_unit_dual(self, primal_shift: float) -> None:


### PR DESCRIPTION
On breakdown, `update()` retried the factorization up to three times with the static-regularization clamp escalating by 1e4 per attempt. That mechanism has no evidence behind it: its only coverage was a test injecting a synthetic `RuntimeError` from a backend shim, so it never produced a matrix a real backend fails on, and no instance across any campaign has been shown to reach the second attempt.

The retries also cannot help the failure mode one might hope they would. Rank deficiency is not a small-diagonal problem, and every rung recomputes `maximum(diag, clamp)` on a diagonal that already dominates the clamp, so each attempt refactorizes an identical matrix. Where a rank-deficient primal block does arise it is `mu` that regularizes it — the factorized block is `P + mu*I`, nonsingular throughout the iteration — not the clamp.

**The static clamp itself is unchanged.** Flooring `s/y` diagonals that race to zero is standard and cheap. Only the escalation loop and its magic 1e4 growth factor are removed (19 lines). A genuine breakdown now propagates to the solver's no-raise boundary and is reported as FAILED rather than retried against the same matrix.

## Validation

Full suite green. Four-dataset sweep at main's defaults against the `cc2ecbb` baseline (timeout 1800s, max_iter 200, QDLDL):

| dataset | N | main | this PR | sgm(t) main | sgm(t) this PR |
|---|---|---|---|---|---|
| maros_meszaros | 129 | 124 | 124 | 3.36 | 3.37 |
| miplib (<20MB) | 173 | 162 | 162 | 10.49 | 10.88 |
| netlib feasible | 93 | 92 | 92 | 0.86 | 0.87 |
| netlib infeasible | 29 | 26 | 26 | 7.26 | 7.28 |

**No status flips**, identical solve counts on every dataset, timing within run-to-run noise — direct evidence that across 424 problems the retry path was never taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)