### PR TITLE
Match Clarabel's initialization exactly; solve z == m through it

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,11 @@ Arguments:
     constraint whose RHS approaches `1e20` before calling the solver.
 -   `c`: (n) Cost vector.
 -   `z`: Number of equality constraints (size of the zero cone). Must satisfy
-    `0 ≤ z ≤ m`; `z == m` (all-equality) is solved by a single direct KKT
-    solve, graded on the same primal and dual residual tests as the
-    iterative path (the gap is reported but not tested: it is bounded by
-    the residuals, and the gap scale has no iterate norm, so it would
-    reject exact large-norm solutions); a singular system is reported as
-    `FAILED`. Problems with no variables, or with no constraints left
+    `0 ≤ z ≤ m`; an all-equality problem (`z == m`) is solved by the
+    initialization itself, which solves that KKT system exactly, and is
+    graded by the standard criteria at iteration 0 (a singular system is
+    reported as `FAILED`, or `ALMOST_SOLVED` if the reduced tolerances
+    hold). Problems with no variables, or with no constraints left
     after presolve, are rejected.
 -   `p`: (n×n) QP matrix. If None, treated as the zero matrix (i.e., LP).
 
@@ -249,8 +248,8 @@ Key parameters:
     the standard initialization, so warm starting is never worse than a
     cold solve by more than the certificate evaluation (three matvecs per
     shift). After `solve`, the measured `warm_lambda` and the `warm_accepted`
-    decision are attributes on the solver. The `z == m` direct solve
-    ignores a warm start.
+    decision are attributes on the solver. A warm start is ignored on an
+    all-equality problem, which the initialization solves outright.
 -   `warm_start_threshold`: Acceptance threshold for the certified warm
     start (default `100.0`). Poisoned or mis-scaled points measure orders of
     magnitude above it; same-problem re-entries orders of magnitude below.
@@ -270,12 +269,16 @@ Choose one with the `equilibration_strategy` argument:
 
 #### Initialization
 
-The initial iterate is a least-squares initialization in the CVXOPT /
-Clarabel style: one saddle-point solve for QPs (two, with a shared
+The initial iterate is Clarabel's initialization: one solve of
+`[P, A'; A, -H][x; y] = [-c; b]` for QPs (two, with a shared
 factorization, for LPs - primal from feasibility, dual from optimality),
-run through the same linear-solver backend, ordering, static
-regularization, and iterative refinement as the main loop, then shifted
-into the strict interior. If the initialization solve produces
+with `H` the identity on inequality rows and zero on equality rows, so
+equality rows are satisfied exactly by the initial point. It runs through
+the same linear-solver backend, ordering, static regularization, and
+iterative refinement as the main loop, then the inequality components are
+shifted into the strict interior. The initial point is graded before the
+first step, so an exact initialization or an accepted warm start can
+terminate at iteration 0. If the initialization solve produces
 non-finite values, the solver falls back to a trivial unit start.
 
 #### Refinement strategies

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -460,106 +460,6 @@ class QTQP:
         + t_tau * t_tau / max(_EPS, h_tau)
     )
 
