### PR TITLE
Adopt Clarabel's termination criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ solve(
     tol_gap_rel: float = 1e-8,
     tol_infeas_abs: float = 1e-8,
     tol_infeas_rel: float = 1e-8,
-    certificate_ktratio: float = 1.0,
+    certificate_ktratio: float = 1e9,
     max_iter: int = 100,
     step_size_scale: float = 0.99,
     min_static_regularization: float = 1e-8,
@@ -190,7 +190,7 @@ Key parameters:
 -   `tol_infeas_abs`, `tol_infeas_rel`: Thresholds for (primal/dual)
     infeasibility detection.
 -   `certificate_ktratio`: Embedding ratio `kappa / tau` above which
-    certificates are considered (Clarabel uses `1e9`).
+    certificates are considered (default `1e9`, as in Clarabel).
 -   `max_iter`: Iteration cap.
 -   `step_size_scale` (0,1): Scale for line search step size to stay strictly
     interior.

--- a/README.md
+++ b/README.md
@@ -144,9 +144,8 @@ Arguments:
 -   `c`: (n) Cost vector.
 -   `z`: Number of equality constraints (size of the zero cone). Must satisfy
     `0 ≤ z ≤ m`; `z == m` (all-equality) is solved by a single direct KKT
-    solve, where `SOLVED` certifies the primal and dual residuals (the gap
-    is reported in stats but not tested) and a singular system is reported
-    as `FAILED`. Problems with no variables, or with no constraints left
+    solve, graded with the same residual and gap tests as the iterative
+    path; a singular system is reported as `FAILED`. Problems with no variables, or with no constraints left
     after presolve, are rejected.
 -   `p`: (n×n) QP matrix. If None, treated as the zero matrix (i.e., LP).
 

--- a/README.md
+++ b/README.md
@@ -155,10 +155,12 @@ This class has a single API method `solve`:
 ```python
 solve(
     *,
-    atol: float = 1e-7,
-    rtol: float = 1e-8,
-    atol_infeas: float = 1e-8,
-    rtol_infeas: float = 1e-9,
+    tol_feas: float = 1e-8,
+    tol_gap_abs: float = 1e-8,
+    tol_gap_rel: float = 1e-8,
+    tol_infeas_abs: float = 1e-8,
+    tol_infeas_rel: float = 1e-8,
+    certificate_ktratio: float = 1.0,
     max_iter: int = 100,
     step_size_scale: float = 0.99,
     min_static_regularization: float = 1e-8,
@@ -184,9 +186,12 @@ solve(
 
 Key parameters:
 
--   `atol`, `rtol`: Absolute/relative stopping tolerances for optimality.
--   `atol_infeas`, `rtol_infeas`: Thresholds for (primal/dual) infeasibility
-    detection.
+-   `tol_feas`, `tol_gap_abs`, `tol_gap_rel`: Stopping tolerances for
+    optimality (Clarabel's definitions; see below).
+-   `tol_infeas_abs`, `tol_infeas_rel`: Thresholds for (primal/dual)
+    infeasibility detection.
+-   `certificate_ktratio`: Embedding ratio `kappa / tau` above which
+    certificates are considered (Clarabel uses `1e9`).
 -   `max_iter`: Iteration cap.
 -   `step_size_scale` (0,1): Scale for line search step size to stay strictly
     interior.
@@ -285,13 +290,16 @@ Choose one with the `refinement_strategy` argument:
 
 #### Advanced numerical options
 
--   Termination scales are the summand norms of each residual and nothing
-    else: `pres` is judged against `max(||Ax||, ||s||, ||b||tau)/tau`,
-    `dres` against `max(||Px||, ||A'y||, ||c||tau)/tau`, and the duality
-    gap against `min(|pcost|, |dcost|)`. No iterate norm enters the
-    acceptance arithmetic (a bare `||x||` or `||y||` term lets a bad
-    warm start or a divergence inflate its own tolerance). The default
-    tolerances (`atol=1e-7`, `rtol=1e-8`) are calibrated to these scales.
+-   Termination criteria are Clarabel's, evaluated on the returned point,
+    so results are directly comparable: `SOLVED` requires
+    `||Ax + s - b|| / max(1, ||b||_inf + ||x|| + ||s||) < tol_feas`,
+    `||Px + A'y + c|| / max(1, ||c||_inf + ||x|| + ||y||) < tol_feas`
+    (2-norms), and a duality gap `|pcost - dcost|` below `tol_gap_abs` or
+    below `tol_gap_rel * max(1, min(|pcost|, |dcost|))`, with the iterate on
+    the solution side of the embedding (`kappa / tau < 1`). A certificate
+    requires `kappa / tau > certificate_ktratio`, an objective slope
+    (`b'y` or `c'x`) below `-tol_infeas_abs`, and violations relative to
+    `max(1, ||ray||)` below `tol_infeas_rel * |slope|`.
 -   `x`: (n) Primal variable or certificate of unboundedness.
 -   `y`: (m) Dual variable or certificate of infeasibility.
 -   `s`: (m) Slack variable or certificate of unboundedness.
@@ -305,9 +313,8 @@ Choose one with the `refinement_strategy` argument:
     `ALMOST_SOLVED` is returned in place of `HIT_MAX_ITER` (or of a
     numerical breakdown of the linear solver, which never raises) when
     the best iterate over the trajectory (by max normalized residual)
-    meets the solved-criteria form at tolerances `1000x` looser than the
-    requested `atol`/`rtol` (so `1e-4` absolute and `1e-5` relative at
-    the defaults): the returned
+    meets the solved criteria at Clarabel's reduced tolerances (`1e-4`
+    feasibility, `5e-5` gap): the returned
     solution is that best iterate, honestly labeled as not meeting the
     full `SOLVED` contract. `SOLVED` semantics are unchanged. A
     breakdown whose best iterate does not qualify returns `FAILED`.

--- a/README.md
+++ b/README.md
@@ -144,8 +144,11 @@ Arguments:
 -   `c`: (n) Cost vector.
 -   `z`: Number of equality constraints (size of the zero cone). Must satisfy
     `0 ≤ z ≤ m`; `z == m` (all-equality) is solved by a single direct KKT
-    solve, graded with the same residual and gap tests as the iterative
-    path; a singular system is reported as `FAILED`. Problems with no variables, or with no constraints left
+    solve, graded on the same primal and dual residual tests as the
+    iterative path (the gap is reported but not tested: it is bounded by
+    the residuals, and the gap scale has no iterate norm, so it would
+    reject exact large-norm solutions); a singular system is reported as
+    `FAILED`. Problems with no variables, or with no constraints left
     after presolve, are rejected.
 -   `p`: (n×n) QP matrix. If None, treated as the zero matrix (i.e., LP).
 

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -660,7 +660,7 @@ class QTQP:
       tol_gap_rel: float = 1e-8,
       tol_infeas_abs: float = 1e-8,
       tol_infeas_rel: float = 1e-8,
-      certificate_ktratio: float = 1.0,
+      certificate_ktratio: float = 1e9,
       max_iter: int = 100,
       step_size_scale: float = 0.99,
       min_static_regularization: float = 1e-8,
@@ -718,7 +718,7 @@ class QTQP:
       tol_gap_rel: float = 1e-8,
       tol_infeas_abs: float = 1e-8,
       tol_infeas_rel: float = 1e-8,
