### PR TITLE
Report completed IPM steps separately from iteration labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ Key parameters:
 -   `collect_stats`: If True, populate `Solution.stats` with per-iteration
     diagnostics (sy, s/y statistics, complementarity, etc.). Defaults to False
     for faster throughput.
+    `Solution.iterations` always reports completed IPM steps, excluding
+    initialization and failed step attempts, even with `collect_stats=False`.
+    A solution found at initialization reports zero. In collected rows, `iter`
+    remains the zero-based label and `iterations` is the completed-step count
+    at that row; the final log footer reports the total completed count.
     Every iteration also logs `delta_path`, a rigorous a posteriori upper
     bound on the distance from the iterate to the exact central-path point
     at the current `mu` (from the strong monotonicity of the regularized path

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -257,6 +257,8 @@ class Solution:
     s: The slack solution or certificate of dual infeasibility.
     stats: A list of statistics dictionaries from each iteration.
     status: SolutionStatus enum indicating the status.
+    iterations: Number of completed IPM steps, excluding initialization and
+      failed step attempts. Available even when statistics are not collected.
   """
 
   x: np.ndarray
@@ -264,6 +266,7 @@ class Solution:
   s: np.ndarray
   stats: List[Dict[str, Any]]
   status: SolutionStatus
+  iterations: int = 0
 
 
 @dataclasses.dataclass(frozen=True)
@@ -376,6 +379,7 @@ class QTQP:
     # before solve() has initialized the tracking state.
     self._best_almost_score = math.inf
     self._best_almost_iterate = None
+    self._iterations = 0
 
   def _presolve(self, inf_bound: float = 1e20):
     """Drop inequality rows with trivially-satisfied RHS (b[i] >= inf_bound
@@ -656,6 +660,7 @@ class QTQP:
   ) -> Solution:
     """Solves the QP using a primal-dual interior-point method."""
     self._linear_solver = None
+    self._iterations = 0
     try:
       return self._solve_impl(
           tol_feas=tol_feas,
@@ -988,7 +993,8 @@ class QTQP:
     # contract, instead of escaping as exceptions. Programming errors
     # (TypeError, NameError, ...) still propagate.
     try:
-      # self.it counts IPM steps already taken.
+      # self.it is the zero-based attempt index; _iterations counts completed
+      # iterate updates, so initialization and failed attempts do not count.
       for self.it in range(max_iter if run_loop else 0):
         stats_i = {}
         if self.it == 0:
@@ -1164,6 +1170,7 @@ class QTQP:
         y[self.z :] = np.maximum(y[self.z :], 1e-30)
         s[self.z :] = np.maximum(s[self.z :], 1e-30)
         tau = max(tau, 1e-30)
+        self._iterations += 1
 
         status = self._check_termination(
             x, y, tau, s, alpha, mu, sigma, stats_i, collect_stats
@@ -1194,21 +1201,21 @@ class QTQP:
         self._log_footer("Solved")
         x, y, s = x / tau, y / tau, s / tau
         y, s = self._postsolve(y, s, s_dropped=self._dropped_slack(x))
-        return Solution(x, y, s, stats, status)
+        return Solution(x, y, s, stats, status, iterations=self._iterations)
       case SolutionStatus.INFEASIBLE:
         self._log_footer("Primal infeasible / dual unbounded")
         x.fill(np.nan)
         s.fill(np.nan)
         y_scaled = y / abs(self.b @ y)
         y_scaled, s = self._postsolve(y_scaled, s)
-        return Solution(x, y_scaled, s, stats, status)
+        return Solution(x, y_scaled, s, stats, status, iterations=self._iterations)
       case SolutionStatus.UNBOUNDED:
         self._log_footer("Dual infeasible / primal unbounded")
         y.fill(np.nan)
         abs_ctx = abs(self.c @ x)
         x, s = x / abs_ctx, s / abs_ctx
         y, s = self._postsolve(y, s, y_dropped=np.nan)
-        return Solution(x, y, s, stats, status)
+        return Solution(x, y, s, stats, status, iterations=self._iterations)
       case SolutionStatus.HIT_MAX_ITER | SolutionStatus.UNFINISHED:
         # Salvage: the best iterate seen, if it meets the criteria at
         # the reduced tolerances, is an honestly-labeled
@@ -1225,7 +1232,10 @@ class QTQP:
           by, bs = self._postsolve(by, bs, s_dropped=self._dropped_slack(bx))
           if stats:
             stats[-1]["status"] = SolutionStatus.ALMOST_SOLVED
-          return Solution(bx, by, bs, stats, SolutionStatus.ALMOST_SOLVED)
+          return Solution(
+              bx, by, bs, stats, SolutionStatus.ALMOST_SOLVED,
+              iterations=self._iterations,
+          )
         if status is SolutionStatus.HIT_MAX_ITER:
           self._log_footer("Hit maximum iterations")
           final = status
@@ -1234,7 +1244,7 @@ class QTQP:
           final = SolutionStatus.FAILED
         x, y, s = x / tau, y / tau, s / tau
         y, s = self._postsolve(y, s, s_dropped=self._dropped_slack(x))
-        return Solution(x, y, s, stats, final)
+        return Solution(x, y, s, stats, final, iterations=self._iterations)
       case _:
         raise ValueError(f"Unknown convergence status: {status}")
 
@@ -1860,6 +1870,7 @@ class QTQP:
 
     stats_i.update({
         "iter": self.it,
+        "iterations": self._iterations,
         "ctx": ctx,
         "bty": bty,
         "pcost": pcost,
@@ -1934,4 +1945,4 @@ class QTQP:
 
   def _log_footer(self, message: str):
     if self.verbose:
-      print(f"{_SEPARA}\n| {message}")
+      print(f"{_SEPARA}\n| {message}\n| Completed IPM steps: {self._iterations}")

--- a/tests/test_iteration_counts.py
+++ b/tests/test_iteration_counts.py
@@ -1,0 +1,200 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Completed IPM work is distinct from zero-based iteration labels."""
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+import qtqp
+
+
+def _box_lp():
+  return qtqp.QTQP(
+      a=sparse.csc_matrix([[-1.0], [1.0]]),
+      b=np.array([0.0, 1.0]),
+      c=np.array([-1.0]),
+      z=0,
+  )
+
+
+def _observe_grading(monkeypatch, fail_on_step=None):
+  """Observe updated points independently of the reported counter.
+
+  The first call grades initialization; later calls follow complete IPM
+  updates. Optionally fail while grading a specified completed step.
+  """
+  points = []
+  original = qtqp.QTQP._check_termination
+
+  def observed(self, x, y, tau, s, *args, **kwargs):
+    points.append((x.copy(), y.copy(), tau, s.copy()))
+    if fail_on_step is not None and len(points) == fail_on_step + 1:
+      raise RuntimeError("Forced failure while grading an updated point")
+    return original(self, x, y, tau, s, *args, **kwargs)
+
+  monkeypatch.setattr(qtqp.QTQP, "_check_termination", observed)
+  return points
+
+
+def _solve(qp, **options):
+  return qp.solve(verbose=False, linear_solver=qtqp.LinearSolver.SCIPY, **options)
+
+
+@pytest.mark.parametrize("collect_stats", [False, True])
+def test_completed_steps_preserve_zero_based_labels(monkeypatch, collect_stats):
+  points = _observe_grading(monkeypatch)
+  solution = _solve(_box_lp(), collect_stats=collect_stats)
+
+  assert solution.status is qtqp.SolutionStatus.SOLVED
+  # This ordinary LP takes four complete updates, followed by four grades.
+  assert len(points) - 1 == 4
+  assert solution.iterations == len(points) - 1
+  np.testing.assert_allclose(solution.x, [1.0], atol=1e-7)
+  if collect_stats:
+    assert [row["iter"] for row in solution.stats] == [0, 1, 2, 3]
+    assert [row["iterations"] for row in solution.stats] == [1, 2, 3, 4]
+  else:
+    assert solution.stats == []
+
+
+@pytest.mark.parametrize("collect_stats", [False, True])
+def test_initial_solution_completes_zero_steps(monkeypatch, collect_stats):
+  points = _observe_grading(monkeypatch)
+  qp = qtqp.QTQP(
+      a=sparse.csc_matrix([[1.0]]),
+      b=np.array([1.0]),
+      c=np.array([-1.0]),
+      p=sparse.csc_matrix([[1.0]]),
+      z=1,
+  )
+  solution = _solve(qp, collect_stats=collect_stats)
+
+  assert solution.status is qtqp.SolutionStatus.SOLVED
+  assert len(points) == 1
+  assert solution.iterations == 0
+  if collect_stats:
+    assert len(solution.stats) == 1
+    assert solution.stats[0]["iter"] == 0
+    assert solution.stats[0]["iterations"] == 0
+  else:
+    assert solution.stats == []
+
+
+@pytest.mark.parametrize("collect_stats", [False, True])
+@pytest.mark.parametrize(
+    ("max_iter", "expected_status"),
+    [(2, qtqp.SolutionStatus.HIT_MAX_ITER),
+     (3, qtqp.SolutionStatus.ALMOST_SOLVED)],
+)
+def test_iteration_cap_and_almost_return_completed_work(
+    monkeypatch, collect_stats, max_iter, expected_status,
+):
+  points = _observe_grading(monkeypatch)
+  solution = _solve(_box_lp(), collect_stats=collect_stats, max_iter=max_iter)
+
+  assert solution.status is expected_status
+  assert len(points) - 1 == max_iter
+  assert solution.iterations == max_iter
+  if collect_stats:
+    assert solution.stats[-1]["iterations"] == max_iter
+    assert solution.stats[-1]["iter"] == max_iter - 1
+
+
+@pytest.mark.parametrize("collect_stats", [False, True])
+@pytest.mark.parametrize("fail_on_attempt", [1, 3])
+def test_unfinished_update_is_not_counted(
+    monkeypatch, collect_stats, fail_on_attempt,
+):
+  points = _observe_grading(monkeypatch)
+  original = qtqp.direct.DirectKktSolver.update
+  attempts = []
+
+  def failing_update(self, *args, **kwargs):
+    attempts.append(None)
+    if len(attempts) == fail_on_attempt:
+      raise RuntimeError("Forced failure before the next iterate update")
+    return original(self, *args, **kwargs)
+
+  monkeypatch.setattr(qtqp.direct.DirectKktSolver, "update", failing_update)
+  solution = _solve(_box_lp(), collect_stats=collect_stats)
+
+  assert solution.status is qtqp.SolutionStatus.FAILED
+  assert len(attempts) == fail_on_attempt
+  assert len(points) - 1 == fail_on_attempt - 1
+  assert solution.iterations == len(points) - 1
+  if collect_stats:
+    assert len(solution.stats) == solution.iterations
+
+
+@pytest.mark.parametrize("collect_stats", [False, True])
+@pytest.mark.parametrize("fail_on_step", [1, 2])
+def test_updated_point_counts_even_when_its_grading_fails(
+    monkeypatch, collect_stats, fail_on_step,
+):
+  points = _observe_grading(monkeypatch, fail_on_step=fail_on_step)
+  solution = _solve(_box_lp(), collect_stats=collect_stats)
+
+  assert solution.status is qtqp.SolutionStatus.FAILED
+  assert len(points) - 1 == fail_on_step
+  assert solution.iterations == fail_on_step
+  if collect_stats:
+    # The failed grade adds no stats row; earlier rows retain their counts.
+    assert len(solution.stats) == fail_on_step - 1
+    if solution.stats:
+      assert solution.stats[-1]["iterations"] == fail_on_step - 1
+
+
+def test_reusing_solver_resets_completed_step_count(monkeypatch):
+  points = _observe_grading(monkeypatch)
+  qp = _box_lp()
+  first = _solve(qp, max_iter=2)
+  assert first.iterations == len(points) - 1 == 2
+
+  points.clear()
+  second = _solve(qp)
+  assert second.status is qtqp.SolutionStatus.SOLVED
+  assert second.iterations == len(points) - 1 == 4
+  assert first.iterations == 2
+
+
+@pytest.mark.parametrize("collect_stats", [False, True])
+@pytest.mark.parametrize(
+    ("b", "c", "expected_status"),
+    [([-1.0], [0.0], qtqp.SolutionStatus.INFEASIBLE),
+     ([1.0], [-1.0], qtqp.SolutionStatus.UNBOUNDED)],
+)
+def test_certificate_returns_completed_step_count(
+    monkeypatch, collect_stats, b, c, expected_status,
+):
+  points = _observe_grading(monkeypatch)
+  qp = qtqp.QTQP(
+      a=sparse.csc_matrix([[0.0]]), b=np.array(b), c=np.array(c), z=0,
+  )
+  solution = _solve(qp, collect_stats=collect_stats)
+
+  assert solution.status is expected_status
+  assert len(points) > 1
+  assert solution.iterations == len(points) - 1
+  if collect_stats:
+    assert solution.stats[-1]["iterations"] == solution.iterations
+
+
+def test_verbose_footer_reports_completed_steps(capsys):
+  solution = _box_lp().solve(
+      verbose=True, linear_solver=qtqp.LinearSolver.SCIPY,
+  )
+  assert solution.iterations == 4
+  assert "Completed IPM steps: 4" in capsys.readouterr().out

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -355,7 +355,7 @@ def test_solve(equilibration, seed, linear_solver, mnz, record_iterations):
   )
 
   # Record stats
-  record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
+  record_iterations(solution.iterations, solution.stats[-1]['time'])
 
   _assert_solution(solution, a, b, c, p, z)
 
@@ -375,7 +375,7 @@ def test_infeasible(equilibration, seed, linear_solver, mnz, record_iterations):
   )
 
   # Record stats
-  record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
+  record_iterations(solution.iterations, solution.stats[-1]['time'])
 
   _assert_infeasible(solution, a, b, z)
 
@@ -395,7 +395,7 @@ def test_unbounded(equilibration, seed, linear_solver, mnz, record_iterations):
   )
 
   # Record stats
-  record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
+  record_iterations(solution.iterations, solution.stats[-1]['time'])
 
   _assert_unbounded(solution, a, c, p, z)
 
@@ -413,7 +413,7 @@ def test_solve_large(equilibration, seed, linear_solver, record_iterations):
       equilibration_strategy=equilibration, linear_solver=linear_solver, collect_stats=True
   )
 
-  record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
+  record_iterations(solution.iterations, solution.stats[-1]['time'])
   _assert_solution(solution, a, b, c, p, z)
 
 
@@ -430,7 +430,7 @@ def test_infeasible_large(equilibration, seed, linear_solver, record_iterations)
       equilibration_strategy=equilibration, linear_solver=linear_solver, collect_stats=True
   )
 
-  record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
+  record_iterations(solution.iterations, solution.stats[-1]['time'])
   _assert_infeasible(solution, a, b, z)
 
 
@@ -447,7 +447,7 @@ def test_unbounded_large(equilibration, seed, linear_solver, record_iterations):
       equilibration_strategy=equilibration, linear_solver=linear_solver, collect_stats=True
   )
 
-  record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
+  record_iterations(solution.iterations, solution.stats[-1]['time'])
   _assert_unbounded(solution, a, c, p, z)
 
 
@@ -1526,7 +1526,7 @@ def test_solve_lp(equilibration, seed, linear_solver, record_iterations):
       verbose=True,
   )
 
-  record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
+  record_iterations(solution.iterations, solution.stats[-1]['time'])
   _assert_solution(solution, a, b, c, p_zero, z)
 
 
@@ -1550,7 +1550,7 @@ def test_infeasible_lp(equilibration, seed, linear_solver, record_iterations):
       verbose=True,
   )
 
-  record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
+  record_iterations(solution.iterations, solution.stats[-1]['time'])
   _assert_infeasible(solution, a, b, z)
 
 
@@ -1574,7 +1574,7 @@ def test_unbounded_lp(equilibration, seed, linear_solver, record_iterations):
       verbose=True,
   )
 
-  record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
+  record_iterations(solution.iterations, solution.stats[-1]['time'])
   _assert_unbounded(solution, a, c, p_zero, z)
 
 
@@ -1629,7 +1629,7 @@ def test_solve_all_inequalities(equilibration, seed, linear_solver, record_itera
       verbose=True,
   )
 
-  record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
+  record_iterations(solution.iterations, solution.stats[-1]['time'])
   _assert_solution(solution, a, b, c, p, z)
 
 
@@ -1651,7 +1651,7 @@ def test_infeasible_small(equilibration, seed, linear_solver, record_iterations)
       verbose=True,
   )
 
-  record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
+  record_iterations(solution.iterations, solution.stats[-1]['time'])
   _assert_infeasible(solution, a, b, z)
 
 
@@ -1669,7 +1669,7 @@ def test_unbounded_small(equilibration, seed, linear_solver, record_iterations):
       verbose=True,
   )
 
-  record_iterations(solution.stats[-1]['iter'], solution.stats[-1]['time'])
+  record_iterations(solution.iterations, solution.stats[-1]['time'])
   _assert_unbounded(solution, a, c, p, z)
 
 


### PR DESCRIPTION
## Summary

Separate the completed IPM step count from the existing zero-based iteration label. Four completed steps now report a count of four rather than the last label, three.

- Add `Solution.iterations`, available with or without `collect_stats`. The counter starts at zero for every solve and increments only after the full iterate update and cone clipping. Initialization and failed step attempts are excluded; ALMOST salvage reports total completed work, not the index of the selected earlier point.
- Preserve existing `stats["iter"]` labels. Add `stats["iterations"]` for the completed count at each recorded row, and show the total in the final log footer.
- Update all twelve benchmark/test recording sites to use `solution.iterations` instead of the last zero-based label.
- Document the distinction. The new dataclass field has a default, preserving existing five-argument `Solution(...)` construction.

No numerical algorithm, termination criterion, iteration cap, or paper changes.

## Validation

- **22 new counting regressions pass**, using an independent observer of updated points rather than deriving expectations from the new counter. Coverage includes statistics on/off, the four-step LP, initialization-only solves, caps, ALMOST and certificate returns, failures before/after updates, repeated solves, unchanged labels, and footer output.
- **683 existing tests pass**, including both SciPy backends, equality, warm-start, statistics, verbosity, iteration limits, and numerical-failure coverage.
- Ruff E9/F and `git diff --check` pass.
- Independent review and additional lifecycle checks found no issues.

GPU backends were unavailable locally; PETSc was excluded because its MPI initialization aborts in this sandbox. The new equality-only statistics fixture emits an existing local-diagnostic divide-by-zero warning; the reporting change does not alter that calculation.

Based on main `4fbc7f5`; separate from #128, #129, and #130.