-  def _solve_equality_only(self, b, c, collect_stats):
-    """Direct solve for z == m: one refined solve of [P, A'; A, 0][x; y] = [-c; b].
-
-    With no inequality rows there are no complementarity pairs, so the
-    interior-point iteration reduces to this single saddle-point system.
-    The result is graded on Clarabel's primal and dual residual tests at
-    tau = 1, s = 0, and returns SOLVED, ALMOST_SOLVED, or FAILED; a singular
-    system (inconsistent or unbounded) is reported as FAILED. The duality
-    gap is reported but not tested: with s = 0 the identity
-    gap = x'(Px + A'y + c) - y'(Ax - b) bounds it by the residuals times
-    the iterate norms, and Clarabel's gap scale max(1, min(|pcost|,
-    |dcost|)) carries no iterate norm, so on a large-norm solution with a
-    near-zero objective it rejects a machine-precision direct solve
-    (A = [1], b = 1e10, c = 0: x = 1e10 exactly, y ~ 1e-14, gap ~ 1e-4).
-    """
-    self.warm_lambda = None
-    self.warm_accepted = False
-    self.lambda_init = None
-    try:
-      # mu = 0 so refinement targets the true equality system; the
-      # additive shift keeps a rank-deficient P factorizable.
-      self._linear_solver.update(
-          mu=0.0, s=np.zeros(self.m), y=np.ones(self.m),
-          additive_regularization=True,
-      )
-      sol, lin_stats = self._linear_solver.solve(
-          rhs=np.concatenate([-c, -b]), warm_start=np.zeros(self.n + self.m)
-      )
-    except (ValueError, ArithmeticError, np.linalg.LinAlgError, RuntimeError):
-      logging.exception("Equality-only KKT solve failed; returning FAILED.")
-      full_m = self.m + (
-          len(self._presolve_state.b_dropped)
-          if self._presolve_state is not None else 0
-      )
-      return Solution(
-          np.full(self.n, np.nan), np.full(full_m, np.nan),
-          np.full(full_m, np.nan), [], SolutionStatus.FAILED
-      )
-    x, y = sol[: self.n], sol[self.n :]
-    svec = np.zeros(self.m)
-    if self.equilibration_strategy is not EquilibrationStrategy.NONE:
-      x, y, svec = self._unequilibrate_iterates(x, y, svec)
-
-    ax = self.a @ x
-    aty = self.a.T @ y
-    px = self.p @ x if self.p.nnz else np.zeros(self.n)
-    ctx = float(self.c @ x)
-    bty = float(self.b @ y)
-    xpx = float(x @ px)
-    pres = _norm(ax - self.b)
-    dres = _norm(px + aty + self.c)
-    gap = abs(ctx + bty + xpx)
-    pcost = ctx + 0.5 * xpx
-    dcost = -bty - 0.5 * xpx
-    # Clarabel's residual scales with tau = 1 and s = 0.
-    norm_x = _norm(x)
-    norm_y = _norm(y)
-    prelrhs = max(1.0, self._norm_b + norm_x)
-    drelrhs = max(1.0, self._norm_c + norm_x + norm_y)
-    res_primal = pres / prelrhs
-    res_dual = dres / drelrhs
-    gap_rel = gap / max(1.0, min(abs(pcost), abs(dcost)))
-
-    def _meets(tol):
-      return res_primal < tol and res_dual < tol
-
-    if _meets(self.tol_feas):
-      status = SolutionStatus.SOLVED
-      self._log_footer("Solved (equality-only direct solve)")
-    elif _meets(_REDUCED_TOL_FEAS):
-      status = SolutionStatus.ALMOST_SOLVED
-      self._log_footer("Almost solved (equality-only direct solve)")
-    else:
-      status = SolutionStatus.FAILED
-      self._log_footer("Failed (equality-only direct solve)")
-
-    stats = []
-    if collect_stats:
-      dinfeas_a = _norm(ax) / max(1.0, norm_x)
-      dinfeas_p = _norm(px) / max(1.0, norm_x)
-      stats.append({
-          "iter": 0, "pres": pres, "dres": dres, "gap": gap,
-          "res_primal": res_primal, "res_dual": res_dual,
-          "gap_rel": gap_rel,
-          "ktratio": 0.0,
-          "pcost": pcost, "dcost": dcost, "status": status,
-          "mu": 0.0, "complementarity": 0.0, "tau": 1.0,
-          "sigma": 0.0, "alpha": 1.0,
-          "norm_x": norm_x, "norm_y": norm_y, "norm_s": 0.0,
-          "prelrhs": prelrhs, "drelrhs": drelrhs,
-          "pinfeas": _norm(aty) / max(1.0, norm_y),
-          "dinfeas": max(dinfeas_a, dinfeas_p),
-          "dinfeas_a": dinfeas_a, "dinfeas_p": dinfeas_p,
-          "ctx": ctx, "bty": bty,
-          "time": timeit.default_timer() - self.start_time,
-          "q_lin_sys_stats": lin_stats,
-      })
-    y, svec = self._postsolve(y, svec, s_dropped=self._dropped_slack(x))
-    return Solution(x, y, svec, stats, status)
-
   def _init_variables(self, a, p, b, c):
     """Produce the initial IPM iterates (CVXOPT-style residual embedding).
 
@@ -581,14 +481,19 @@ class QTQP:
       x, y, s = self._equilibrate_iterates(x, y, s)
     return x, y, s, 1.0, {}
 
-  def _init_cvxopt(self, a, p, b, c, reg=1e-8, interior_margin=1.0):
-    """CVXOPT-style init: solve regularized saddle-point KKT, then shift."""
+  def _init_cvxopt(self, a, p, b, c, interior_margin=1.0):
+    """Clarabel-style init: solve the initial-point KKT system, then shift."""
     m, n, z = self.m, self.n, self.z
     a_csc = a.tocsc() if not sp.isspmatrix_csc(a) else a
-    # The (2,2) block is -I, not -reg*I: this is the standard
-    # least-squares initialization (CVXOPT/Clarabel), giving y ~ Ax - b.
-    # With -reg*I the block is near-singular and y is amplified by 1/reg
-    # (measured: ||y|| ~ 3e10, mu_0 ~ 2e12 on netlib/25fv47).
+    self._init_lin_stats = {}
+    # The system is [P, A'; A, -H] with H the identity on inequality rows
+    # and ZERO on equality rows, exactly as Clarabel forms its initial
+    # point (the zero cone contributes no scaling block). Equality rows
+    # are therefore satisfied exactly by the initial point, and an
+    # all-equality problem is solved by the initialization alone; on
+    # inequality rows the block gives the bounded least-squares point
+    # y ~ Ax - b (with -reg*I there instead, y is amplified by 1/reg:
+    # measured ||y|| ~ 3e10, mu_0 ~ 2e12 on netlib/25fv47).
     #
     # The solve runs through the session's DirectKktSolver - same backend,
     # symbolic ordering, static regularization, and iterative refinement
@@ -596,21 +501,33 @@ class QTQP:
     # wall-clock on the kennington instances). The main loop's first
     # update() refactorizes afterwards as usual.
     if getattr(self, "_linear_solver", None) is not None:
-      self._linear_solver.update_unit_dual(reg)
+      self._linear_solver.update_init()
 
       def _saddle_solve(rx, ry):
-        # DirectKktSolver.solve applies [P+reg*I, A'; A, -I] with the
-        # second RHS block negated internally; pass (rx, -ry) so the
-        # solved system is [P+reg*I, A'; A, -I] @ sol = (rx, ry).
+        # DirectKktSolver.solve applies [P, A'; A, -H] with the second
+        # RHS block negated internally; pass (rx, -ry) so the solved
+        # system is [P, A'; A, -H] @ sol = (rx, ry).
         rhs = np.concatenate([rx, -ry])
-        sol, _ = self._linear_solver.solve(rhs=rhs, warm_start=np.zeros_like(rhs))
+        sol, lin_stats = self._linear_solver.solve(
+            rhs=rhs, warm_start=np.zeros_like(rhs)
+        )
+        # Accumulate over the (one or two) initialization solves so the
+        # iteration-0 stats row reports the initialization's refinement.
+        prev = self._init_lin_stats
+        lin_stats["solves"] = lin_stats.get("solves", 0) + (
+            prev.get("solves", 0) if prev else 0
+        )
+        self._init_lin_stats = lin_stats
         return sol
 
     else:
-      # Standalone use (tests): assemble and solve directly.
-      p_reg = (p + reg * sp.eye(n, format="csc")).tocsc()
+      # Standalone use (tests): assemble and solve directly, with a small
+      # shift on both blocks in place of the backend's static regularization.
+      shift = 1e-8
+      p_reg = (p + shift * sp.eye(n, format="csc")).tocsc()
+      h = np.concatenate([np.zeros(z), np.ones(m - z)]) + shift
       kkt = sp.bmat(
-          [[p_reg, a_csc.T], [a_csc, -sp.eye(m, format="csc")]],
+          [[p_reg, a_csc.T], [a_csc, -sp.diags(h, format="csc")]],
           format="csc",
       )
 
@@ -914,11 +831,6 @@ class QTQP:
         gmres_restart=gmres_restart,
     )
 
-    if self.z == self.m:
-      # All-equality problem: no complementarity pairs, so the IPM
-      # reduces to one saddle-point solve. A warm start is ignored.
-      return self._solve_equality_only(b, c, collect_stats)
-
     stats = []
     self.kinv_q = np.zeros_like(self.q)  # K^{-1}q, warm-started across iterations.
     self._best_almost_score = math.inf
@@ -934,7 +846,9 @@ class QTQP:
     self.warm_lambda = None
     self.warm_accepted = False
     validated_warm = self._validate_warm_start(warm_start, warm_start_threshold)
-    if validated_warm is not None:
+    if validated_warm is not None and self.z < self.m:
+      # (An all-equality problem is solved by the initialization; a warm
+      # start has nothing to improve there.)
       wx, wy, ws = validated_warm
       if self.equilibration_strategy is not EquilibrationStrategy.NONE:
         wx, wy, ws = self._equilibrate_iterates(wx, wy, ws)
@@ -975,9 +889,34 @@ class QTQP:
     # Maros-Meszaros); pathologically scaled data announces itself here
     # by tens of orders of magnitude — this diagnostic is how corrupted
     # infinity-sentinel bounds in the benchmark datasets were found.
-    self.lambda_init = self._lambda_local(x, y, s, tau, a, p, b, c)
+    self.lambda_init = (
+        self._lambda_local(x, y, s, tau, a, p, b, c) if self.z < self.m else None
+    )
 
     self._log_header()
+
+    # Grade the initial point before the first step, as Clarabel does: an
+    # exact initialization - every all-equality problem, since the
+    # initialization solves that KKT system - or an accepted warm start can
+    # already meet the criteria. With no complementarity pairs (z == m)
+    # there is nothing to iterate on, so that point is the answer either
+    # way; otherwise the loop below takes over from it.
+    self.it = 0
+    stats_i = {
+        "lambda_init": self.lambda_init,
+        "q_lin_sys_stats": getattr(self, "_init_lin_stats", None) or {},
+        "predictor_lin_sys_stats": {},
+        "corrector_lin_sys_stats": {},
+    }
+    x, y, tau, s = self._normalize(x, y, tau, s)
+    status = self._check_termination(
+        x, y, tau, s, 0.0, 0.0, 0.0, stats_i, collect_stats
+    )
+    run_loop = status is SolutionStatus.UNFINISHED and self.z < self.m
+    if not run_loop:
+      self._log_iteration(stats_i)
+      if collect_stats:
+        stats.append(stats_i)
 
     # Pre-allocate [x; y] and d_s to avoid repeated allocation each iteration.
     xy = np.empty(self.n + self.m)   # Combined primal-dual vector [x; y]
@@ -993,7 +932,7 @@ class QTQP:
     # (TypeError, NameError, ...) still propagate.
     try:
       # self.it counts IPM steps already taken.
-      for self.it in range(max_iter):
+      for self.it in range(max_iter if run_loop else 0):
         stats_i = {}
         if self.it == 0:
           stats_i["lambda_init"] = self.lambda_init
@@ -1178,9 +1117,10 @@ class QTQP:
         if status != SolutionStatus.UNFINISHED:
           break
       else:
-        status = SolutionStatus.HIT_MAX_ITER
-        if collect_stats:
-          stats[-1]["status"] = status
+        if run_loop:
+          status = SolutionStatus.HIT_MAX_ITER
+          if collect_stats:
+            stats[-1]["status"] = status
 
     except (ValueError, ArithmeticError, np.linalg.LinAlgError,
             RuntimeError) as exc:
@@ -1638,7 +1578,7 @@ class QTQP:
     # kept for the distance-to-path certificate below; mu_hat is the
     # complementarity of THIS iterate in the operating scale.
     x_w, y_w, s_w = x, y, s
-    mu_hat = float(y_w @ s_w) / (self.m - self.z)
+    mu_hat = float(y_w @ s_w) / max(self.m - self.z, 1)
 
     if self.equilibration_strategy is not EquilibrationStrategy.NONE:
       x, y, s = self._unequilibrate_iterates(x, y, s)
@@ -1744,10 +1684,13 @@ class QTQP:
     # separating near-solution never reaches while a genuine certificate
     # does, since the ratio grows like 1 / tau as tau -> 0.
     yts_ret = float(y @ s)
-    nu_tau_sq = float(self.m - self.z) * tau * tau
-    on_solution_side = yts_ret < nu_tau_sq
-    on_certificate_side = yts_ret > self.certificate_ktratio * nu_tau_sq
-    ktratio = yts_ret / nu_tau_sq if nu_tau_sq > 0.0 else math.inf
+    nu = self.m - self.z
+    nu_tau_sq = float(nu) * tau * tau
+    # With no complementarity pairs (z == m) there is no certificate side.
+    on_solution_side = nu == 0 or yts_ret < nu_tau_sq
+    on_certificate_side = nu > 0 and yts_ret > self.certificate_ktratio * nu_tau_sq
+    ktratio = (yts_ret / nu_tau_sq if nu_tau_sq > 0.0
+               else (0.0 if nu == 0 else math.inf))
 
     if (
         on_solution_side
@@ -1799,7 +1742,7 @@ class QTQP:
         "dinfeas": dinfeas,
         "dinfeas_a": dinfeas_a,
         "dinfeas_p": dinfeas_p,
-        "mu": float(y @ s) / (self.m - self.z),
+        "mu": float(y @ s) / max(self.m - self.z, 1),
         "sigma": sigma,
         "alpha": alpha,
         "tau": tau,

--- a/src/qtqp/direct.py
+++ b/src/qtqp/direct.py
@@ -238,10 +238,7 @@ class DirectKktSolver:
     self._kkt_rhs = np.empty(self.n + self.m, dtype=np.float64)    # RHS with cone block negated
     self._diag_correction = np.zeros(self.n + self.m, dtype=np.float64)  # reg - true
 
-  def update(
-      self, mu: float, s: np.ndarray, y: np.ndarray,
-      additive_regularization: bool = False,
-  ):
+  def update(self, mu: float, s: np.ndarray, y: np.ndarray):
     """Forms the KKT matrix diagonals and factorizes it.
 
     Computes regularized diagonals (clamped to min_static_regularization) for