-      certificate_ktratio: float = 1.0,
+      certificate_ktratio: float = 1e9,
       max_iter: int = 100,
       step_size_scale: float = 0.99,
       min_static_regularization: float = 1e-8,
@@ -755,8 +755,9 @@ class QTQP:
         to max(1, ||ray||), to be below tol_infeas_rel * |slope|.
       certificate_ktratio (float): Certificates are considered only when the
         embedding ratio kappa / tau exceeds this (SOLVED requires it below
-        1). Clarabel, which carries kappa explicitly, uses 1e9; here kappa
-        is eliminated through tau * kappa = mu, so the ratio is mu / tau^2.
+        1). The default 1e9 is Clarabel's; here kappa is eliminated through
+        tau * kappa = mu, so the ratio is mu / tau^2, which grows like
+        1 / tau on the certificate side and so crosses any threshold.
       max_iter (int): Maximum number of iterations before stopping.
       step_size_scale (float): A factor in (0, 1) to scale the step size,
         ensuring iterates remain strictly interior.
@@ -1735,8 +1736,9 @@ class QTQP:
     # Embedding dichotomy gate on kappa / tau. With kappa eliminated through
     # tau * kappa = mu the ratio is mu / tau^2 (y's / (nu * tau^2) here):
     # below 1 the iterate is on the solution side; certificates require it
-    # above certificate_ktratio. A pure number, so a divergence cannot
-    # launder it: y's grows with the iterate while nu * tau^2 does not.
+    # above certificate_ktratio (1e9, as in Clarabel), which a weakly
+    # separating near-solution never reaches while a genuine certificate
+    # does, since the ratio grows like 1 / tau as tau -> 0.
     yts_ret = float(y @ s)
     nu_tau_sq = float(self.m - self.z) * tau * tau
     on_solution_side = yts_ret < nu_tau_sq

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -465,9 +465,10 @@ class QTQP:
 
     With no inequality rows there are no complementarity pairs, so the
     interior-point iteration reduces to this single saddle-point system.
-    The result is graded with the main loop's summand-anchored residual
-    scales (tau = 1, s = 0) and returns SOLVED, ALMOST_SOLVED, or FAILED;
-    a singular system (inconsistent or unbounded) is reported as FAILED.
+    The result is graded with the main loop's termination tests (Clarabel's
+    residual and gap criteria, at tau = 1, s = 0) and returns SOLVED,
+    ALMOST_SOLVED, or FAILED; a singular system (inconsistent or unbounded)
+    is reported as FAILED.
     """
     self.warm_lambda = None
     self.warm_accepted = False
@@ -515,14 +516,16 @@ class QTQP:
     drelrhs = max(1.0, self._norm_c + norm_x + norm_y)
     res_primal = pres / prelrhs
     res_dual = dres / drelrhs
+    gap_rel = gap / max(1.0, min(abs(pcost), abs(dcost)))
 
-    def _meets(tol):
-      return res_primal < tol and res_dual < tol
+    def _meets(tol_feas, tol_gap_abs, tol_gap_rel):
+      return (res_primal < tol_feas and res_dual < tol_feas
+              and (gap < tol_gap_abs or gap_rel < tol_gap_rel))
 
-    if _meets(self.tol_feas):
+    if _meets(self.tol_feas, self.tol_gap_abs, self.tol_gap_rel):
       status = SolutionStatus.SOLVED
       self._log_footer("Solved (equality-only direct solve)")
-    elif _meets(_REDUCED_TOL_FEAS):
+    elif _meets(_REDUCED_TOL_FEAS, _REDUCED_TOL_GAP_ABS, _REDUCED_TOL_GAP_REL):
       status = SolutionStatus.ALMOST_SOLVED
       self._log_footer("Almost solved (equality-only direct solve)")
     else:
@@ -536,7 +539,7 @@ class QTQP:
       stats.append({
           "iter": 0, "pres": pres, "dres": dres, "gap": gap,
           "res_primal": res_primal, "res_dual": res_dual,
-          "gap_rel": gap / max(1.0, min(abs(pcost), abs(dcost))),
+          "gap_rel": gap_rel,
           "ktratio": 0.0,
           "pcost": pcost, "dcost": dcost, "status": status,
           "mu": 0.0, "complementarity": 0.0, "tau": 1.0,

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -52,10 +52,10 @@ _norm = np.linalg.norm
 _EPS = 1e-15  # Standard epsilon for numerical safety
 # ALMOST_SOLVED acceptance: on HIT_MAX_ITER or numerical breakdown, the
 # best iterate seen is returned as ALMOST_SOLVED when it meets the same
-# criteria form at tolerances this factor looser than the user-requested
-# atol/rtol (at the current defaults: 1e-4 absolute / 1e-5 relative,
-# still a usable near-solution).
-_ALMOST_FACTOR = 1000.0
+# criteria at these reduced tolerances (Clarabel's reduced_tol_* defaults).
+_REDUCED_TOL_FEAS = 1e-4
+_REDUCED_TOL_GAP_ABS = 5e-5
+_REDUCED_TOL_GAP_REL = 5e-5
 # Floor on the complementarity parameter mu wherever it enters the
 # algorithm (KKT shift, corrector targets, barrier terms). Below this
 # scale mu carries no information in double precision relative to O(1)
@@ -503,23 +503,26 @@ class QTQP:
     ctx = float(self.c @ x)
     bty = float(self.b @ y)
     xpx = float(x @ px)
-    pres = _norm(ax - self.b, np.inf)
-    dres = _norm(px + aty + self.c, np.inf)
+    pres = _norm(ax - self.b)
+    dres = _norm(px + aty + self.c)
     gap = abs(ctx + bty + xpx)
     pcost = ctx + 0.5 * xpx
     dcost = -bty - 0.5 * xpx
-    # Summand scales, as in the main loop: no iterate norms.
-    prelrhs = max(_norm(ax, np.inf), self._norm_b)
-    drelrhs = max(_norm(px, np.inf), _norm(aty, np.inf), self._norm_c)
+    # Clarabel's residual scales with tau = 1 and s = 0.
+    norm_x = _norm(x)
+    norm_y = _norm(y)
+    prelrhs = max(1.0, self._norm_b + norm_x)
+    drelrhs = max(1.0, self._norm_c + norm_x + norm_y)
+    res_primal = pres / prelrhs
+    res_dual = dres / drelrhs
 
-    def _meets(f):
-      return (pres < f * self.atol + f * self.rtol * prelrhs
-              and dres < f * self.atol + f * self.rtol * drelrhs)
+    def _meets(tol):
+      return res_primal < tol and res_dual < tol
 
-    if _meets(1.0):
+    if _meets(self.tol_feas):
       status = SolutionStatus.SOLVED
       self._log_footer("Solved (equality-only direct solve)")
-    elif _meets(_ALMOST_FACTOR):
+    elif _meets(_REDUCED_TOL_FEAS):
       status = SolutionStatus.ALMOST_SOLVED
       self._log_footer("Almost solved (equality-only direct solve)")
     else:
@@ -528,18 +531,19 @@ class QTQP:
 
     stats = []
     if collect_stats:
-      norm_x = _norm(x, np.inf)
-      norm_y = _norm(y, np.inf)
-      dinfeas_a = _norm(ax, np.inf) / (self._norm_a_inf * norm_x + _EPS)
-      dinfeas_p = _norm(px, np.inf) / (self._norm_p_inf * norm_x + _EPS)
+      dinfeas_a = _norm(ax) / max(1.0, norm_x)
+      dinfeas_p = _norm(px) / max(1.0, norm_x)
       stats.append({
           "iter": 0, "pres": pres, "dres": dres, "gap": gap,
+          "res_primal": res_primal, "res_dual": res_dual,
+          "gap_rel": gap / max(1.0, min(abs(pcost), abs(dcost))),
+          "ktratio": 0.0,
           "pcost": pcost, "dcost": dcost, "status": status,
           "mu": 0.0, "complementarity": 0.0, "tau": 1.0,
           "sigma": 0.0, "alpha": 1.0,
           "norm_x": norm_x, "norm_y": norm_y, "norm_s": 0.0,
           "prelrhs": prelrhs, "drelrhs": drelrhs,
-          "pinfeas": _norm(aty, np.inf) / (self._norm_a_one * norm_y + _EPS),
+          "pinfeas": _norm(aty) / max(1.0, norm_y),
           "dinfeas": max(dinfeas_a, dinfeas_p),
           "dinfeas_a": dinfeas_a, "dinfeas_p": dinfeas_p,
           "ctx": ctx, "bty": bty,
@@ -648,10 +652,12 @@ class QTQP:
   def solve(
       self,
       *,
-      atol: float = 1e-7,
-      rtol: float = 1e-8,
-      atol_infeas: float = 1e-8,
-      rtol_infeas: float = 1e-9,
+      tol_feas: float = 1e-8,
+      tol_gap_abs: float = 1e-8,
+      tol_gap_rel: float = 1e-8,
+      tol_infeas_abs: float = 1e-8,
+      tol_infeas_rel: float = 1e-8,
+      certificate_ktratio: float = 1.0,
       max_iter: int = 100,
       step_size_scale: float = 0.99,
       min_static_regularization: float = 1e-8,
@@ -673,10 +679,12 @@ class QTQP:
     self._linear_solver = None
     try:
       return self._solve_impl(
-          atol=atol,
-          rtol=rtol,
-          atol_infeas=atol_infeas,
-          rtol_infeas=rtol_infeas,
+          tol_feas=tol_feas,
+          tol_gap_abs=tol_gap_abs,
+          tol_gap_rel=tol_gap_rel,
+          tol_infeas_abs=tol_infeas_abs,
+          tol_infeas_rel=tol_infeas_rel,
+          certificate_ktratio=certificate_ktratio,
           max_iter=max_iter,
           step_size_scale=step_size_scale,
           min_static_regularization=min_static_regularization,
@@ -702,10 +710,12 @@ class QTQP:
   def _solve_impl(
       self,
       *,
-      atol: float = 1e-7,
-      rtol: float = 1e-8,
-      atol_infeas: float = 1e-8,
-      rtol_infeas: float = 1e-9,
+      tol_feas: float = 1e-8,
+      tol_gap_abs: float = 1e-8,
+      tol_gap_rel: float = 1e-8,
+      tol_infeas_abs: float = 1e-8,
+      tol_infeas_rel: float = 1e-8,
+      certificate_ktratio: float = 1.0,
       max_iter: int = 100,
       step_size_scale: float = 0.99,
       min_static_regularization: float = 1e-8,
@@ -726,21 +736,24 @@ class QTQP:
     """Solves the QP using a primal-dual interior-point method.
 
     Args:
