### PR TITLE
Reuse invariant matrix products across Newton substeps

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -489,10 +489,11 @@ class QTQP:
     mu0 = float(y @ s) / (self.m - self.z)
     if not np.isfinite(mu0) or mu0 <= 0.0:
       return math.inf
-    t_x0 = p @ x + a.T @ y + c * tau + mu0 * x
+    px = p @ x
+    t_x0 = px + a.T @ y + c * tau + mu0 * x
     t_y0 = -(a @ x) + b * tau + mu0 * y
     t_y0[self.z :] -= mu0 / y[self.z :]
-    px0_ = float(x @ (p @ x)) if p.nnz else 0.0
+    px0_ = float(x @ px) if p.nnz else 0.0
     t_t0 = (-(float(c @ x) + float(b @ y)) - px0_ / max(_EPS, tau)
             + mu0 * (tau - 1.0 / max(_EPS, tau)))
     return self._local_metric_norm(t_x0, t_y0, t_t0, y, tau, mu0)
@@ -867,14 +868,6 @@ class QTQP:
     self._norm_b = _norm(self.b, np.inf)
     self._norm_c = _norm(self.c, np.inf)
 
-    # Data operator norms (original scale) for the certificate-quality tests:
-    # ||A||_inf (rows, acts on x), ||A||_1 (columns, = ||A'||_inf, acts on y),
-    # and ||P||_inf.
-    abs_a = abs(self.a)
-    self._norm_a_inf = float(abs_a.sum(axis=1).max()) if self.a.nnz else 0.0
-    self._norm_a_one = float(abs_a.sum(axis=0).max()) if self.a.nnz else 0.0
-    self._norm_p_inf = float(abs(self.p).sum(axis=1).max()) if self.p.nnz else 0.0
-
     self._linear_solver = direct.DirectKktSolver(
         a=a,
         p=p,
@@ -1006,6 +999,9 @@ class QTQP:
             rhs=self.q, warm_start=self.kinv_q
         )
         stats_i["q_lin_sys_stats"] = q_lin_sys_stats
+        # The data column and leading tau coefficient are invariant across
+        # the predictor, corrector, and any Gondzio trials on this factor.
+        tau_data = self._tau_invariants(p, mu)
 
         # --- Step 2: Predictor (Affine) Step ---
         # Solve KKT with mu_target = 0 to find pure Newton direction.
@@ -1022,6 +1018,7 @@ class QTQP:
             s=s,
             tau=tau,
             correction=None,
+            tau_data=tau_data,
         )
         stats_i["predictor_lin_sys_stats"] = predictor_lin_sys_stats
 
@@ -1064,6 +1061,7 @@ class QTQP:
             s=s,
             tau=tau,
             correction=correction,
+            tau_data=tau_data,
         )
         stats_i["corrector_lin_sys_stats"] = corrector_lin_sys_stats
 
@@ -1123,6 +1121,7 @@ class QTQP:
               s=s,
               tau=tau,
               correction=correction_g,
+              tau_data=tau_data,
           )
           d_s_g = np.zeros_like(d_s)
           # Single-division form, matching the primary corrector.
@@ -1487,6 +1486,7 @@ class QTQP:
 
   def _newton_step(
       self, *, p, mu, mu_target, r_anchor, tau_anchor, x, y, s, tau, correction,
+      tau_data=None,
   ):
     """Computes a Newton search direction by solving the augmented KKT system.
 
@@ -1529,7 +1529,9 @@ class QTQP:
     tau_plus = None
     try:
       r_tau = (mu - mu_target) * tau_anchor
-      tau_plus = self._solve_for_tau(p, kinv_r, mu, mu_target, r_tau)
+      tau_plus = self._solve_for_tau(
+          p, kinv_r, mu, mu_target, r_tau, tau_data=tau_data
+      )
       lin_sys_stats["tau_method"] = "quadratic"
     except ValueError:
       logging.debug("Primary tau solve failed; falling back to linearized.")
@@ -1546,7 +1548,19 @@ class QTQP:
     x_plus, y_plus = kinv_r[: self.n], kinv_r[self.n :]
     return x_plus, y_plus, tau_plus, lin_sys_stats
 
-  def _solve_for_tau(self, p, kinv_r, mu, mu_target, r_tau) -> float:
+  def _tau_invariants(self, p, mu):
+    """Return (P K^-1 q, leading tau coefficient) for one outer iteration."""
+    kinv_q = self.kinv_q
+    t_a = mu + kinv_q @ self.q
+    p_kinv_q = None
+    if p.nnz > 0:
+      p_kinv_q = p @ kinv_q[: self.n]
+      t_a -= kinv_q[: self.n] @ p_kinv_q
+    return p_kinv_q, t_a
+
+  def _solve_for_tau(
+      self, p, kinv_r, mu, mu_target, r_tau, *, tau_data=None
+  ) -> float:
     """Solves for tau+ using the homogeneous embedding's tau equation.
 
     The parametric KKT solution is:
@@ -1568,15 +1582,15 @@ class QTQP:
     n = self.n
     q, kinv_q = self.q, self.kinv_q
 
-    t_a = mu + kinv_q @ q
+    # Standalone calls can compute these locally; the IPM passes the shared
+    # values explicitly so they cannot outlive the factorization that made them.
+    if tau_data is None:
+      tau_data = self._tau_invariants(p, mu)
+    p_kinv_q, t_a = tau_data
     t_b = -r_tau - kinv_r @ q
     t_c = -mu_target
     if p.nnz > 0:
-      # Memory access for the sparse matrix P is the bottleneck here.
-      # np.stack enables a single pass over P's data and indices, which
-      # is ~25% faster than two separate SpMVs (p @ kinv_r and p @ kinv_q).
-      p_kinv_r, p_kinv_q = (p @ np.stack([kinv_r[:n], kinv_q[:n]], axis=1)).T
-      t_a -= kinv_q[:n] @ p_kinv_q
+      p_kinv_r = p @ kinv_r[:n]
       t_b += kinv_r[:n] @ p_kinv_q + kinv_q[:n] @ p_kinv_r
       t_c -= kinv_r[:n] @ p_kinv_r
     logging.debug("t_a=%s, t_b=%s, t_c=%s", t_a, t_b, t_c)

