### PR TITLE
Cut per-iteration Python overhead: cached transpose, GMRES buffers, direct norms

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -128,6 +128,43 @@ def _auto_linear_solver_order() -> list[LinearSolver]:
   return [LinearSolver.PARDISO] + fallbacks
 
 
+def _csc_col_inf_norms(mat: sp.csc_matrix, abs_data: np.ndarray) -> np.ndarray:
+  """Infinity norm of every column of a CSC matrix (0 for empty columns).
+
+  abs_data is |mat.data|; passing it in lets one pass over the entries serve
+  both the row and the column norms.
+  """
+  norms = np.zeros(mat.shape[1])
+  starts = mat.indptr[:-1]
+  nonempty = mat.indptr[1:] > starts
+  if abs_data.size:
+    norms[nonempty] = np.maximum.reduceat(abs_data, starts[nonempty])
+  return norms
+
+
+def _csc_row_order(mat: sp.csc_matrix) -> tuple[np.ndarray, np.ndarray]:
+  """Permutation taking mat.data to row-major order, with the row pointers.
+
+  Computed once per equilibration so the per-pass row norms are a gather and
+  a segmented max over the CSC data, with no temporary sparse matrices.
+  """
+  tags = np.arange(1, mat.nnz + 1, dtype=np.float64)
+  by_row = sp.csc_matrix((tags, mat.indices, mat.indptr), shape=mat.shape).tocsr()
+  return by_row.data.astype(np.intp) - 1, by_row.indptr
+
+
+def _csc_row_inf_norms(
+    abs_data: np.ndarray, row_perm: np.ndarray, row_indptr: np.ndarray, m: int
+) -> np.ndarray:
+  """Infinity norm of every row of a CSC matrix, given _csc_row_order."""
+  norms = np.zeros(m)
+  starts = row_indptr[:-1]
+  nonempty = row_indptr[1:] > starts
+  if abs_data.size:
+    norms[nonempty] = np.maximum.reduceat(abs_data[row_perm], starts[nonempty])
+  return norms
+
+
 def _resolve_linear_solver(
     linear_solver: LinearSolver,
 ) -> tuple[LinearSolver, direct.LinearSolver]:
@@ -1238,20 +1275,23 @@ class QTQP:
     sigma = gamma = 1.0
 
     # Sparsity patterns are static across iterations; the per-column nnz
-    # counts only need to be computed once for the scaling-broadcast step.
+    # counts only need to be computed once for the scaling-broadcast step,
+    # and the row ordering once for the row norms.
     a_col_counts = np.diff(a.indptr)
     p_col_counts = np.diff(p.indptr) if p.nnz > 0 else None
+    a_row_perm, a_row_indptr = _csc_row_order(a)
 
     for i in range(num_iters):
+      abs_a = np.abs(a.data)
       # Row norms (infinity norm)
-      d_i = sp.linalg.norm(a, np.inf, axis=1)
+      d_i = _csc_row_inf_norms(abs_a, a_row_perm, a_row_indptr, self.m)
       d_i = np.where(d_i == 0.0, 1.0, d_i)  # If a row is zero, set d_i 1.0.
       d_i = 1.0 / np.sqrt(d_i)
       d_i = np.clip(d_i, min_scale, max_scale)
 
       # Column norms (max of A col norms and P col norms)
-      e_i_a = sp.linalg.norm(a, np.inf, axis=0)
-      e_i_p = sp.linalg.norm(p, np.inf, axis=0)
+      e_i_a = _csc_col_inf_norms(a, abs_a)
+      e_i_p = _csc_col_inf_norms(p, np.abs(p.data))
       e_i = np.maximum(e_i_a, e_i_p)
       e_i = np.where(e_i == 0.0, 1.0, e_i)  # If a col is zero, set e_i 1.0.
       e_i = 1.0 / np.sqrt(e_i)
@@ -1331,20 +1371,26 @@ class QTQP:
     d, e = np.ones(self.m), np.ones(self.n)
     sigma = 1.0
 
-    # Sparsity patterns are static; pre-compute the per-column nnz counts.
+    # Sparsity patterns are static; pre-compute the per-column nnz counts
+    # and the row ordering for the row norms.
     a_col_counts = np.diff(a.indptr)
     p_col_counts = np.diff(p.indptr) if p.nnz > 0 else None
+    a_row_perm, a_row_indptr = _csc_row_order(a)
 
     for i in range(num_iters):
+      abs_a = np.abs(a.data)
       # Column inf-norms of the symmetric augmented matrix.
       # x-columns (0..n): max(||P[:,j]||_inf, ||A[:,j]||_inf, |c[j]|)
       norms_e = np.maximum(
-          sp.linalg.norm(p, np.inf, axis=0),
-          sp.linalg.norm(a, np.inf, axis=0),
+          _csc_col_inf_norms(p, np.abs(p.data)),
+          _csc_col_inf_norms(a, abs_a),
       )
       norms_e = np.maximum(norms_e, np.abs(c))
       # y-columns (n..n+m): max(||A[i,:]||_inf, |b[i]|)
-      norms_d = np.maximum(sp.linalg.norm(a, np.inf, axis=1), np.abs(b))
+      norms_d = np.maximum(
+          _csc_row_inf_norms(abs_a, a_row_perm, a_row_indptr, self.m),
+          np.abs(b),
+      )
       # tau-column (n+m): max(||c||_inf, ||b||_inf)
       norm_sigma = max(_norm(c, np.inf), _norm(b, np.inf))
 