-      atol (float): Absolute tolerance for convergence criteria.
-      rtol (float): Relative tolerance for convergence criteria, scaled by
-        problem data norms.
-      atol_infeas (float): Certificate-quality tolerance for infeasibility
-        and unboundedness detection. A candidate ray u must be good in two
-        complementary senses: its relative backward error (violations over
-        ||operator|| * ||u||) must be at most atol_infeas, AND its
-        violations must be at most atol_infeas * |objective slope| (the
-        pure-slope sense: quality judged absolutely on the slope-normalized
-        ray, with no ray-norm slack). The first rejects large-slope
-        pseudo-rays, the second rejects huge-norm weakly separating
-        near-solutions; each guards the other's blind spot.
-      rtol_infeas (float): The margin by which the certificate's objective
-        slope (c'x or b'y) must be negative relative to the data and ray
-        norms.
+      tol_feas (float): Feasibility tolerance. SOLVED requires the primal
+        residual ||Ax + s - b|| / max(1, ||b||_inf + ||x|| + ||s||) and the
+        dual residual ||Px + A'y + c|| / max(1, ||c||_inf + ||x|| + ||y||)
+        (2-norms, evaluated on the returned point) to be below it. These
+        are Clarabel's criteria, so results are directly comparable.
+      tol_gap_abs (float): Absolute duality-gap tolerance; SOLVED requires
+        |pcost - dcost| below it OR the relative gap below tol_gap_rel.
+      tol_gap_rel (float): Relative duality-gap tolerance, against
+        max(1, min(|pcost|, |dcost|)).
+      tol_infeas_abs (float): A certificate requires its objective slope
+        (b'y for infeasibility, c'x for unboundedness) below
+        -tol_infeas_abs.
+      tol_infeas_rel (float): A certificate requires its violations, relative
+        to max(1, ||ray||), to be below tol_infeas_rel * |slope|.
+      certificate_ktratio (float): Certificates are considered only when the
+        embedding ratio kappa / tau exceeds this (SOLVED requires it below
+        1). Clarabel, which carries kappa explicitly, uses 1e9; here kappa
+        is eliminated through tau * kappa = mu, so the ratio is mu / tau^2.
       max_iter (int): Maximum number of iterations before stopping.
       step_size_scale (float): A factor in (0, 1) to scale the step size,
         ensuring iterates remain strictly interior.