@@ -253,8 +250,6 @@ class DirectKktSolver:
       mu: The barrier parameter.
       s: The slack variables.
       y: The dual variables for the conic constraints.
-      additive_regularization: Add the clamp to the factorized diagonals
-        instead of flooring with it (for mu = 0 callers).
     """
     # Fill true diagonals: [p_diags + mu, h + mu] where h = [[0]*z; s/y].
     # KKT form: [P+mu*I, A'; A, -(D+mu*I)]
@@ -268,42 +263,34 @@ class DirectKktSolver:
     self._true_diags[self.n :] = -np.abs(self._true_diags[self.n :])
     self._true_diags[: self.n] = np.abs(self._true_diags[: self.n])
 
-    # Inject regularized diagonals and factorize. Iterative refinement
-    # applies diag_correction against the TRUE diagonals, so the shift
-    # costs refinement steps, never accuracy.
-    if additive_regularization:
-      # Add the clamp instead of flooring with it: a floor cannot
-      # regularize a rank-deficient block with a healthy diagonal, which
-      # the mu = 0 direct path needs (the main loop has P + mu*I).
-      np.add(abs_true, self.min_static_regularization, out=self._reg_diags)
-    else:
-      np.maximum(
-          abs_true, self.min_static_regularization, out=self._reg_diags
-      )
+    # Inject regularized diagonals (clamped to min_static_regularization)
+    # and factorize. Iterative refinement applies diag_correction against
+    # the TRUE diagonals, so the clamp costs refinement steps, never
+    # accuracy - the refined solution still solves the true system.
+    np.maximum(abs_true, self.min_static_regularization, out=self._reg_diags)
     self._reg_diags[self.n :] *= -1.0
     self._solver.update_diag(self._reg_diags)
     self._solver.factorize()
     np.subtract(self._reg_diags, self._true_diags, out=self._diag_correction)
 
-  def update_unit_dual(self, primal_shift: float) -> None:
-    """Forms and factorizes [P + primal_shift*I, A'; A, -I].
+  def update_init(self) -> None:
+    """Forms and factorizes the initialization system [P, A'; A, -H].
 
-    The saddle system of the CVXOPT-style initialization, routed through
-    exactly the same backend, symbolic ordering, static-regularization
-    clamp, and iterative-refinement bookkeeping as the main-loop update().
-    The subsequent main-loop update() refactorizes as usual.
-
-    Args:
-      primal_shift: The (1, 1)-block Tikhonov shift (the init's reg).
+    H is the identity on inequality rows and zero on equality rows: this
+    is Clarabel's initial-point system (the zero cone contributes no
+    scaling block), so on equality rows the initial point satisfies
+    Ax = b exactly rather than a least-squares penalty. The static
+    regularization is ADDED to the factorized diagonals only - a
+    magnitude floor cannot regularize the zero block, nor a rank-deficient
+    P - and iterative refinement targets the true system, so the shift
+    costs refinement steps, never accuracy. The subsequent main-loop
+    update() refactorizes as usual.
     """
     self._true_diags[: self.n] = self._p_diags
-    self._true_diags[: self.n] += primal_shift
-    self._true_diags[self.n :] = 1.0
-    np.maximum(
-        self._true_diags, self.min_static_regularization,
-        out=self._reg_diags,
-    )
-    self._true_diags[self.n :] *= -1.0
+    self._true_diags[self.n : self.n + self.z] = 0.0
+    self._true_diags[self.n + self.z :] = -1.0
+    np.abs(self._true_diags, out=self._reg_diags)
+    self._reg_diags += self.min_static_regularization
     self._reg_diags[self.n :] *= -1.0
     self._solver.update_diag(self._reg_diags)
     self._solver.factorize()

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -662,7 +662,8 @@ def test_equality_only_recovers_known_solution():
 
 
 def test_equality_only_verbose(capsys):
-  """The equality-only direct path reports a footer and one stats row."""
+  """An all-equality problem terminates at the initial point: one stats
+  row, iteration 0, and the solved footer."""
   rng = np.random.default_rng(8842)
   m, n, z = 5, 10, 5
   a, b, c, p = _gen_equality_only(m, n, random_state=rng)
@@ -670,9 +671,9 @@ def test_equality_only_verbose(capsys):
       verbose=True, collect_stats=True
   )
   assert sol.status == qtqp.SolutionStatus.SOLVED