--- a/src/qtqp/direct.py
+++ b/src/qtqp/direct.py
@@ -85,12 +85,12 @@ def diag_data_indices(mat: sp.spmatrix) -> np.ndarray:
   """
   mat.sort_indices()
   dim = mat.shape[0]
-  idxs = np.empty(dim, dtype=np.intp)
-  for k in range(dim):
-    start = mat.indptr[k]
-    idxs[k] = start + np.searchsorted(
-        mat.indices[start:mat.indptr[k + 1]], k
-    )
+  # The scaffold stores every diagonal entry explicitly, so column k (row k
+  # for CSR) holds exactly one entry with index k; find them all at once.
+  owner = np.repeat(np.arange(dim), np.diff(mat.indptr))
+  idxs = np.flatnonzero(mat.indices == owner)
+  if idxs.size != dim:
+    raise ValueError("KKT scaffold must store every diagonal entry once.")
   return idxs
 
 
@@ -119,6 +119,9 @@ class LinearSolver:
     self._kkt = kkt
     self._kkt_diag = kkt.diagonal()
     self._kkt_diag_idxs = diag_data_indices(kkt)
+    # Transposed view sharing kkt.data, so update_diag keeps it current and
+    # the matvec below does not rebuild a sparse object on every call.
+    self._kkt_t = kkt.T
 
   def update_diag(self, diag: np.ndarray) -> None:
     """Updates the KKT diagonal in place; called each iteration before factorize.
@@ -146,7 +149,7 @@ class LinearSolver:
   def __matmul__(self, x: np.ndarray) -> np.ndarray:
     res = self._kkt @ x
     res -= self._kkt_diag * x
-    res += self._kkt.T @ x
+    res += self._kkt_t @ x
     return res
 
   def format(self) -> str:
@@ -237,6 +240,15 @@ class DirectKktSolver:
     self._reg_diags = np.empty(self.n + self.m, dtype=np.float64)
     self._kkt_rhs = np.empty(self.n + self.m, dtype=np.float64)    # RHS with cone block negated
     self._diag_correction = np.zeros(self.n + self.m, dtype=np.float64)  # reg - true
+    if refinement_strategy is RefinementStrategy.GMRES:
+      # GMRES work arrays, allocated once for the largest cycle.
+      k, dim = gmres_restart, self.n + self.m
+      self._gm_v = np.empty((k + 1, dim))
+      self._gm_z = np.empty((k, dim))
+      self._gm_h = np.zeros((k + 1, k))
+      self._gm_cs = np.zeros(k)
+      self._gm_sn = np.zeros(k)
+      self._gm_g = np.zeros(k + 1)
 
   def update(self, mu: float, s: np.ndarray, y: np.ndarray):
     """Forms the KKT matrix diagonals and factorizes it.
@@ -539,13 +551,14 @@ class DirectKktSolver:
     the 2-norm, so this is a safe (slightly conservative) trigger for the
     inf-norm convergence test the outer loop applies.
     """
-    n = sol.size
-    v = np.empty((max_inner + 1, n))
-    z = np.empty((max_inner, n))
-    h = np.zeros((max_inner + 1, max_inner))
-    cs = np.zeros(max_inner)
-    sn = np.zeros(max_inner)
-    g = np.zeros(max_inner + 1)
+    v = self._gm_v[: max_inner + 1]
+    z = self._gm_z[:max_inner]
+    h = self._gm_h[: max_inner + 1, :max_inner]
+    h.fill(0.0)
+    cs = self._gm_cs[:max_inner]
+    sn = self._gm_sn[:max_inner]
+    g = self._gm_g[: max_inner + 1]
+    g.fill(0.0)
 
     applies = 0
     beta = float(np.linalg.norm(residual))


### PR DESCRIPTION
Four changes with bit-identical results (x, y and iteration counts match
main exactly on the QDLDL backend across Maros-Meszaros and NETLIB
instances); profiling on small problems showed the time going to scipy
sparse object construction rather than arithmetic:

- The KKT matvec used self._kkt.T on every call, which builds a new sparse
  object each time; the transposed view (sharing kkt.data, so update_diag
  keeps it current) is now cached in set_kkt.
- diag_data_indices ran a Python loop with one searchsorted per column
  (0.1 s once per solve on 80k-row problems); it is now a single vectorized
  comparison against the column owner of each entry.
- GMRES allocated its Krylov basis, the preconditioned basis and the
  Hessenberg workspace on every refinement cycle; they are allocated once
  per DirectKktSolver, sized by gmres_restart, and sliced per cycle.
- Ruiz equilibration computed row and column infinity norms through
  scipy.sparse.linalg.norm, which materializes abs(A) and axis reductions
  as temporary sparse matrices three times per pass; the norms are now
  segmented maxima over the CSC data (columns) and over a row-order
  permutation of the data computed once per equilibration (rows). The
  AUGMENTED strategy uses the same helpers.

Best-of-three solve times, QDLDL backend, before -> after: HS118 6.3 ->
3.6 ms, afiro 5.4 -> 3.1 ms, QSC205 10.6 -> 7.0 ms, QSCAGR25 19.1 -> 13.2
ms, AUG3DCQP 39.1 -> 27.0 ms, pilot4 80.6 -> 70.0 ms, degen3 120 -> 110 ms;
on large instances the factorization dominates and the change is within
noise (CVXQP3_L and supportcase40 with Accelerate: 5-6% faster).

Profiling background: on large instances the numeric factorization is 85-90% of the time (the QDLDL backend, single-threaded simplicial LDL with its own AMD ordering, is 4x slower than CHOLMOD and 10x slower than Accelerate on CVXQP3_L; with the platform default backend qtqp is at parity with Clarabel). On small instances the time went to scipy sparse object construction, which these four changes remove. Results are bit-identical on the QDLDL backend.