@@ -815,10 +828,12 @@ class QTQP:
     Returns:
       A Solution object containing the solution and solve stats.
     """
-    assert atol >= 0
-    assert rtol >= 0
-    assert atol_infeas >= 0
-    assert rtol_infeas >= 0
+    assert tol_feas >= 0
+    assert tol_gap_abs >= 0
+    assert tol_gap_rel >= 0
+    assert tol_infeas_abs >= 0
+    assert tol_infeas_rel >= 0
+    assert certificate_ktratio >= 1.0
     assert max_iter > 0
     assert 0 < step_size_scale < 1
     assert min_static_regularization >= 0
@@ -831,8 +846,10 @@ class QTQP:
     self._max_centrality_correctors = int(max_centrality_correctors)
 
     self.start_time = timeit.default_timer()
-    self.atol, self.rtol = atol, rtol
-    self.atol_infeas, self.rtol_infeas = atol_infeas, rtol_infeas
+    self.tol_feas = tol_feas
+    self.tol_gap_abs, self.tol_gap_rel = tol_gap_abs, tol_gap_rel
+    self.tol_infeas_abs, self.tol_infeas_rel = tol_infeas_abs, tol_infeas_rel
+    self.certificate_ktratio = certificate_ktratio
     self.verbose = verbose
     self.equilibration_strategy = equilibration_strategy
 
@@ -1189,7 +1206,7 @@ class QTQP:
         return Solution(x, y, s, stats, status)
       case SolutionStatus.HIT_MAX_ITER | SolutionStatus.UNFINISHED:
         # Salvage: the best iterate seen, if it meets the criteria at
-        # _ALMOST_FACTOR looser tolerances, is an honestly-labeled
+        # the reduced tolerances, is an honestly-labeled
         # near-solution - more useful than the raw final iterate after a
         # cap-out or a numerical breakdown. The stored iterate is already
         # unequilibrated (captured inside _check_termination).
@@ -1640,8 +1657,8 @@ class QTQP:
     # certificates below, so compute them once.
     ax_plus_s = ax + s
     px_plus_aty = px + aty
-    pres = _norm(ax_plus_s * inv_tau - self.b, np.inf)
-    dres = _norm(px_plus_aty * inv_tau + self.c, np.inf)
+    pres = _norm(ax_plus_s * inv_tau - self.b)
+    dres = _norm(px_plus_aty * inv_tau + self.c)
     gap = abs((ctx + bty + xpx * inv_tau) * inv_tau)
 
     # Distance-to-path diagnostics are pure stats consumers: skip the
@@ -1686,95 +1703,72 @@ class QTQP:
           t_x, t_y, t_tau, y_w, tau, mu_hat
       )
 
-    norm_x = _norm(x, np.inf)
-    norm_y = _norm(y, np.inf)
+    # Clarabel's termination criteria, evaluated on the returned point
+    # (x, y, s) / tau: 2-norm residuals over max(1, data inf-norm + iterate
+    # 2-norms), and a duality gap that may pass absolutely or relatively.
+    norm_x = _norm(x) * inv_tau
+    norm_y = _norm(y) * inv_tau
+    norm_s = _norm(s) * inv_tau
+    prelrhs = max(1.0, self._norm_b + norm_x + norm_s)
+    drelrhs = max(1.0, self._norm_c + norm_x + norm_y)
+    res_primal = pres / prelrhs
+    res_dual = dres / drelrhs
+    gap_rel = gap / max(1.0, min(abs(pcost), abs(dcost)))
 
-    # Certificate-quality measures (Farkas-type, from the embedding
-    # structure). A candidate ray is judged by the smallest relative data
-    # perturbation that would make it an exact certificate (Rigal-Gaches
-    # normwise backward error): e.g. dinfeas_a = ||Ax + s|| / (||A|| ||x||)
-    # is the relative perturbation of A under which x is an exact unbounded
-    # ray. Normalizing by the objective slope |c'x| instead (the common
-    # convention) hands out slack proportional to a quantity degenerate
-    # problems can inflate — near-null directions with enormous c-slope pass
-    # such tests while violating the constraints badly (e.g. NETLIB dfl001).
-    norm_aty = _norm(aty, np.inf)
-    norm_px = _norm(px, np.inf)
-    norm_ax_plus_s = _norm(ax_plus_s, np.inf)
-    dinfeas_a = norm_ax_plus_s / (self._norm_a_inf * norm_x + _EPS)
-    dinfeas_p = norm_px / (self._norm_p_inf * norm_x + _EPS)
+    # Certificate quality: Clarabel's infeasibility residuals, violations
+    # over max(1, ||ray||), evaluated on the ray scaled to unit slope
+    # (b'y = -1, c'x = -1), which is the certificate actually returned.
+    # Clarabel's floor at 1 makes the test scale-dependent, so it has to
+    # be evaluated at one definite scale; on the unit-slope ray it reads
+    # violations / max(|slope|, ||ray||) in the homogeneous frame.
+    norm_x_h = _norm(x)
+    norm_y_h = _norm(y)
+    norm_s_h = _norm(s)
+    pinfeas = _norm(aty) / max(abs(bty), norm_y_h, _EPS)
+    dinfeas_a = _norm(ax_plus_s) / max(abs(ctx), norm_x_h + norm_s_h, _EPS)
+    dinfeas_p = _norm(px) / max(abs(ctx), norm_x_h, _EPS)
     dinfeas = max(dinfeas_a, dinfeas_p)
-    pinfeas = norm_aty / (self._norm_a_one * norm_y + _EPS)
 
-    # Residual tolerance relative scales: the summand norms of each
-    # residual and nothing else. No iterate norm enters, so a bad warm
-    # start or a divergence cannot inflate its own tolerance.
-    prelrhs = max(
-        _norm(ax, np.inf) * inv_tau, _norm(s, np.inf) * inv_tau, self._norm_b
-    )
-    drelrhs = max(norm_px * inv_tau, norm_aty * inv_tau, self._norm_c)
-    # Gap tolerance relative scale: the cost magnitudes.
-    gaprelrhs = min(abs(pcost), abs(dcost))
-
-    # Embedding dichotomy gate: kappa < tau (equivalently y's < nu * tau^2
-    # with nu = m - z) puts the iterate on the solution side, kappa > tau
-    # on the certificate side. A pure number, so a divergence cannot
+    # Embedding dichotomy gate on kappa / tau. With kappa eliminated through
+    # tau * kappa = mu the ratio is mu / tau^2 (y's / (nu * tau^2) here):
+    # below 1 the iterate is on the solution side; certificates require it
+    # above certificate_ktratio. A pure number, so a divergence cannot
     # launder it: y's grows with the iterate while nu * tau^2 does not.
     yts_ret = float(y @ s)
     nu_tau_sq = float(self.m - self.z) * tau * tau
     on_solution_side = yts_ret < nu_tau_sq
-    on_certificate_side = yts_ret > nu_tau_sq
+    on_certificate_side = yts_ret > self.certificate_ktratio * nu_tau_sq
+    ktratio = yts_ret / nu_tau_sq if nu_tau_sq > 0.0 else math.inf
 
-    # Solved: duality gap and both residuals are within tolerance.
     if (
         on_solution_side
-        and gap < self.atol + self.rtol * gaprelrhs
-        and pres < self.atol + self.rtol * prelrhs
-        and dres < self.atol + self.rtol * drelrhs
+        and res_primal < self.tol_feas
+        and res_dual < self.tol_feas
+        and (gap < self.tol_gap_abs or gap_rel < self.tol_gap_rel)
     ):
       status = SolutionStatus.SOLVED
-    # Certificate acceptance requires BOTH quality senses, because each
-    # guards the other's blind spot:
-    #   - data-scaled (violations / (||operator|| ||ray||) < atol_infeas):
-    #     rejects large-slope pseudo-rays whose |c'x| buys unbounded slack
-    #     in the slope-scaled test (e.g. NETLIB dfl001, where a direction
-    #     violating the constraints at 5-9% of ||A|| ||x|| was certified);
-    #   - pure-slope (violations < atol_infeas * |slope|): rejects
-    #     huge-norm weakly separating near-solutions, whose data-scaled
-    #     quality becomes small automatically (A'y ~ -c*tau with enormous
-    #     ||y|| makes ||A'y|| / (||A||_1 ||y||) tiny while y is nothing
-    #     like a ray; e.g. NETLIB fit1p, tuff, vtp.base, fffff800, and
-    #     the miplib physiciansched6-2 false-infeasibility class).
-    # The quality measures need no zero-ray guard: as ||x|| -> 0 the
-    # data-scaled denominator vanishes while the numerator retains the
-    # O(1) slack s, so dinfeas diverges and nothing is certified.
     elif (
         on_certificate_side
-        and ctx < -(self.rtol_infeas * self._norm_c * norm_x + _EPS)
-        and dinfeas < self.atol_infeas
-        and max(norm_ax_plus_s, norm_px) < self.atol_infeas * abs(ctx)
-    ):
-      status = SolutionStatus.UNBOUNDED
-    elif (
-        on_certificate_side
-        and bty < -(self.rtol_infeas * self._norm_b * norm_y + _EPS)
-        and pinfeas < self.atol_infeas
-        and norm_aty < self.atol_infeas * abs(bty)
+        and bty < -self.tol_infeas_abs
+        and pinfeas < self.tol_infeas_rel
     ):
       status = SolutionStatus.INFEASIBLE
+    elif (
+        on_certificate_side
+        and ctx < -self.tol_infeas_abs
+        and dinfeas < self.tol_infeas_rel
+    ):
+      status = SolutionStatus.UNBOUNDED
     else:
       status = SolutionStatus.UNFINISHED
 
-    # Track the best iterate seen, scored by the max normalized residual
-    # at the ALMOST_SOLVED thresholds (same criteria form, looser
-    # constants). Used to return an honestly-labeled near-solution when
-    # the iteration cap is reached without meeting the SOLVED contract.
-    almost_atol = _ALMOST_FACTOR * self.atol
-    almost_rtol = _ALMOST_FACTOR * self.rtol
+    # Best iterate for the ALMOST_SOLVED salvage: the same criteria at the
+    # reduced tolerances, scored by the largest ratio to its bar (the gap
+    # takes the better of its absolute and relative ratios).
     almost_score = max(
-        gap / (almost_atol + almost_rtol * gaprelrhs),
-        pres / (almost_atol + almost_rtol * prelrhs),
-        dres / (almost_atol + almost_rtol * drelrhs),
+        res_primal / _REDUCED_TOL_FEAS,
+        res_dual / _REDUCED_TOL_FEAS,
+        min(gap / _REDUCED_TOL_GAP_ABS, gap_rel / _REDUCED_TOL_GAP_REL),
     )
     new_best_almost = (
         on_solution_side and almost_score < self._best_almost_score
@@ -1806,6 +1800,10 @@ class QTQP:
         "time": timeit.default_timer() - self.start_time,
         "prelrhs": prelrhs,
         "drelrhs": drelrhs,
+        "res_primal": res_primal,
+        "res_dual": res_dual,
+        "gap_rel": gap_rel,
+        "ktratio": ktratio,
     })
 
     if collect_stats:

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -465,10 +465,15 @@ class QTQP:
 
     With no inequality rows there are no complementarity pairs, so the
     interior-point iteration reduces to this single saddle-point system.
-    The result is graded with the main loop's termination tests (Clarabel's
-    residual and gap criteria, at tau = 1, s = 0) and returns SOLVED,
-    ALMOST_SOLVED, or FAILED; a singular system (inconsistent or unbounded)
-    is reported as FAILED.
+    The result is graded on Clarabel's primal and dual residual tests at
+    tau = 1, s = 0, and returns SOLVED, ALMOST_SOLVED, or FAILED; a singular
+    system (inconsistent or unbounded) is reported as FAILED. The duality
+    gap is reported but not tested: with s = 0 the identity
+    gap = x'(Px + A'y + c) - y'(Ax - b) bounds it by the residuals times
+    the iterate norms, and Clarabel's gap scale max(1, min(|pcost|,
+    |dcost|)) carries no iterate norm, so on a large-norm solution with a
+    near-zero objective it rejects a machine-precision direct solve
+    (A = [1], b = 1e10, c = 0: x = 1e10 exactly, y ~ 1e-14, gap ~ 1e-4).
     """
     self.warm_lambda = None
     self.warm_accepted = False
