### PR TITLE
Reset initialization statistics for reused warm-start solves

### DIFF
--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -662,6 +662,8 @@ class QTQP:
     """Solves the QP using a primal-dual interior-point method."""
     self._linear_solver = None
     self._iterations = 0
+    # Accepted warm starts skip initialization; its stats belong to this call.
+    self._init_lin_stats = {}
     try:
       return self._solve_impl(
           tol_feas=tol_feas,

--- a/tests/test_qtqp.py
+++ b/tests/test_qtqp.py
@@ -3715,6 +3715,72 @@ def test_accepted_warm_start_skips_cold_init(monkeypatch):
   assert calls["n"] == 1, "vetoed warm start must fall back to the cold init"
 
 
+@pytest.mark.parametrize('linear_solver', [
+    qtqp.LinearSolver.SCIPY, qtqp.LinearSolver.SCIPY_DENSE,
+])
+def test_reused_solver_warm_start_has_no_stale_init_stats(
+    monkeypatch, linear_solver,
+):
+  """A zero-step warm solve reports only initialization work from this call."""
+  solver = qtqp.QTQP(
+      a=sparse.csc_matrix([[1.0], [-1.0]]),
+      b=np.full(2, 1e-3), c=np.zeros(1),
+      p=sparse.eye(1, format='csc'), z=0,
+  )
+  init_calls = 0
+  original_init = solver._init_variables
+
+  def counting_init(*args, **kwargs):
+    nonlocal init_calls
+    init_calls += 1
+    return original_init(*args, **kwargs)
+
+  monkeypatch.setattr(solver, '_init_variables', counting_init)
+  options = dict(verbose=False, collect_stats=True, linear_solver=linear_solver)
+  cold = solver.solve(**options)
+  assert cold.status == qtqp.SolutionStatus.SOLVED
+  assert init_calls == 1
+  assert solver._init_lin_stats['solves'] > 0
+
+  warm = solver.solve(warm_start=(cold.x, cold.y, cold.s), **options)
+  assert warm.status == qtqp.SolutionStatus.SOLVED
+  assert solver.warm_accepted
+  assert warm.iterations == 0
+  assert init_calls == 1, 'accepted warm start ran cold initialization'
+  assert len(warm.stats) == 1
+  assert warm.stats[0]['q_lin_sys_stats'] == {}
+  assert warm.stats[0]['predictor_lin_sys_stats'] == {}
+  assert warm.stats[0]['corrector_lin_sys_stats'] == {}
+
+  next_cold = solver.solve(**options)
+  assert next_cold.status == qtqp.SolutionStatus.SOLVED
+  assert init_calls == 2
+  assert solver._init_lin_stats['solves'] > 0
+
+
+@pytest.mark.parametrize('linear_solver', [
+    qtqp.LinearSolver.SCIPY, qtqp.LinearSolver.SCIPY_DENSE,
+])
+def test_reused_solver_preserves_returned_init_stats(linear_solver):
+  """Resetting per-solve state must not mutate an earlier solution's stats."""
+  solver = qtqp.QTQP(
+      a=sparse.csc_matrix([[1.0]]), b=np.ones(1), c=np.zeros(1),
+      p=sparse.eye(1, format='csc'), z=1,
+  )
+  options = dict(verbose=False, collect_stats=True, linear_solver=linear_solver)
+  first = solver.solve(**options)
+  assert first.status == qtqp.SolutionStatus.SOLVED
+  assert first.iterations == 0
+  first_stats = first.stats[0]['q_lin_sys_stats'].copy()
+  assert first_stats['solves'] > 0
+
+  second = solver.solve(**options)
+  assert second.status == qtqp.SolutionStatus.SOLVED
+  assert second.iterations == 0
+  assert second.stats[0]['q_lin_sys_stats']['solves'] > 0
+  assert first.stats[0]['q_lin_sys_stats'] == first_stats
+
+
 def test_equality_only_qp_unique_solution():
   """Equality-constrained strictly convex QP: the direct path recovers
   the unique KKT solution."""


### PR DESCRIPTION
## Summary

Reset `_init_lin_stats` at the start of every `solve()` call. An accepted warm start can skip cold initialization and finish with zero IPM updates; previously that return could report the prior cold solve's factor applications when the same QTQP object was reused.

Rebind to a fresh dictionary rather than clearing the old one, preserving statistics already attached to earlier returned solutions. This changes diagnostics only; warm-start acceptance, numerical steps, and the paper are unchanged.

## Regression coverage

Both SCIPY and SCIPY_DENSE now cover:

- Cold → accepted zero-update warm → cold on the same object: no stale initialization work, no initialization during the warm call, and fresh stats on the next cold call.
- Repeated equality-only solves: current initialization stats remain populated and earlier returned statistics remain unchanged.

The stale-stat regression fails on unmodified main for both backends and passes with this fix.

## Validation

- 122 related warm-start/initialization/equality tests passed.
- All 64 tests in the other five test modules passed.
- `ruff check --select E9,F src/ tests/test_qtqp.py` and `git diff --check` passed.
- An additional broad `tests/test_qtqp.py` run reached 1,099 passed with no failures before being stopped after about five minutes. This is not a completed full-suite result; the full PR CI matrix is running separately.

Local tests use Python 3.12, NumPy 2.4.2, SciPy 1.16.3. An external import shim marks the optional PETSc/MUMPS backend unavailable because its installed import terminates this local test process. No solver implementation is stubbed or modified for testing.