-  assert len(sol.stats) == 1
+  assert len(sol.stats) == 1 and sol.stats[0]["iter"] == 0
   captured = capsys.readouterr().out
-  assert "equality-only" in captured
+  assert "Solved" in captured
 
 
 def test_equality_only_sparse_p():
@@ -3691,10 +3692,9 @@ def test_equality_only_large_scale_refines_true_system():
   floor baked into the 'true' diagonals is never refined away and
   visibly perturbs large-scale duals; the direct path uses mu = 0.
 
-  Also pins that the direct path grades on residuals only: y comes back
-  at roundoff (~1e-14 on some BLAS builds), so the absolute gap is
-  |b'y| ~ 1e-4 against a zero objective, and a Clarabel-style gap test
-  would reject this machine-precision solution."""
+  With Clarabel's initialization the LP split solves [-c; 0] = [0; 0] for
+  the dual, so y is exactly zero and the point passes every criterion at
+  iteration 0."""
   a = sparse.csc_matrix(np.array([[1.0]]))
   sol = qtqp.QTQP(a=a, b=np.array([1e10]), c=np.array([0.0]), z=1).solve(
       verbose=False
@@ -3713,19 +3713,6 @@ def test_empty_problems_rejected():
         a=sparse.csc_matrix(np.array([[1.0]])), b=np.array([np.inf]),
         c=np.array([-2.0]), z=0, p=sparse.csc_matrix(np.array([[1.0]])),
     )