@@ -518,14 +523,13 @@ class QTQP:
     res_dual = dres / drelrhs
     gap_rel = gap / max(1.0, min(abs(pcost), abs(dcost)))
 
-    def _meets(tol_feas, tol_gap_abs, tol_gap_rel):
-      return (res_primal < tol_feas and res_dual < tol_feas
-              and (gap < tol_gap_abs or gap_rel < tol_gap_rel))
+    def _meets(tol):
+      return res_primal < tol and res_dual < tol
 
-    if _meets(self.tol_feas, self.tol_gap_abs, self.tol_gap_rel):
+    if _meets(self.tol_feas):
       status = SolutionStatus.SOLVED
       self._log_footer("Solved (equality-only direct solve)")
-    elif _meets(_REDUCED_TOL_FEAS, _REDUCED_TOL_GAP_ABS, _REDUCED_TOL_GAP_REL):
+    elif _meets(_REDUCED_TOL_FEAS):
       status = SolutionStatus.ALMOST_SOLVED
       self._log_footer("Almost solved (equality-only direct solve)")
     else:

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -3689,7 +3689,12 @@ def test_equality_only_impossible_zero_row_not_solved():
 def test_equality_only_large_scale_refines_true_system():
   """Reviewer repro: A=[1], b=1e10, c=0 must return x=1e10, y=0 — a mu
   floor baked into the 'true' diagonals is never refined away and
-  visibly perturbs large-scale duals; the direct path uses mu = 0."""
+  visibly perturbs large-scale duals; the direct path uses mu = 0.
+
+  Also pins that the direct path grades on residuals only: y comes back
+  at roundoff (~1e-14 on some BLAS builds), so the absolute gap is
+  |b'y| ~ 1e-4 against a zero objective, and a Clarabel-style gap test
+  would reject this machine-precision solution."""
   a = sparse.csc_matrix(np.array([[1.0]]))
   sol = qtqp.QTQP(a=a, b=np.array([1e10]), c=np.array([0.0]), z=1).solve(
       verbose=False
@@ -3744,23 +3749,6 @@ def test_equality_only_stats_schema_matches_main_loop():
   missing = base_keys - sol.stats[0].keys()
   assert not missing, f"equality stats row missing {missing}"
 
-
-def test_equality_only_direct_path_tests_the_gap():
-  """The direct path applies the same gap predicate as the iterative path:
-  with zero gap tolerances a direct solve whose residuals pass must not be
-  SOLVED (its floating-point gap is nonzero), only ALMOST_SOLVED under the
-  reduced tolerances; at the defaults it is SOLVED."""
-  rng = np.random.default_rng(6300)
-  m, n = 6, 12
-  a, b, c, p = _gen_equality_only(m, n, random_state=rng)
-  sol = qtqp.QTQP(a=a, b=b, c=c, z=m, p=p).solve(verbose=False, collect_stats=True)
-  assert sol.status == qtqp.SolutionStatus.SOLVED
-  assert sol.stats[0]["gap"] > 0.0  # a nonzero gap, so zero tolerances bite
-  sol = qtqp.QTQP(a=a, b=b, c=c, z=m, p=p).solve(
-      verbose=False, collect_stats=True, tol_gap_abs=0.0, tol_gap_rel=0.0,
-  )
-  assert sol.stats[0]["res_primal"] < 1e-8 and sol.stats[0]["res_dual"] < 1e-8
-  assert sol.status == qtqp.SolutionStatus.ALMOST_SOLVED
 
 def test_semidefinite_p_direct_path_solves_on_every_backend():
   """The z == m direct path solves at mu = 0, so the factorized primal block

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -3745,6 +3745,23 @@ def test_equality_only_stats_schema_matches_main_loop():
   assert not missing, f"equality stats row missing {missing}"
 
 