--- a/tests/test_product_reuse.py
+++ b/tests/test_product_reuse.py
@@ -1,0 +1,159 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Product reuse preserves the local metric and Newton tau equation."""
+
+from collections import defaultdict
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+import qtqp
+
+
+class _CountingMatrix:
+  """Count actual matrix applications without changing their arithmetic."""
+
+  def __init__(self, matrix):
+    self.matrix = sparse.csc_matrix(matrix)
+    self.nnz = self.matrix.nnz
+    self.applies = 0
+
+  def __matmul__(self, vector):
+    self.applies += 1
+    return self.matrix @ vector
+
+
+def test_warm_local_metric_uses_one_p_product():
+  a = np.array([[1.0, -0.2], [0.3, 1.2], [-0.7, 0.5]])
+  p = np.array([[2.0, 0.3], [0.3, 1.5]])
+  b, c = np.array([0.4, 1.0, -0.2]), np.array([0.7, -0.1])
+  x, y = np.array([0.3, -0.7]), np.array([-0.4, 1.2, 0.8])
+  s, tau = np.array([0.0, 0.7, 1.1]), 0.9
+  solver = qtqp.QTQP(
+      a=sparse.csc_matrix(a), b=b, c=c, p=sparse.csc_matrix(p), z=1
+  )
+  counted_p = _CountingMatrix(p)
+  actual = solver._lambda_local(x, y, s, tau, solver.a, counted_p, b, c)
+
+  # Evaluate ||T_mu||_{H^-1} independently as a dense diagonal-metric
+  # solve, including the equality row and the quadratic perspective term.
+  mu = y @ s / 2
+  u = np.concatenate([x, y, [tau]])
+  barrier_gradient = np.array([0.0, 0.0, 0.0, -1 / y[1], -1 / y[2], -1 / tau])
+  embedding = np.concatenate([
+      p @ x + a.T @ y + c * tau,
+      -a @ x + b * tau,
+      [-c @ x - b @ y - (x @ p @ x) / tau],
+  ])
+  residual = embedding + mu * (u + barrier_gradient)
+  metric = mu * np.diag([1.0, 1.0, 1.0,
+                         1 + 1 / y[1] ** 2, 1 + 1 / y[2] ** 2,
+                         1 + 1 / tau ** 2])
+  expected = np.sqrt(residual @ np.linalg.solve(metric, residual))
+  assert actual == pytest.approx(expected, rel=1e-13)
+  assert counted_p.applies == 1
+
+
+def test_tau_products_shared_through_gondzio_trials(monkeypatch):
+  rng = np.random.default_rng(2)
+  n, m, z = 8, 20, 3
+  a = rng.normal(size=(m, n))
+  factor = rng.normal(size=(n, n))
+  p = 0.1 * (factor.T @ factor) + 0.05 * np.eye(n)
+  x_star, y_star = rng.normal(size=n), rng.normal(size=m)
+  s_star = np.zeros(m)
+  y_star[z:] = rng.uniform(0.1, 2.0, size=m - z)
+  inactive = rng.uniform(size=m - z) < 0.5
+  y_star[z:][inactive] = 0.0
+  s_star[z:][inactive] = rng.uniform(0.1, 2.0, size=inactive.sum())
+  b, c = a @ x_star + s_star, -p @ x_star - a.T @ y_star
+  solver = qtqp.QTQP(
+      a=sparse.csc_matrix(a), b=b, c=c, p=sparse.csc_matrix(p), z=z
+  )
+  invariants = {}
+  newton_calls = defaultdict(list)
+  original_invariants = solver._tau_invariants
+  original_newton = solver._newton_step
+
+  def record_invariants(p, mu):
+    assert solver.it not in invariants, "tau products rebuilt within an iteration"
+    data = original_invariants(p, mu)
+    invariants[solver.it] = (mu, data)
+    return data
+
+  def record_newton(**kwargs):
+    data = kwargs["tau_data"]
+    assert data is invariants[solver.it][1]
+    newton_calls[solver.it].append(data)
+    return original_newton(**kwargs)
+
+  monkeypatch.setattr(solver, "_tau_invariants", record_invariants)
+  monkeypatch.setattr(solver, "_newton_step", record_newton)
+  result = solver.solve(
+      verbose=False, linear_solver=qtqp.LinearSolver.SCIPY_DENSE,
+      max_centrality_correctors=3,
+  )
+  assert result.status == qtqp.SolutionStatus.SOLVED
+  assert invariants.keys() == newton_calls.keys()
+  assert len({mu for mu, _ in invariants.values()}) > 1
+  # The first two calls are predictor/corrector; a third is a real
+  # Gondzio trial, so this checks every production consumer of the cache.
+  assert max(map(len, newton_calls.values())) >= 3
+  np.testing.assert_allclose(a @ result.x + result.s, b, atol=1e-6, rtol=0)
+  np.testing.assert_allclose(p @ result.x + a.T @ result.y + c, 0, atol=1e-6)
+  assert c @ result.x + 0.5 * result.x @ p @ result.x == pytest.approx(
+      c @ x_star + 0.5 * x_star @ p @ x_star, abs=1e-6
+  )
+
+
+def test_cached_tau_root_tracks_changed_system():
+  a = np.array([[1.0, 0.2], [-0.3, 1.0]])
+  b, c = np.array([0.2, 1.0]), np.array([0.4, -0.1])
+  solver = qtqp.QTQP(a=sparse.csc_matrix(a), b=b, c=c, z=1)
+  rhs = np.array([0.8, -0.3, 0.1, 0.5])
+  mu_target, r_tau = 0.03, 0.2
+
+  for mu, cost_scale, p_scale in [(0.2, 1.0, 1.0), (0.07, 0.8, 1.7)]:
+    p = p_scale * np.array([[2.0, 0.3], [0.3, 1.5]])
+    kkt = np.block([
+        [p + mu * np.eye(2), a.T],
+        [-a, np.diag([mu, 0.7 / 1.2 + mu])],
+    ])
+    solver.q = np.concatenate([cost_scale * c, b])
+    solver.kinv_q = np.linalg.solve(kkt, solver.q)
+    kinv_r = np.linalg.solve(kkt, rhs)
+    counted_p = _CountingMatrix(p)
+    tau_data = solver._tau_invariants(counted_p, mu)
+    assert counted_p.applies == 1
+    cached = solver._solve_for_tau(
+        counted_p, kinv_r, mu, mu_target, r_tau, tau_data=tau_data
+    )
+    assert counted_p.applies == 2  # only the varying P K^-1 r product
+    standalone = solver._solve_for_tau(
+        sparse.csc_matrix(p), kinv_r, mu, mu_target, r_tau
+    )
+
+    # Form the perspective equation independently and select its positive
+    # polynomial root. Changing both the system and q detects stale data.
+    v, w = solver.kinv_q, kinv_r
+    coefficients = [
+        mu + v @ solver.q - v[:2] @ p @ v[:2],
+        -r_tau - w @ solver.q + 2 * w[:2] @ p @ v[:2],
+        -mu_target - w[:2] @ p @ w[:2],
+    ]
+    expected = max(np.roots(coefficients))
+    assert cached == pytest.approx(expected, rel=1e-13)
+    assert standalone == pytest.approx(expected, rel=1e-13)

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -1296,8 +1296,8 @@ def _make_tau_gating_solver(converged):
   solver._linear_solver = FakeLinearSolver()  # pylint: disable=protected-access
   calls = {'quadratic': 0, 'linearized': 0}
 
-  def _fake_quadratic(self, p, kinv_r, mu, mu_target, r_tau):
-    del self, p, kinv_r, mu, mu_target, r_tau
+  def _fake_quadratic(self, p, kinv_r, mu, mu_target, r_tau, *, tau_data=None):
+    del self, p, kinv_r, mu, mu_target, r_tau, tau_data
     calls['quadratic'] += 1
     return 1.0
 
@@ -3525,10 +3525,10 @@ def test_gondzio_stacking_gates_on_fresh_tau_method(monkeypatch):
     counts = []
     orig = qtqp.QTQP._newton_step
     def spy(self, *, p, mu, mu_target, r_anchor, tau_anchor, x, y, s, tau,
-            correction):
+            correction, tau_data=None):
       out = orig(self, p=p, mu=mu, mu_target=mu_target, r_anchor=r_anchor,
                  tau_anchor=tau_anchor, x=x, y=y, s=s, tau=tau,
-                 correction=correction)
+                 correction=correction, tau_data=tau_data)
       if correction is None:
         counts.append(0)  # predictor: new iteration
       elif len(counts) > 0 and counts[-1] >= 0:


### PR DESCRIPTION
## Summary

Reuse matrix products that remain constant within an IPM iteration:

- Compute `P @ kinv_q` and the leading tau-polynomial coefficient once after the data-column solve, and pass them explicitly through predictor, corrector, and Gondzio trials. Standalone tau solves still compute their own values. The cache is local to the outer iteration, so it cannot survive a factorization/data-column update.
- Reuse `P @ x` in warm-start local-distance evaluation instead of multiplying by P twice.
- Remove unused absolute-operator-norm reductions and their sparse temporaries during setup; termination no longer consumes these fields.

This does not change termination criteria, tolerances, regularization, or the paper.

## Validation

- Independent numerical comparison: 800 randomized tau cases agree between main, the standalone path, and the explicitly cached path.
- Independent end-to-end comparison: 72 ordinary strictly convex QPs across NONE/RUIZ/AUGMENTED all return SOLVED, with identical iteration counts; the maximum output difference is `5.39e-10` (the individual sparse matvecs can accumulate in a different order from the previous two-column product).
- Single-thread tau-kernel measurements, including construction of the once-per-iteration cache, show approximately 0–8% improvement for two substeps and 9–19% for three substeps over the tested sizes. This is a kernel measurement, not an end-to-end speedup claim.

- Full existing available-CPU suite: **2,214 passed, 1 xfailed** (383 seconds).
- Three new regression tests pass separately: independent local-metric and tau-polynomial checks, product counts, and a public solve that exercises predictor/corrector/Gondzio reuse across changing outer iterations.
- Ruff E9/F and `git diff --check` pass.

GPU backends were unavailable locally. PETSc was excluded because its MPI initialization aborts in this sandbox.

Based on main `4fbc7f5`; independent of #128.