-
-def test_equality_only_update_failure_returns_failed(monkeypatch):
-  """A backend whose factorization fails through every retry must return
-  FAILED (with an all-NaN full-size payload), not raise."""
-  rng = np.random.default_rng(5900)
-  m, n = 5, 10
-  a, b, c, p = _gen_equality_only(m, n, random_state=rng)
-  def boom(self, *args, **kwargs):
-    raise RuntimeError("forced persistent factorization failure")
-  monkeypatch.setattr(qtqp.direct.DirectKktSolver, "update", boom)
-  sol = qtqp.QTQP(a=a, b=b, c=c, z=m, p=p).solve(verbose=False)
-  assert sol.status == qtqp.SolutionStatus.FAILED
-  assert np.all(np.isnan(sol.x)) and np.all(np.isnan(sol.y))
 
 
 def test_equality_only_stats_schema_matches_main_loop():
@@ -3750,12 +3737,12 @@ def test_equality_only_stats_schema_matches_main_loop():
   assert not missing, f"equality stats row missing {missing}"
 
 
-def test_semidefinite_p_direct_path_solves_on_every_backend():
-  """The z == m direct path solves at mu = 0, so the factorized primal block
-  is exactly P. P = [[1, 1], [1, 1]] is singular along the constraint's
-  null space, so a magnitude floor leaves the KKT matrix singular and the
-  outcome depended on the backend; the additive shift makes every backend
-  solve it."""
+def test_semidefinite_p_equality_only_solves_on_every_backend():
+  """An all-equality problem is solved by the initialization, whose
+  factorized primal block is exactly P. P = [[1, 1], [1, 1]] is singular
+  along the constraint's null space, so a magnitude floor would leave the
+  KKT matrix singular and the outcome backend-dependent; the additive
+  static shift in the initialization factor makes every backend solve it."""
   p = sparse.csc_matrix(np.array([[1.0, 1.0], [1.0, 1.0]]))
   a = sparse.csc_matrix(np.array([[1.0, 1.0]]))
   c = np.array([-1.0, -1.0])