+def test_equality_only_direct_path_tests_the_gap():
+  """The direct path applies the same gap predicate as the iterative path:
+  with zero gap tolerances a direct solve whose residuals pass must not be
+  SOLVED (its floating-point gap is nonzero), only ALMOST_SOLVED under the
+  reduced tolerances; at the defaults it is SOLVED."""
+  rng = np.random.default_rng(6300)
+  m, n = 6, 12
+  a, b, c, p = _gen_equality_only(m, n, random_state=rng)
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=m, p=p).solve(verbose=False, collect_stats=True)
+  assert sol.status == qtqp.SolutionStatus.SOLVED
+  assert sol.stats[0]["gap"] > 0.0  # a nonzero gap, so zero tolerances bite
+  sol = qtqp.QTQP(a=a, b=b, c=c, z=m, p=p).solve(
+      verbose=False, collect_stats=True, tol_gap_abs=0.0, tol_gap_rel=0.0,
+  )
+  assert sol.stats[0]["res_primal"] < 1e-8 and sol.stats[0]["res_dual"] < 1e-8
+  assert sol.status == qtqp.SolutionStatus.ALMOST_SOLVED
+
 def test_semidefinite_p_direct_path_solves_on_every_backend():
   """The z == m direct path solves at mu = 0, so the factorized primal block
   is exactly P. P = [[1, 1], [1, 1]] is singular along the constraint's

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -280,87 +280,64 @@ def _gen_unbounded(m, n, z, random_state=None):
   return sparse.csc_matrix(a), b, c, sparse.csc_matrix(p)
 
 
-def _assert_solution(solution, a, b, c, p, z, atol=1e-7, rtol=1e-8):
-  """Assert that the solution satisfies KKT conditions."""
+def _assert_solution(solution, a, b, c, p, z, tol_feas=1e-8, tol_gap=1e-8):
+  """Assert that the solution satisfies KKT conditions (Clarabel's criteria)."""
   x = solution.x
   y = solution.y
   s = solution.s
 
   pcost = c @ x + 0.5 * x @ p @ x
   dcost = -b @ y - 0.5 * x @ p @ x
-  pres = np.linalg.norm(a @ x + s - b, np.inf)
-  dres = np.linalg.norm(p @ x + a.T @ y + c, np.inf)
+  pres = np.linalg.norm(a @ x + s - b)
+  dres = np.linalg.norm(p @ x + a.T @ y + c)
   gap = np.abs(c @ x + b @ y + x @ p @ x)
-  # Relative scales mirror the solver's termination criteria exactly:
-  # the summand norms of each residual and nothing else (no iterate
-  # norms anywhere - those were the round-5/7 laundering channels).
-  prelrhs = max(
-      np.linalg.norm(a @ x, np.inf),
-      np.linalg.norm(s, np.inf),
-      np.linalg.norm(b, np.inf),
-  )
-  drelrhs = max(
-      np.linalg.norm(p @ x, np.inf),
-      np.linalg.norm(a.T @ y, np.inf),
-      np.linalg.norm(c, np.inf),
-  )
-  gaprelrhs = min(abs(pcost), abs(dcost))
+  norm_x, norm_y, norm_s = map(np.linalg.norm, (x, y, s))
+  res_primal = pres / max(1.0, np.linalg.norm(b, np.inf) + norm_x + norm_s)
+  res_dual = dres / max(1.0, np.linalg.norm(c, np.inf) + norm_x + norm_y)
+  gap_rel = gap / max(1.0, min(abs(pcost), abs(dcost)))
   assert solution.status == qtqp.SolutionStatus.SOLVED
-  np.testing.assert_array_less(gap, atol + rtol * gaprelrhs)
-  np.testing.assert_array_less(pres, atol + rtol * prelrhs)
-  np.testing.assert_array_less(dres, atol + rtol * drelrhs)
+  assert res_primal < tol_feas, res_primal
+  assert res_dual < tol_feas, res_dual
+  assert gap < tol_gap or gap_rel < tol_gap, (gap, gap_rel)
   np.testing.assert_array_less(-1e-9, np.min(y[z:], initial=0.0))
   np.testing.assert_array_less(-1e-9, np.min(s[z:], initial=0.0))
 
 
-def _assert_infeasible(solution, a, b, z, atol=1e-8, rtol=1e-9):
-  """Assert that the solution satisfies KKT conditions for primal infeasibility."""
+def _assert_infeasible(solution, a, b, z, tol_infeas_abs=1e-8, tol_infeas_rel=1e-8):
+  """Assert a valid primal-infeasibility certificate (Clarabel's test)."""
   x = solution.x
   y = solution.y
   s = solution.s
-
-  # Certificate quality is judged as relative backward error, mirroring the
-  # solver's detection contract: violations over ||A||_1 * ||y||.
-  norm_a_one = float(abs(a).sum(axis=0).max())
-  norm_aty = np.linalg.norm(a.T @ y, np.inf)
-  pinfeas = norm_aty / (norm_a_one * np.linalg.norm(y, np.inf) + 1e-300)
 
   assert solution.status == qtqp.SolutionStatus.INFEASIBLE
   np.testing.assert_array_equal(np.isnan(x), True)
   np.testing.assert_array_equal(np.isnan(s), True)
-  np.testing.assert_allclose(b @ y, -1.0, atol=atol, rtol=rtol)
+  np.testing.assert_allclose(b @ y, -1.0, atol=1e-8, rtol=1e-9)
   np.testing.assert_array_less(-1e-9, np.min(y[z:], initial=0.0))
-  # BOTH public gates: data-scaled quality AND the pure-slope sense
-  # (violations at most atol * |b'y|).
-  np.testing.assert_array_less(pinfeas, atol)
-  assert norm_aty <= atol * abs(float(b @ y)) + 1e-300
+  bty = float(b @ y)
+  assert bty < -tol_infeas_abs
+  pinfeas = np.linalg.norm(a.T @ y) / max(1.0, np.linalg.norm(y))
+  assert pinfeas < -tol_infeas_rel * bty, pinfeas
 
 
-def _assert_unbounded(solution, a, c, p, z, atol=1e-8, rtol=1e-9):
-  """Assert that the solution satisfies KKT conditions for primal unboundedness."""
+def _assert_unbounded(solution, a, c, p, z, tol_infeas_abs=1e-8, tol_infeas_rel=1e-8):
+  """Assert a valid dual-infeasibility (unboundedness) certificate."""
   x = solution.x
   y = solution.y
   s = solution.s
 
-  # Certificate quality is judged as relative backward error, mirroring the
-  # solver's detection contract: violations over ||A||_inf * ||x|| (and
-  # ||P||_inf * ||x|| for the quadratic part).
-  norm_x = np.linalg.norm(x, np.inf)
-  norm_a_inf = float(abs(a).sum(axis=1).max())
-  norm_p_inf = float(abs(p).sum(axis=1).max()) if p.nnz else 0.0
-  norm_axs = np.linalg.norm(a @ x + s, np.inf)
-  norm_pxc = np.linalg.norm(p @ x, np.inf)
-  dinfeas_a = norm_axs / (norm_a_inf * norm_x + 1e-300)
-  dinfeas_p = norm_pxc / (norm_p_inf * norm_x + 1e-300)
-
   assert solution.status == qtqp.SolutionStatus.UNBOUNDED
   np.testing.assert_array_equal(np.isnan(y), True)
-  np.testing.assert_allclose(c @ x, -1.0, atol=atol, rtol=rtol)
+  np.testing.assert_allclose(c @ x, -1.0, atol=1e-8, rtol=1e-9)
   np.testing.assert_array_less(-1e-9, np.min(s[z:], initial=0.0))
-  # BOTH public gates: data-scaled quality AND the pure-slope sense.
-  np.testing.assert_array_less(dinfeas_a, atol)
-  np.testing.assert_array_less(dinfeas_p, atol)
-  assert max(norm_axs, norm_pxc) <= atol * abs(float(c @ x)) + 1e-300
+  ctx = float(c @ x)
+  assert ctx < -tol_infeas_abs
+  norm_x, norm_s = np.linalg.norm(x), np.linalg.norm(s)
+  dinfeas = max(
+      np.linalg.norm(p @ x) / max(1.0, norm_x),
+      np.linalg.norm(a @ x + s) / max(1.0, norm_x + norm_s),
+  )
+  assert dinfeas < -tol_infeas_rel * ctx, dinfeas
 
 
 @pytest.mark.parametrize('equilibration', [qtqp.EquilibrationStrategy.RUIZ, qtqp.EquilibrationStrategy.NONE])
@@ -1977,10 +1954,12 @@ def test_tolerance_effect_on_iterations():
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
 
   sol_loose = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      atol=1e-3, rtol=1e-4, verbose=True, collect_stats=True
+      tol_feas=1e-3, tol_gap_abs=1e-3, tol_gap_rel=1e-3, verbose=True,
+      collect_stats=True,
   )
   sol_tight = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      atol=1e-7, rtol=1e-8, verbose=True, collect_stats=True
