### PR TITLE
Bump version to 0.0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qtqp"
-version = "0.0.5"
+version = "0.0.6"
 description = "The 'cutie' QP solver."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -45,7 +45,7 @@ import scipy.sparse as sp
 from . import direct
 from .direct import RefinementStrategy
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 _HEADER = """| iter |      pcost |      dcost |     pres |     dres |      gap |   infeas |       mu |  q, p, c |     time |"""
 _SEPARA = """|------|------------|------------|----------|----------|----------|----------|----------|----------|----------|"""
 _norm = np.linalg.norm


### PR DESCRIPTION
Version bump for the 0.0.6 release. The release notes (Clarabel comparison, warm-start results, API changes) go on the GitHub release created from the v0.0.6 tag, which triggers the PyPI publish job.