### PR DESCRIPTION
Stacked on #122 (base branch `clarabel-criteria`); retarget to `main` once that lands.

**Initialization.** The initial-point system is now Clarabel's: `[P, A'; A, -H][x; y] = [-c; b]` with `H` the identity on inequality rows and **zero** on equality rows, since the zero cone contributes no scaling block. The initial point therefore satisfies every equality row exactly instead of a least-squares penalty (on DPKLO1 the old init had `||Ax - b|| = 0.43`; Clarabel's iteration-0 point has 7e-16). The former 1e-8 primal shift is gone from the true system; static regularization is added to the factorized diagonals only, which keeps a rank-deficient `P` or the zero block factorizable, and iterative refinement targets the true system.

**Iteration 0.** The initial point is graded before the first step, as Clarabel does. An all-equality problem is therefore solved by the initialization alone and terminates at iteration 0 through the standard criteria, exactly as Clarabel reports `Solved` with zero iterations on those problems. The special-case direct path (`_solve_equality_only`), its residual-only grading, and the `additive_regularization` flag on `DirectKktSolver.update` are removed (net −80 lines). With no complementarity pairs the embedding has no certificate side, which the gate now states explicitly. A warm start is ignored on all-equality problems.

**Verified.** Full suite 2477 passed, 1 xfailed. The nine equality-only Maros-Meszaros problems (AUG2D, AUG2DC, AUG3D, AUG3DC, DPKLO1, DTOC3, GENHS28, HS51, HS52), previously excluded from the campaign because `z == m` was rejected, are back in the sweeps. The large-scale fixture `A = [1], b = 1e10, c = 0` now returns `y = 0` exactly (the LP split solves `[-c; 0] = [0; 0]` for the dual), so it passes every criterion at iteration 0 on every platform.

**Sweep.** A four-dataset sweep at this commit against the #122 behavior and Clarabel is running; the comparison (solve counts, status changes, iteration ratios, refinement) will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)