+      tol_feas=1e-8, tol_gap_abs=1e-8, tol_gap_rel=1e-8, verbose=True,
+      collect_stats=True,
   )
 
   assert sol_loose.status == qtqp.SolutionStatus.SOLVED
@@ -2315,22 +2294,26 @@ def test_step_size_scale(scale):
 
 
 # =============================================================================
-# atol_infeas / rtol_infeas parameters
+# tol_infeas_abs / tol_infeas_rel parameters
 # =============================================================================
 
-@pytest.mark.parametrize('atol_infeas,rtol_infeas', [(1e-4, 1e-5), (1e-10, 1e-11)])
-def test_infeasibility_tolerances(atol_infeas, rtol_infeas):
+@pytest.mark.parametrize('tol_infeas_abs,tol_infeas_rel', [(1e-4, 1e-5), (1e-10, 1e-11)])
+def test_infeasibility_tolerances(tol_infeas_abs, tol_infeas_rel):
   """Test that infeasibility detection works with different tolerances."""
   rng = np.random.default_rng(142)
   m, n, z = 150, 100, 10
   a, b, c, p = _gen_infeasible(m, n, z, random_state=rng)
 
   solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      atol_infeas=atol_infeas, rtol_infeas=rtol_infeas, verbose=True
+      tol_infeas_abs=tol_infeas_abs, tol_infeas_rel=tol_infeas_rel,
+      verbose=True,
   )
 
   assert solution.status == qtqp.SolutionStatus.INFEASIBLE
-  _assert_infeasible(solution, a, b, z, atol=atol_infeas, rtol=rtol_infeas)
+  _assert_infeasible(
+      solution, a, b, z, tol_infeas_abs=tol_infeas_abs,
+      tol_infeas_rel=tol_infeas_rel,
+  )
 
 
 # =============================================================================
@@ -2861,14 +2844,14 @@ def test_fused_corrector_handles_tiny_y():
     assert stats_i['alpha'] > 0.0, stats_i
 
 
-def test_default_tolerances_match_summand_only_criteria():
-  '''Defaults are calibrated to the summand-only termination scales: the
-  pre-tightening tier (atol=1e-7, rtol=1e-8) that the original criteria
-  were validated with.'''
+def test_default_tolerances_match_clarabel():
+  """Defaults are Clarabel's, so results are directly comparable."""
   import inspect
   sig = inspect.signature(qtqp.QTQP.solve)
-  assert sig.parameters['atol'].default == 1e-7
-  assert sig.parameters['rtol'].default == 1e-8
+  for name in ("tol_feas", "tol_gap_abs", "tol_gap_rel", "tol_infeas_abs",
+               "tol_infeas_rel"):
+    assert sig.parameters[name].default == 1e-8, name
+  assert sig.parameters["certificate_ktratio"].default == 1.0
 
 
 def test_almost_solved_near_cap():
@@ -3310,75 +3293,6 @@ def test_centrality_correctors_infeasible_unbounded():
 # Certificate quality: pseudo-rays must not be certified
 # =============================================================================
 
