### PR TITLE
Add the (b, c) and objective scalars to Ruiz equilibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,9 +258,13 @@ Key parameters:
 
 Choose one with the `equilibration_strategy` argument:
 
--   `qtqp.EquilibrationStrategy.RUIZ`: Default. Ruiz equilibration on `A` and
-    `P`; `b` and `c` are scaled passively by the accumulated row/column
-    scalings.
+-   `qtqp.EquilibrationStrategy.RUIZ`: Default. Ruiz equilibration on the KKT
+    block `[P, A'; A, 0]`, plus the two scalars a QP admits freely: a joint
+    scale on `b` and `c` (a rescale of the solution) taking `||b||_inf` to 1,
+    and a scale on the objective `P`, `c` (a rescale of the duals) taking
+    `max(||c||_inf, max |P_ij|)` to 1, both kept within `[1e-4, 1e4]`. `b`
+    and `c` never enter the row/column scalings, so the factorized block
+    keeps unit rows and columns.
 -   `qtqp.EquilibrationStrategy.AUGMENTED`: Ruiz equilibration on the symmetric
     augmented matrix containing `P`, `A`, `b`, and `c`. This lets `b` and `c`
     participate directly in the scaling and can improve reliability on

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -67,6 +67,13 @@ _REDUCED_TOL_GAP_REL = 5e-5
 # touch the floor.
 _MU_FLOOR = 1e-14
 
+# Bounds on the accumulated equilibration scalars sigma and gamma (Clarabel's
+# bounds on its cost scaling). Beyond them the absolute mu floor and static
+# regularization, which live in the operating frame, would take over: a
+# single big-M entry in b can put ||Db||_inf at 1e12.
+_SCALAR_MIN = 1e-4
+_SCALAR_MAX = 1e4
+
 
 class LinearSolver(enum.Enum):
   """Available linear solvers."""
@@ -162,11 +169,21 @@ class EquilibrationStrategy(enum.Enum):
     Do not equilibrate. Pass (A, P, b, c) through unchanged.
 
   RUIZ:
-    Ruiz equilibration on the constraint matrix A and Hessian P. Symmetric
-    diagonal scalings D (rows) and E (columns) are chosen so that, at each
-    iteration, the inf-norm of every row of D A E and every column of
-    [D A E ; E P E] is driven toward 1. The vectors b and c are passively
-    rescaled as b <- D b and c <- E c.
+    Ruiz equilibration on the KKT block [P, A'; A, 0] plus two scalars.
+    Symmetric diagonal scalings D (rows) and E (columns) are chosen so that,
+    at each pass, the inf-norm of every row of D A E and every column of
+    [D A E ; E P E] is driven toward 1. Each pass then applies the two scalar
+    factors a QP admits without changing its solution set:
+
+        sigma: a joint scale on (b, c), i.e. a rescale of the solution,
+               taking ||b||_inf to 1;
+        gamma: a scale on the objective (P, c), i.e. a rescale of the
+               duals, taking max(||c||_inf, max |P_ij|) to 1.
+
+    So A_eq = D A E, P_eq = gamma E P E, b_eq = sigma D b and
+    c_eq = sigma gamma E c. b and c never enter D or E: the factorized block
+    keeps unit rows and columns, and only the scalars absorb their magnitude.
+    Both scalars are kept within [1e-4, 1e4].
 
   AUGMENTED:
     Ruiz equilibration on the symmetric augmented matrix
@@ -176,7 +193,7 @@ class EquilibrationStrategy(enum.Enum):
             [ c^T -b^T   0 ]
 
     so b and c participate in determining the row/column norms rather than
-    being scaled passively. The scaling has three blocks (E for x columns,
+    only moving the scalars. The scaling has three blocks (E for x columns,
     D for y rows, and a scalar sigma for the augmented row/column), giving
 
         A_eq = D A E,    P_eq = E P E,
@@ -184,7 +201,8 @@ class EquilibrationStrategy(enum.Enum):
 
     The sigma factor maps to the homogenization variable (tau_orig =
     sigma * tau_eq), so iterate (un)equilibration must apply 1/sigma to
-    keep the recovered x/tau, y/tau, s/tau in the original scale.
+    keep the recovered x/tau, y/tau, s/tau in the original scale. This
+    strategy has no objective scale (gamma == 1).
   """
 
   NONE = "none"
@@ -790,9 +808,11 @@ class QTQP:
       )
     if equilibration_strategy is EquilibrationStrategy.NONE:
       a, p, b, c = self.a, self.p, self.b, self.c
-      self.d, self.e, self.sigma_eq = None, None, 1.0
+      self.d, self.e, self.sigma_eq, self.gamma_eq = None, None, 1.0, 1.0
     else:
-      a, p, b, c, self.d, self.e, self.sigma_eq = self._equilibrate()
+      a, p, b, c, self.d, self.e, self.sigma_eq, self.gamma_eq = (
+          self._equilibrate()
+      )
     # Operating-scale b, c, kept for the distance-to-path certificate.
     self._b_op, self._c_op = b, c
 
@@ -1184,9 +1204,10 @@ class QTQP:
   def _equilibrate(self, num_iters=10, min_scale=1e-3, max_scale=1e3):
     """Dispatch to the selected equilibration strategy.
 
-    Returns a 7-tuple (a, p, b, c, d, e, sigma) of equilibrated problem data
-    and accumulated scalings. For RUIZ, sigma == 1.0; for AUGMENTED, sigma is
-    the scalar scaling on the augmented row/column (== tau_orig / tau_eq).
+    Returns an 8-tuple (a, p, b, c, d, e, sigma, gamma) of equilibrated
+    problem data and accumulated scalings: sigma is the joint scale on
+    (b, c) (== tau_orig / tau_eq) and gamma the scale on the objective
+    (P, c); AUGMENTED has gamma == 1.0.
     """
     if self.equilibration_strategy is EquilibrationStrategy.RUIZ:
       return self._equilibrate_ruiz(num_iters, min_scale, max_scale)
@@ -1197,14 +1218,24 @@ class QTQP:
     )
 
   def _equilibrate_ruiz(self, num_iters, min_scale, max_scale):
-    """Ruiz equilibration on A and P. b, c rescaled passively by d, e."""
-    # Work on copies so self.a / self.p are not modified in-place; they are
-    # used unequilibrated later (e.g. in _check_termination). The constructor
-    # already enforces CSC, so .copy() preserves format without a re-convert.
+    """Ruiz on the KKT block [P, A'; A, 0] plus the scalars sigma and gamma.
+
+    b and c never enter D or E. Each pass equilibrates the block, then takes
+    ||b||_inf to 1 with the joint (b, c) scale sigma and
+    max(||c||_inf, max |P_ij|) to 1 with the objective (P, c) scale gamma.
+    P sees gamma, so the next pass's column norms rebalance P against A.
+    Clarabel scales its cost the same way but with P's mean column norm;
+    the max is used here because it is attainable together with E's unit
+    columns when P has zero columns, whereas a unit mean is not.
+    """
+    # Work on copies so self.a / self.p / self.b / self.c are not modified
+    # in-place; they are used unequilibrated later (e.g. in
+    # _check_termination). The constructor already enforces CSC, so .copy()
+    # preserves format without a re-convert.
     a, p = self.a.copy(), self.p.copy()
-    b, c = self.b, self.c
-    # Initialize the equilibration matrices.
-    d, e = (np.ones(self.m), np.ones(self.n))
+    b, c = self.b.copy(), self.c.copy()
+    d, e = np.ones(self.m), np.ones(self.n)
+    sigma = gamma = 1.0
 
     # Sparsity patterns are static across iterations; the per-column nnz
     # counts only need to be computed once for the scaling-broadcast step.
@@ -1238,18 +1269,50 @@ class QTQP:
         # E @ P @ E: scale non-zero at row r, col c by e_i[r] * e_i[c].
         col_scale_p = np.repeat(e_i, p_col_counts)
         p.data *= e_i[p.indices] * col_scale_p
+      b *= d_i
+      c *= e_i
+
+      # sigma: joint scale on (b, c), a rescale of the solution, taking
+      # ||b||_inf to 1 within the cumulative bounds.
+      norm_b = _norm(b, np.inf)
+      sigma_i = 1.0
+      if norm_b > 0.0:
+        sigma_i = float(
+            np.clip(1.0 / norm_b, _SCALAR_MIN / sigma, _SCALAR_MAX / sigma)
+        )
+      b *= sigma_i
+      c *= sigma_i
+
+      # gamma: scale on the objective (P, c), a rescale of the duals, taking
+      # max(||c||_inf, max |P_ij|) to 1.
+      scale_cost = _norm(c, np.inf)
+      if p_col_counts is not None:
+        scale_cost = max(scale_cost, float(np.abs(p.data).max()))
+      gamma_i = 1.0
+      if scale_cost > 0.0:
+        gamma_i = float(
+            np.clip(1.0 / scale_cost, _SCALAR_MIN / gamma, _SCALAR_MAX / gamma)
+        )
+      p.data *= gamma_i
+      c *= gamma_i
 
       # Accumulate scaling factors
       d *= d_i
       e *= e_i
+      sigma *= sigma_i
+      gamma *= gamma_i
       logging.debug(
-          "Equilibration: iter %d: d_i err: %s, e_i err: %s",
+          "Equilibration: iter %d: d_i err: %s, e_i err: %s, sigma_i: %s,"
+          " gamma_i: %s",
           i,
           _norm(d_i - 1, np.inf),
           _norm(e_i - 1, np.inf),
+          sigma_i,
+          gamma_i,
       )
 
-    return a, p, b * d, c * e, d, e, 1.0
+    return a, p, b, c, d, e, sigma, gamma
+
 
   def _equilibrate_augmented(self, num_iters, min_scale, max_scale):
     """Ruiz equilibration on the symmetric augmented matrix.
@@ -1315,18 +1378,19 @@ class QTQP:
           abs(sigma_i - 1.0),
       )
 
-    return a, p, b, c, d, e, sigma
+    return a, p, b, c, d, e, sigma, 1.0
 
   def _unequilibrate_iterates(self, x, y, s):
     """Map equilibrated iterates back to original-problem scale.
 
-    Bakes the 1/sigma factor into (x, y, s) so the subsequent division by
-    the (equilibrated-space) tau produces the original-problem solution.
+    Bakes the scalar factors into (x, y, s) so the subsequent division by
+    the (equilibrated-space) tau produces the original-problem solution:
+    1/sigma on all of them, and 1/gamma on the duals only.
     """
     inv_sigma = 1.0 / self.sigma_eq
     return (
         inv_sigma * self.e * x,
-        inv_sigma * self.d * y,
+        inv_sigma / self.gamma_eq * self.d * y,
         inv_sigma * s / self.d,
     )
 
@@ -1334,7 +1398,7 @@ class QTQP:
     """Inverse of _unequilibrate_iterates: original scale -> equilibrated."""
     return (
         self.sigma_eq * x / self.e,
-        self.sigma_eq * y / self.d,
+        self.sigma_eq * self.gamma_eq * y / self.d,
         self.sigma_eq * s * self.d,
     )
 
@@ -1621,13 +1685,16 @@ class QTQP:
       # roundoff of the summands (late endgame); treat large-mu iterates as
       # the informative regime.
       if self.equilibration_strategy is not EquilibrationStrategy.NONE:
-        se = self.sigma_eq * self.e
+        # Operating-scale products from the original-scale ones: A_eq x_eq =
+        # sigma D (A x), A_eq' y_eq = sigma gamma E (A' y), P_eq x_eq =
+        # sigma gamma E (P x), and the scalars pick up sigma^2 gamma.
         sd = self.sigma_eq * self.d
-        sig2 = self.sigma_eq * self.sigma_eq
+        sge = self.sigma_eq * self.gamma_eq * self.e
+        sig2g = self.sigma_eq * self.sigma_eq * self.gamma_eq
         ax_w = sd * ax
-        aty_w = se * aty
-        px_w = se * px
-        ctx_w, bty_w, xpx_w = sig2 * ctx, sig2 * bty, sig2 * xpx
+        aty_w = sge * aty
+        px_w = sge * px
+        ctx_w, bty_w, xpx_w = sig2g * ctx, sig2g * bty, sig2g * xpx
       else:
         ax_w, aty_w, px_w = ax, aty, px
         ctx_w, bty_w, xpx_w = ctx, bty, xpx

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -1456,8 +1456,8 @@ class QTQP:
     unmodified mu_target.
 
     Uses the exact quadratic tau solve when the KKT solve is accurate, and a
-    linearized fallback (avoids squaring solver noise) when it's noisy or the
-    quadratic residual check fails.
+    fallback with P linearized at the current x (avoids squaring solver
+    noise) when the quadratic is degenerate or has no admissible root.
     """
     # Prepare RHS for the linear system.
     r = (mu - mu_target) * r_anchor
@@ -1566,12 +1566,15 @@ class QTQP:
   def _solve_for_tau_linearized_fallback(
       self, p, kinv_r, mu, mu_target, x, y, tau_curr, tau_anchor,
   ) -> float:
-    """Linearized fallback for tau via first-order Taylor expansion of G(z,tau).
+    """Fallback for tau: the exact tau quadratic with P linearized at x.
 
-    Replaces the exact quadratic with a linearization around z_curr = [x; y]
-    and tau_curr. P only multiplies the safe current iterate x, so KKT noise
-    enters linearly rather than quadratically. A [0.1x, 10x] trust region
-    prevents manifold drift from the first-order approximation.
+    The same equation as _solve_for_tau, except that x'Px is replaced by its
+    first-order expansion around the current x, so P only multiplies the
+    safe current iterate and KKT noise enters the coefficients linearly
+    rather than squared. The mu tau^2 term stays exact, which matters when
+    tau is not small relative to the rest of the iterate. If the quadratic
+    has no admissible root, take the first-order step in tau of the same
+    model instead. A [0.1x, 10x] trust region prevents manifold drift.
 
     Linear-residual coefficients on tau use mu and mu_target; the
     cone-product constant -mu_target keeps the unmodified mu_target.
@@ -1580,31 +1583,44 @@ class QTQP:
     q, kinv_q = self.q, self.kinv_q
 
     px = p @ x if p.nnz > 0 else np.zeros(n)
-
-    # Scalar inner products; avoids allocating z_curr = [x; y] or r_z.
-    q_z = q[:n] @ x + q[n:] @ y
-    x_px = x @ px
     q_kinv_q = q @ kinv_q
+    q_kinv_r = q @ kinv_r
     px_kinv_q = px @ kinv_q[:n]
-    # r_z = kinv_r - tau_curr * kinv_q - z_curr, collapsed into scalar dots.
-    q_rz = q @ kinv_r - tau_curr * q_kinv_q - q_z
-    px_rz = px @ kinv_r[:n] - tau_curr * px_kinv_q - x_px
+    px_kinv_r = px @ kinv_r[:n]
+    x_px = x @ px
+    t_a = mu + q_kinv_q
+    t_b = (mu_target - mu) * tau_anchor - q_kinv_r + 2.0 * px_kinv_q
+    t_c = -mu_target + x_px - 2.0 * px_kinv_r
 
-    # Base residual G(z_curr, tau_curr).
-    g = (mu * tau_curr * tau_curr
-         + (mu_target - mu) * tau_anchor * tau_curr
-         - tau_curr * q_z - mu_target - x_px)
-
-    # Numerator: G + (dG/dz) @ r_z.  Denominator: dG/dtau - (dG/dz) @ kinv_q.
-    num = g - tau_curr * q_rz - 2.0 * px_rz
-    den = (2.0 * mu * tau_curr + (mu_target - mu) * tau_anchor - q_z +
-           tau_curr * q_kinv_q + 2.0 * px_kinv_q)
-
-    tau_sol = tau_curr + (0.0 if abs(den) < 1e-16 else -num / den)
-
-    if not np.isfinite(tau_sol):
-      logging.warning("Linearized tau fallback non-finite; using current tau.")
-      return tau_curr
+    tau_sol = None
+    if abs(t_a) < _EPS:
+      if abs(t_b) >= _EPS:
+        tau_sol = -t_c / t_b
+    else:
+      discriminant = t_b * t_b - 4.0 * t_a * t_c
+      if discriminant >= 0.0:
+        # Stable quadratic formula (Muller), as in _solve_for_tau.
+        if t_b > 0:
+          tau_sol = t_c / (-0.5 * (t_b + math.sqrt(discriminant)))
+        else:
+          tau_sol = (-0.5 * (t_b - math.sqrt(discriminant))) / t_a
+    if tau_sol is None or not np.isfinite(tau_sol):
+      # First-order step: linearize the same model around the current
+      # iterate z_curr = [x; y] and tau_curr, with r_z = kinv_r -
+      # tau_curr * kinv_q - z_curr collapsed into scalar dots.
+      q_z = q[:n] @ x + q[n:] @ y
+      q_rz = q_kinv_r - tau_curr * q_kinv_q - q_z
+      px_rz = px_kinv_r - tau_curr * px_kinv_q - x_px
+      g = (mu * tau_curr * tau_curr
+           + (mu_target - mu) * tau_anchor * tau_curr
+           - tau_curr * q_z - mu_target - x_px)
+      num = g - tau_curr * q_rz - 2.0 * px_rz
+      den = (2.0 * mu * tau_curr + (mu_target - mu) * tau_anchor - q_z
+             + tau_curr * q_kinv_q + 2.0 * px_kinv_q)
+      tau_sol = tau_curr + (0.0 if abs(den) < 1e-16 else -num / den)
+      if not np.isfinite(tau_sol):
+        logging.warning("Tau fallback non-finite; using current tau.")
+        return tau_curr
     return min(max(tau_sol, 0.1 * tau_curr), 10.0 * tau_curr)
 
   def _normalize(self, x, y, tau, s):

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1382,10 +1382,11 @@ def test_linearized_tau_always_converges(seed, problem_type):
     _assert_unbounded(solution, a, c, p, z)
 
 
-def _equilibrate_reference(a, p, num_iters=10, min_scale=1e-3, max_scale=1e3):
-  """Reference Ruiz equilibration using sparse diagonal matrix products."""
-  a, p = a.copy(), p.copy()
+def _equilibrate_reference(a, p, b, c, num_iters=10, min_scale=1e-3, max_scale=1e3):
+  """Reference Ruiz + scalars using sparse diagonal matrix products."""
+  a, p, b, c = a.copy(), p.copy(), b.copy(), c.copy()
   d, e = np.ones(a.shape[0]), np.ones(a.shape[1])
+  sigma = gamma = 1.0
   for _ in range(num_iters):
     d_i = sparse.linalg.norm(a, np.inf, axis=1)
     d_i = np.where(d_i == 0.0, 1.0, d_i)
@@ -1397,29 +1398,72 @@ def _equilibrate_reference(a, p, num_iters=10, min_scale=1e-3, max_scale=1e3):
     d_mat, e_mat = sparse.diags(d_i), sparse.diags(e_i)
     a = d_mat @ a @ e_mat
     p = e_mat @ p @ e_mat
+    b, c = d_mat @ b, e_mat @ c
+    sigma_i = np.clip(1.0 / np.abs(b).max(), 1e-4 / sigma, 1e4 / sigma)
+    b, c = sigma_i * b, sigma_i * c
+    scale_cost = max(np.abs(c).max(), abs(p).max())
+    gamma_i = np.clip(1.0 / scale_cost, 1e-4 / gamma, 1e4 / gamma)
+    p, c = gamma_i * p, gamma_i * c
     d *= d_i
     e *= e_i
-  return a, p, d, e
+    sigma *= sigma_i
+    gamma *= gamma_i
+  return a, p, b, c, d, e, sigma, gamma
 
 
 @pytest.mark.parametrize('seed', 2142 + np.arange(10))
 def test_equivalent_equilibration(seed):
-  """Test that in-place equilibration matches the reference sparse matmul."""
+  """In-place equilibration matches the reference sparse matmul and its targets."""
   rng = np.random.default_rng(seed)
   m, n, z = 150, 100, 10
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  b, c = 1e2 * b, 1e-3 * c  # Badly scaled, so the scalars have work to do.
 
   solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
   solver.equilibration_strategy = qtqp.EquilibrationStrategy.RUIZ
-  a_eq, p_eq, _, _, d, e, sigma = solver._equilibrate()  # pylint: disable=protected-access
+  a_eq, p_eq, b_eq, c_eq, d, e, sigma, gamma = solver._equilibrate()  # pylint: disable=protected-access
 
-  a_ref, p_ref, d_ref, e_ref = _equilibrate_reference(a, p)
+  ref = _equilibrate_reference(a, p, b, c)
+  got = (a_eq.toarray(), p_eq.toarray(), b_eq, c_eq, d, e, sigma, gamma)
+  want = (ref[0].toarray(), ref[1].toarray(), *ref[2:])
+  for g, w in zip(got, want):
+    np.testing.assert_allclose(g, w, atol=1e-14, rtol=1e-14)
 
-  np.testing.assert_allclose(a_eq.toarray(), a_ref.toarray(), atol=1e-14, rtol=1e-14)
-  np.testing.assert_allclose(p_eq.toarray(), p_ref.toarray(), atol=1e-14, rtol=1e-14)
-  np.testing.assert_allclose(d, d_ref, atol=1e-14, rtol=1e-14)
-  np.testing.assert_allclose(e, e_ref, atol=1e-14, rtol=1e-14)
-  assert sigma == 1.0  # RUIZ never touches the augmented scalar.
+  # The accumulated factors reproduce the equilibrated data from the original.
+  d_mat, e_mat = sparse.diags(d), sparse.diags(e)
+  np.testing.assert_allclose(a_eq.toarray(), (d_mat @ a @ e_mat).toarray(), rtol=1e-12)
+  np.testing.assert_allclose(p_eq.toarray(), gamma * (e_mat @ p @ e_mat).toarray(), rtol=1e-12)
+  np.testing.assert_allclose(b_eq, sigma * d * b, rtol=1e-12)
+  np.testing.assert_allclose(c_eq, sigma * gamma * e * c, rtol=1e-12)
+
+  # Targets: ||b_eq||_inf = 1, cost scale 1, and the KKT block at unit rows.
+  assert np.abs(b_eq).max() == pytest.approx(1.0)
+  cost = max(np.abs(c_eq).max(), abs(p_eq).max())
+  assert cost == pytest.approx(1.0)
+  rows = sparse.linalg.norm(a_eq, np.inf, axis=1)
+  np.testing.assert_allclose(rows[rows > 0], 1.0, rtol=1e-2)
+
+  # A big-M entry in b saturates sigma at its bound instead of dragging the
+  # whole frame down with it.
+  solver = qtqp.QTQP(a=a, b=1e12 * b, c=c, z=z, p=p)
+  solver.equilibration_strategy = qtqp.EquilibrationStrategy.RUIZ
+  _, _, b_eq, _, _, _, sigma, _ = solver._equilibrate()  # pylint: disable=protected-access
+  assert sigma == 1e-4
+  assert np.abs(b_eq).max() > 1.0
+
+
+@pytest.mark.parametrize('seed', 7 + np.arange(5))
+@pytest.mark.parametrize('scales', ((1e5, 1e-4), (1e-4, 1e5)))
+def test_solve_badly_scaled_b_c(seed, scales):
+  """Rescaled b and c (valid: the cones are invariant) come back in the original frame."""
+  rng = np.random.default_rng(seed)
+  m, n, z = 150, 100, 10
+  a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
+  b, c = scales[0] * b, scales[1] * c
+
+  solution = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p).solve(collect_stats=True)
+
+  _assert_solution(solution, a, b, c, p, z)
 
 
 def _compute_sigma_reference(solver, mu_curr, x, y, tau, s, alpha, d_x, d_y,
@@ -1901,14 +1945,14 @@ def test_max_step_size():
 ])
 def test_equilibrate_unequilibrate_roundtrip(strategy):
   """Equilibrating then unequilibrating iterates must be the identity for
-  every non-NONE strategy (sigma factor must cancel)."""
+  every non-NONE strategy (the sigma and gamma factors must cancel)."""
   rng = np.random.default_rng(42)
   m, n, z = 30, 20, 5
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
   solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
   solver.equilibration_strategy = strategy
 
-  _, _, _, _, solver.d, solver.e, solver.sigma_eq = solver._equilibrate()  # pylint: disable=protected-access
+  _, _, _, _, solver.d, solver.e, solver.sigma_eq, solver.gamma_eq = solver._equilibrate()  # pylint: disable=protected-access
 
   x = rng.normal(size=n)
   y = rng.uniform(size=m)
@@ -2150,10 +2194,13 @@ def test_iterative_refinement_improves_residual():
       max_iterative_refinement_steps=50, verbose=True, collect_stats=True
   )
 
-  # Compare the first iteration (cold start) q-solve residual.
+  # Compare the first iteration (cold start) q-solve residual. With ||q||_inf
+  # normalized to 1 by the equilibration scalars, a single step can already
+  # sit at the rounding floor, where the ordering is noise.
   res_1 = sol_1.stats[0]['q_lin_sys_stats']['final_residual_norm']
   res_50 = sol_50.stats[0]['q_lin_sys_stats']['final_residual_norm']
-  assert res_1 >= res_50, (
+  floor = 8 * np.finfo(float).eps
+  assert res_1 >= res_50 or res_50 <= floor, (
       f"1-step residual {res_1} should be >= 50-step residual {res_50}"
   )
 
@@ -2473,8 +2520,7 @@ def test_augmented_equilibration_unbounded():
 
 def test_augmented_equilibration_scales_b_and_c():
   """AUGMENTED equilibration must drive |b| and |c| toward unit scale when
-  the original problem has them several orders of magnitude away from 1.
-  RUIZ scales b and c only passively by d/e and cannot reach this."""
+  the original problem has them several orders of magnitude away from 1."""
   rng = np.random.default_rng(99)
   m, n, z = 30, 20, 5
   a, b, c, p = _gen_feasible(m, n, z, random_state=rng)
@@ -2483,7 +2529,7 @@ def test_augmented_equilibration_scales_b_and_c():
   c = c * 1e-6
   solver = qtqp.QTQP(a=a, b=b, c=c, z=z, p=p)
   solver.equilibration_strategy = qtqp.EquilibrationStrategy.AUGMENTED
-  _, _, b_eq, c_eq, d, e, sigma = solver._equilibrate()  # pylint: disable=protected-access
+  _, _, b_eq, c_eq, d, e, sigma, _ = solver._equilibrate()  # pylint: disable=protected-access
 
   # sigma absorbed most of the gross scale mismatch.
   assert sigma != 1.0


### PR DESCRIPTION
Based on #123 (exact-init). Two commits.

**1. Add the (b, c) and objective scalars to Ruiz equilibration.** RUIZ still equilibrates the KKT block `[P, A'; A, 0]` with D and E, and now applies on every pass the two scalar factors a QP admits without changing its solution set: `sigma` on (b, c), a rescale of the solution, taking `||b||_inf` to 1; and `gamma` on (P, c), a rescale of the duals, taking `max(||c||_inf, max |P_ij|)` to 1 (Clarabel's cost scaling, with the max entry of P instead of its mean column norm, which is not attainable together with unit columns when P has zero columns). Both are kept within `[1e-4, 1e4]`, Clarabel's bounds on its cost scaling. b and c never enter D or E, so the factorized block keeps unit rows and columns, and the `K^{-1} q` refinement tolerance `1e-12 (1 + ||q||_inf)` no longer scales with the largest cost entry.

**2. Make the tau fallback exact in tau, first-order in P.** The fallback (used only when the primary tau quadratic is degenerate or has no admissible root) now solves the same quadratic with `x'Px` linearized at the current x, so KKT noise still enters linearly, and keeps the previous first-order step as its backstop. Needed because the forced-fallback stress test wandered on one feasible seed in the balanced frame; it improves the old frame too (worst stress case 28 -> 12 iterations). The production path is unchanged, and on LPs the new fallback reduces to the old step whenever the primary fails.

**Sweep** (MM 138, MIPLIB 173 under 20 MB, NETLIB feasible 93 and infeasible 29; default tolerances, `max_iter=200`, qdldl; baseline is #123's RUIZ):

| dataset | RUIZ (#123) | this PR | Clarabel |
|---|---|---|---|
| Maros-Meszaros solved | 131 | 131 | 117 |
| MIPLIB solved | 165 | 171 | 151 |
| NETLIB feasible solved | 91 | 93 | 91 |
| NETLIB infeasible certificates | 27 | 27 | 27 |

Status changes vs RUIZ: gains cryptanalysiskb128n5obj16 (199 -> 7 it), neos-1171448 (199 -> 8), neos-1354092 (199 -> 49), satellites2-40 (time limit -> 24), satellites2-60-fs (199 -> 22), sp97ar (199 -> 36), traininstance2 (199 -> 106), traininstance6 (199 -> 45), cycle (199 -> 28), dfl001 (199 -> 37); loss cbs-cta (49 -> 199, a step-size stall at the clipped `sigma`); ns1116954 flips from 1448 s to the 1830 s time limit; cplex1's certificate changes from primal to dual infeasibility. Iterations vs RUIZ on the 377 problems both solve: median 1.00 (p25 0.90, p75 1.15); vs Clarabel: median 0.89.

**Why the clip.** The unclipped scalars (net -5) and Clarabel-style gamma alone (net -11) were both swept and rejected. The balanced frame is right (lotfi 47 crawling iterations -> 14 clean, cryptanalysis-obj16 199 -> 7), but big-M rows put `||Db||_inf` as high as 1e12, and the operating mu `sigma^2 gamma mu` then sits on the 1e-14 floor while the physical mu is O(1) (the QGROWs, BOYD2, mas74/76, roll3000, atlanta-ip all failed that way); gamma alone unbalances the primal and dual blocks. The clip keeps the scalars where the absolute mu floor, static regularization and refinement tolerance tolerate them; making those three frame-invariant is the follow-up that would let the clip go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
