### PR TITLE
Avoid full KKT densification in dense backend setup

### DIFF
--- a/src/qtqp/solvers_dense.py
+++ b/src/qtqp/solvers_dense.py
@@ -88,9 +88,12 @@ class ScipyDenseSolver(LinearSolver):
   def set_kkt(self, kkt: sp.spmatrix) -> None:
     super().set_kkt(kkt)
     n = self._n
-    kkt_dense = kkt.toarray()
-    self._A = np.asfortranarray(kkt_dense[:n, n:].T, dtype=np.float64)
-    P_block = kkt_dense[:n, :n]
+    # Densify only the blocks used by the Gram reduction: the full KKT
+    # would require O((n + m)^2) temporary storage when m >> n.
+    self._A = np.asfortranarray(
+        kkt[:n, n:].T.toarray(order="F"), dtype=np.float64
+    )
+    P_block = kkt[:n, :n].toarray()
     P_block = P_block + P_block.T - np.diag(np.diag(P_block))
     np.fill_diagonal(P_block, 0.0)
     self._P_offdiag = np.asfortranarray(P_block)

--- a/src/qtqp/solvers_gpu.py
+++ b/src/qtqp/solvers_gpu.py
@@ -154,9 +154,12 @@ class CupyDenseSolver(LinearSolver):
     super().set_kkt(kkt)
     cp = self._cp
     n = self._n
-    kkt_dense = kkt.toarray()
-    self._A_gpu = cp.asarray(kkt_dense[:n, n:].T, dtype=cp.float64)
-    P_block = kkt_dense[:n, :n]
+    # Extract before densifying, avoiding a full (n + m)^2 host allocation
+    # for a backend that only needs the m x n and n x n blocks.
+    self._A_gpu = cp.asarray(
+        kkt[:n, n:].T.toarray(order="F"), dtype=cp.float64
+    )
+    P_block = kkt[:n, :n].toarray()
     P_block = P_block + P_block.T - np.diag(np.diag(P_block))
     np.fill_diagonal(P_block, 0.0)
     self._P_offdiag_gpu = cp.asarray(P_block, dtype=cp.float64)

--- a/tests/test_dense_setup.py
+++ b/tests/test_dense_setup.py
@@ -1,0 +1,89 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Dense backend setup must preserve the Gram reduction's memory bound."""
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+from qtqp import direct
+
+
+@pytest.mark.parametrize("backend_name", ["scipy", "cupy"])
+@pytest.mark.parametrize("sparse_format", ["csr", "csc"])
+def test_dense_setup_only_densifies_required_blocks(
+    monkeypatch, backend_name, sparse_format
+):
+  n, m = 4, 31
+  rng = np.random.default_rng(921)
+  a = rng.normal(size=(m, n))
+  p_factor = rng.normal(size=(n, n))
+  p = p_factor.T @ p_factor + np.eye(n)
+  kkt = sparse.bmat(
+      [[sparse.csc_matrix(np.triu(p)), sparse.csc_matrix(a.T)],
+       [None, -sparse.eye(m)]],
+      format=sparse_format,
+  )
+  dense_shapes = []
+
+  def track_toarray(original):
+    def checked(matrix, *args, **kwargs):
+      # Check before allocating, so the regression remains cheap even if
+      # somebody restores the full KKT conversion.
+      assert matrix.shape in ((m, n), (n, n))
+      dense_shapes.append(matrix.shape)
+      return original(matrix, *args, **kwargs)
+    return checked
+
+  for matrix_type in (sparse.csr_matrix, sparse.csc_matrix):
+    monkeypatch.setattr(
+        matrix_type, "toarray", track_toarray(matrix_type.toarray)
+    )
+
+  if backend_name == "scipy":
+    backend = direct.ScipyDenseSolver()
+  else:
+    # Setup only uses allocation/transfer primitives. NumPy stands in for
+    # those so the host-memory regression is covered without a CUDA device.
+    backend = direct.CupyDenseSolver.__new__(direct.CupyDenseSolver)
+    backend._cp = np
+  backend.set_dims(n=n, m=m, z=0)
+  backend.set_kkt(kkt)
+
+  assert dense_shapes == [(m, n), (n, n)]
+  p_offdiag = p.copy()
+  np.fill_diagonal(p_offdiag, 0.0)
+  if backend_name == "cupy":
+    np.testing.assert_array_equal(backend._A_gpu, a)
+    np.testing.assert_array_equal(backend._P_offdiag_gpu, p_offdiag)
+  else:
+    np.testing.assert_array_equal(backend._A, a)
+    np.testing.assert_array_equal(backend._P_offdiag, p_offdiag)
+    assert backend._A.flags.f_contiguous
+    assert backend._P_offdiag.flags.f_contiguous
+
+    # Validate the factorization and block matvec independently against
+    # the original saddle-point system, including nonzero P off-diagonals.
+    backend.update_diag(np.concatenate([p.diagonal(), -np.ones(m)]))
+    backend.factorize()
+    expected = rng.normal(size=n + m)
+    rhs = np.concatenate([
+        p @ expected[:n] + a.T @ expected[n:],
+        a @ expected[:n] - expected[n:],
+    ])
+    np.testing.assert_allclose(backend @ expected, rhs, rtol=1e-13, atol=1e-13)
+    np.testing.assert_allclose(
+        backend.solve(rhs), expected, rtol=1e-11, atol=1e-11
+    )


### PR DESCRIPTION
## Summary

Avoid converting the full `(n + m) × (n + m)` sparse KKT matrix to a dense array when configuring the CPU and CuPy dense backends. Both backends only need the `m × n` constraint block and `n × n` quadratic block, so slice these while the matrix is sparse and then densify them.

This removes the unnecessary `m × m` allocation, without changing the Gram factorization, regularization, matrix values, or CPU Fortran layout.

## Validation

- Four new setup regressions pass (CSR/CSC input, CPU/GPU host setup); all four fail against the original full-densification implementation.
- 334 existing focused backend tests pass.
- Ruff E9/F and `git diff --check` pass.
- For `m=5000, n=20`, measured peak Python-tracked setup allocation falls from **204.840 MB to 5.703 MB**; retained allocation is effectively unchanged (3.305 MB to 3.301 MB). This is a setup-memory measurement, not an end-to-end timing claim.

No CUDA device was available locally; the GPU regression checks host block extraction and transfer inputs with a NumPy stand-in. PETSc was excluded locally because its MPI initialization aborts in this sandbox.

Based on main `4fbc7f5`; independent of the iteration matrix-product reuse change.