-def test_certificate_rejects_large_slope_pseudo_ray():
-  """A direction with enormous |c'x| but non-trivial constraint violations
-  must not be accepted as an unboundedness certificate.
-
-  This is the mechanism behind false certificates on degenerate LPs (e.g.
-  NETLIB dfl001): tests that normalize violations by |c'x| hand out slack
-  proportional to the objective slope, which a near-null direction of A with
-  a large c-component can inflate arbitrarily. The certificate test must
-  judge violations against ||A|| ||x|| instead.
-  """
-  rng = np.random.default_rng(7)
-  m, n, z = 12, 8, 3
-  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
-
-  # Direction v: right singular vector of A with the smallest singular value
-  # (near-null for A but not null), and a cost vector with a huge component
-  # along v so that c'v is enormously negative.
-  u_svd, s_svd, vt_svd = np.linalg.svd(a.toarray())
-  mid = len(s_svd) // 2
-  v = vt_svd[mid]
-  sigma_v = s_svd[mid]  # clearly nonzero: v is NOT a feasible ray
-  norm_a = np.max(np.abs(a.toarray()).sum(axis=1))
-  big = 1e12
-  c_adv = -big * v
-
-  solver = qtqp.QTQP(a=a, b=b, c=c_adv, z=z, p=p)
-  # Prime the state that solve() would normally set before termination checks.
-  solver.atol, solver.rtol = 1e-7, 1e-8
-  solver.atol_infeas, solver.rtol_infeas = 1e-8, 1e-9
-  solver.equilibration_strategy = qtqp.EquilibrationStrategy.NONE
-  solver._norm_b = np.linalg.norm(solver.b, np.inf)
-  solver._norm_c = np.linalg.norm(solver.c, np.inf)
-  abs_a = abs(solver.a)
-  solver._norm_a_inf = float(abs_a.sum(axis=1).max())
-  solver._norm_a_one = float(abs_a.sum(axis=0).max())
-  solver._norm_p_inf = (
-      float(abs(solver.p).sum(axis=1).max()) if solver.p.nnz else 0.0
-  )
-  solver.it = 0
-  solver.start_time = 0.0
-
-  x = v.copy()
-  y = np.zeros(m)
-  y[z:] = 1e-6
-  s = np.zeros(m)
-  s[z:] = 1e-6
-  tau = 1e-8  # deep in the certificate regime
-
-  ctx = c_adv @ x
-  assert ctx < 0
-
-  # The legacy |c'x|-normalized test would have accepted this pseudo-ray:
-  legacy_dinfeas = np.linalg.norm(a @ x + s, np.inf) / abs(ctx)
-  assert legacy_dinfeas < 1e-8 + 1e-9 * np.linalg.norm(x, np.inf) / abs(ctx)
-
-  # The data-scaled test must reject it: the violations are a sigma_v /
-  # ||A|| fraction of ||A|| ||x||, far above any certificate tolerance.
-  assert sigma_v / norm_a > 1e-3
-  status = solver._check_termination(  # pylint: disable=protected-access
-      x, y, tau, s, alpha=0.5, mu=1.0, sigma=0.5, stats_i={},
-      collect_stats=False,
-  )
-  assert status != qtqp.SolutionStatus.UNBOUNDED
-  assert status != qtqp.SolutionStatus.INFEASIBLE
-
-
-# =============================================================================
-# Refinement and factorization robustness
-# =============================================================================
 
 def test_richardson_rollback_returns_genuine_iterate_dense():
   """The rollback must restore the pre-correction iterate even when the
@@ -3629,12 +3543,13 @@ def test_almost_solved_stats_status_consistent():
   '''When salvage returns ALMOST_SOLVED, the last stats row must agree.
   Unreachable tolerances with a full budget make the salvage fire
   deterministically (the 1e-9-quality best iterate meets the
-  _ALMOST_FACTOR-loosened bar while 1e-15 never converges).'''
+  reduced-tolerance bar while 1e-15 never converges).'''
   rng = np.random.default_rng(4800)
   m, n, z = 60, 40, 8
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
   sol = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(
-      verbose=False, collect_stats=True, atol=1e-15, rtol=1e-15,
+      verbose=False, collect_stats=True, tol_feas=1e-15, tol_gap_abs=1e-15,
+      tol_gap_rel=1e-15,
       linear_solver=qtqp.LinearSolver.SCIPY,
   )
   assert sol.status == qtqp.SolutionStatus.ALMOST_SOLVED
@@ -3712,45 +3627,6 @@ def test_infeasible_qp_not_solved_via_quadratic_bar():
   )
   assert sol.status != qtqp.SolutionStatus.SOLVED
   assert sol.status != qtqp.SolutionStatus.ALMOST_SOLVED
-
-
-def test_weak_separation_ray_not_certified():
-  """Round-7 root cause of the physiciansched6-2 false INFEASIBLE: a ray
-  with excellent relative dual residual but separation |b'y| / ||y|| far
-  below its violation level must not be certified - the pure-slope sense
-  requires ||A'y|| <= atol_infeas * |b'y|, with no rtol * ||ray|| slack
-  for the ray's own norm to launder."""
-  m, z = 3, 0
-  a = sparse.csc_matrix(np.eye(3, 2))
-  b = np.array([-0.05, -0.05, 0.0])
-  c = np.zeros(2)
-  solver = qtqp.QTQP(a=a, b=b, c=c, z=z)
-  solver.atol, solver.rtol = 1e-7, 1e-8
-  solver.atol_infeas, solver.rtol_infeas = 1e-8, 1e-9
-  solver.equilibration_strategy = qtqp.EquilibrationStrategy.NONE
-  solver._norm_b = np.linalg.norm(b, np.inf)
-  solver._norm_c = 0.0
-  abs_a = abs(solver.a)
-  solver._norm_a_inf = float(abs_a.sum(axis=1).max())
-  solver._norm_a_one = float(abs_a.sum(axis=0).max())
-  solver._norm_p_inf = 0.0
-  solver.it = 0
-  solver.start_time = 0.0
-  # y >= 0 with its mass in null(A') (the b_3 = 0 row): b'y = -1 while
-  # ||y|| = 1e10, so separation per unit norm is 1e-10; ||A'y|| = 10 is
-  # residual-level relative to ||A||*||y|| (1e-9, passes data-scaled) and
-  # sits just under the OLD slope bar 1e-8 + 1e-9 * 1e10 ~ 10.00000001 -
-  # exactly the physiciansched regime. The pure-slope bar is 1e-8 * 1.
-  y = np.array([10.0, 10.0, 1e10])
-  assert float(b @ y) == pytest.approx(-1.0)
-  x = np.zeros(2)
-  s = np.full(m, 1e-9)
-  tau = 1e-9  # certificate side: y's >> nu * tau^2
-  status = solver._check_termination(  # pylint: disable=protected-access
-      x, y, tau, s, alpha=0.5, mu=1.0, sigma=0.5, stats_i={},
-      collect_stats=False,
-  )
-  assert status != qtqp.SolutionStatus.INFEASIBLE, status
 
 
 def test_accepted_warm_start_skips_cold_init(monkeypatch):

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -2851,7 +2851,7 @@ def test_default_tolerances_match_clarabel():
   for name in ("tol_feas", "tol_gap_abs", "tol_gap_rel", "tol_infeas_abs",
                "tol_infeas_rel"):
     assert sig.parameters[name].default == 1e-8, name
-  assert sig.parameters["certificate_ktratio"].default == 1.0
+  assert sig.parameters["certificate_ktratio"].default == 1e9
 
 
 def test_almost_solved_near_cap():


### PR DESCRIPTION
Termination is now judged exactly as Clarabel judges it, so solve
counts and iteration counts are directly comparable and every measured
improvement is attributable to the algorithm:

- SOLVED: primal residual ||Ax + s - b|| / max(1, ||b||_inf + ||x|| +
  ||s||) and dual residual ||Px + A'y + c|| / max(1, ||c||_inf + ||x||
  + ||y||) below tol_feas (2-norms, on the returned point), and the
  duality gap below tol_gap_abs or, relative to max(1, min(|pcost|,
  |dcost|)), below tol_gap_rel. Defaults 1e-8 throughout.
- Certificates: objective slope (b'y, c'x) below -tol_infeas_abs and
  Clarabel's infeasibility residuals, violations over max(1, ||ray||),
  below tol_infeas_rel * |slope|. Evaluated on the unit-slope ray that is
  actually returned, since the floor at 1 makes the test scale-dependent.
- ALMOST_SOLVED uses Clarabel's reduced tolerances (1e-4 feasibility,
  5e-5 gap) instead of a fixed factor.
- The embedding gates are unchanged: kappa / tau < 1 for SOLVED (as in
  Clarabel), and certificates require kappa / tau > certificate_ktratio,
  default 1, exposed so Clarabel's 1e9 can be tested. With kappa
  eliminated through tau * kappa = mu the ratio is mu / tau^2.

The public tolerance arguments take Clarabel's names: tol_feas,
tol_gap_abs, tol_gap_rel, tol_infeas_abs, tol_infeas_rel, replacing
atol, rtol, atol_infeas, rtol_infeas. The z == m direct path grades with
the same residual scales at tau = 1, s = 0.

Two tests that encoded the previous certificate senses are removed with
them: the data-scaled sense (main's #110, for the NETLIB dfl001
false-unbounded case) and the pure-slope sense (the physiciansched6-2
false-infeasible case). Clarabel's test is slope-scaled only, so those
two cases revert to Clarabel's behavior; the comparison sweep measures
both.

**Status:** CI green on all platforms at the final head; the four-dataset sweep against `main` and Clarabel, the certificate-gate comparison (now defaulting to Clarabel's 1e9), the refinement counts for both solvers, and the equality-only Maros-Meszaros problems are all posted in the comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
