### PR TITLE
Reuse warm-start screening products and clarify heuristic guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,21 +216,18 @@ Key parameters:
     A solution found at initialization reports zero. In collected rows, `iter`
     remains the zero-based label and `iterations` is the completed-step count
     at that row; the final log footer reports the total completed count.
-    Every iteration also logs `delta_path`, a rigorous a posteriori upper
-    bound on the distance from the iterate to the exact central-path point
-    at the current `mu` (from the strong monotonicity of the regularized path
-    map); it is informative when small, conservative for aggressively
-    centered iterates, and saturates at the floating-point floor in the
-    final iterations. Its local-norm companion `delta_path_local` measures
-    the same residual in the barrier metric `H = mu*I + mu*hess(Phi)`
-    (a Newton-decrement analogue): it weights each component by the
-    curvature resisting it and remains informative for aggressive
-    iterates. `lambda_init` (also an attribute on the solver) is the same
-    measure at the deterministic initial point, before the first step:
-    healthy problems measure small, while pathologically scaled data
-    announces itself by tens of orders of magnitude — this diagnostic is
-    how corrupted infinity-sentinel bounds were found in the
-    Maros-Meszaros benchmark files.
+    Collected rows also include `delta_path`, an estimate of
+    `||T_mu(u)|| / mu`. In exact arithmetic with positive `mu`, this bounds
+    the distance to the central-path point by strong monotonicity. The
+    recorded value uses floating-point denominator guards, so it is a
+    diagnostic rather than a certified numerical bound. Its local-norm
+    companion `delta_path_local` approximates the residual norm
+    `lambda = ||T_mu(u)||_(H^-1)`, where
+    `H = mu*I + mu*hess(Phi)`. This score also uses denominator guards and
+    is not itself a distance bound. `lambda_init` (also an attribute on
+    the solver) is the same guarded local score at the chosen initial
+    point, warm or cold, before the first step. For an accepted warm
+    start, it reuses the screening score.
 -   `refinement_strategy`: Choose the iterative-refinement method used for KKT
     solves. Defaults to `qtqp.RefinementStrategy.GMRES`.
 -   `gmres_restart`: Restart length for `qtqp.RefinementStrategy.GMRES`.
@@ -250,17 +247,26 @@ Key parameters:
     caps at a linear rate. Set False for the constant legacy schedule.
 -   `warm_start`: Optional `(x, y, s)` from a nearby problem (original scale,
     e.g. a previous solution's arrays). The point is equilibrated into the
-    operating scale, embedded interior at a few centering shifts, and the
-    best embedding is accepted only when the distance-to-path certificate
-    measures `lambda <= warm_start_threshold`; a vetoed point falls back to
-    the standard initialization, so warm starting is never worse than a
-    cold solve by more than the certificate evaluation (three matvecs per
-    shift). After `solve`, the measured `warm_lambda` and the `warm_accepted`
-    decision are attributes on the solver. A warm start is ignored on an
-    all-equality problem, which the initialization solves outright.
--   `warm_start_threshold`: Acceptance threshold for the certified warm
-    start (default `100.0`). Poisoned or mis-scaled points measure orders of
-    magnitude above it; same-problem re-entries orders of magnitude below.
+    operating scale, its inequality duals and slacks are floored at each
+    of `1e-6`, `1e-4`, `1e-2`, and `1.0`, and each candidate is normalized.
+    The candidate with the smallest guarded local score is accepted when
+    `lambda <= warm_start_threshold`; otherwise the solver uses the
+    standard initialization. This is empirical screening: acceptance does
+    not certify distance to the path or guarantee fewer iterations or less
+    time than a cold solve. Screening uses no factorization and six
+    matrix-vector products across the four candidates: shared `A @ x` and
+    `P @ x`, plus one `A.T @ y` per candidate. An accepted start skips the
+    cold initialization factorization and reuses its score as `lambda_init`;
+    a rejected start adds screening overhead before the cold solve. After
+    `solve`, the measured `warm_lambda` and the `warm_accepted` decision are
+    attributes on the solver. A warm start is ignored on an all-equality
+    problem, which the initialization solves outright.
+-   `warm_start_threshold`: Empirical screening threshold (default `100.0`),
+    not a certified distance tolerance. For the exact local score, the
+    theoretical distance bound instead requires
+    `eta = lambda / sqrt(mu) < 1` and is `eta / (1 - eta)`. The solver does
+    not use this test for acceptance, and its guarded score must not be
+    substituted into that bound as a numerical certificate.
 
 #### Equilibration strategies
 

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -480,22 +480,27 @@ class QTQP:
     del x
     return np.inf
 
-  def _lambda_local(self, x, y, s, tau, a, p, b, c):
-    """Local-norm distance-to-path measure at a working-scale point.
+  def _lambda_local(self, x, y, s, tau, a, p, b, c, *, ax=None, px=None):
+    """Guarded local-norm residual score at a working-scale point.
 
     lambda = ||T_mu(u)||_{H^-1} with H = mu*I + mu*hess(Phi) (diagonal),
-    evaluated at the point's own complementarity mu = y's/(m-z). Three
-    matvecs. Certified-distance semantics when small; a scaled residual
-    score when large. Returns inf when the point has no positive
-    complementarity to define a barrier parameter at (e.g. junk warm
-    points with sign-mixed y), which reads as maximally far from the path.
+    evaluated at the point's own complementarity mu = y's/(m-z), with
+    epsilon guards in the residual and metric. A threshold on this score
+    alone does not certify distance to the path or faster convergence.
+    Returns inf when complementarity cannot define a positive finite mu.
+
+    Optional ax and px must be the products A@x and P@x for this candidate
+    in the working frame. Without them, evaluation costs three matvecs.
     """
     mu0 = float(y @ s) / (self.m - self.z)
     if not np.isfinite(mu0) or mu0 <= 0.0:
       return math.inf
-    px = p @ x
+    if px is None:
+      px = p @ x
+    if ax is None:
+      ax = a @ x
     t_x0 = px + a.T @ y + c * tau + mu0 * x
-    t_y0 = -(a @ x) + b * tau + mu0 * y
+    t_y0 = -ax + b * tau + mu0 * y
     t_y0[self.z :] -= mu0 / y[self.z :]
     px0_ = float(x @ px) if p.nnz else 0.0
     t_t0 = (-(float(c @ x) + float(b @ y)) - px0_ / max(_EPS, tau)
@@ -503,13 +508,13 @@ class QTQP:
     return self._local_metric_norm(t_x0, t_y0, t_t0, y, tau, mu0)
 
   def _local_metric_norm(self, t_x, t_y, t_tau, y, tau, mu):
-    """||(t_x, t_y, t_tau)||_{H^-1} with H = mu*I + mu*diag(hess barrier).
+    """Guarded ||(t_x, t_y, t_tau)||_{H^-1}, H = mu*(I + hess barrier).
 
-    The barrier metric deflates the boundary-adjacent rows that make the
-    Euclidean certificate conservative on aggressively centered iterates
-    (Newton-decrement flavor). Shared by lambda_init, the warm-start
-    certification, and the delta_path_local diagnostic so the three
-    measures stay definitionally identical.
+    The barrier metric weights residual components by local curvature
+    (Newton-decrement flavor). Epsilon floors approximate the exact metric
+    near the numerical boundary. Shared by lambda_init, warm-start
+    screening, and delta_path_local; these are diagnostics, not standalone
+    distance or iteration-count guarantees.
     """
     h_y = np.full(self.m, mu)
     h_y[self.z :] += mu / (y[self.z :] * y[self.z :])
@@ -779,17 +784,19 @@ class QTQP:
         RICHARDSON.
       warm_start (tuple | None): Optional (x, y, s) from a nearby problem
         (original scale, e.g. a previous Solution's arrays). The point is
-        equilibrated into the operating scale, embedded interior at a few
-        centering shifts, and the best embedding is accepted only when the
-        distance-to-path certificate measures lambda <=
-        warm_start_threshold; otherwise the solve falls back to the
-        standard initialization. After solve, `warm_lambda` (the measured
-        lambda, or None when no warm start was given) and `warm_accepted`
-        are available as attributes on the solver.
-      warm_start_threshold (float): Acceptance threshold for the certified
-        warm start. Default 100.0: poisoned or mis-scaled points measure
-        orders of magnitude above it, same-problem re-entries orders of
-        magnitude below.
+        equilibrated into the operating scale and embedded interior using
+        four positivity floors. The candidate with the smallest guarded
+        local-norm residual score is accepted when lambda <=
+        warm_start_threshold; otherwise the standard initialization runs.
+        This is an empirical screen, not a distance certificate or a
+        no-slowdown guarantee. Screening shares A@x and P@x across candidates
+        and costs six matvecs total; an accepted score is reused as
+        `lambda_init`. After solve, `warm_lambda` (the minimum score, or None
+        when screening was skipped) and `warm_accepted` are available as
+        attributes on the solver. All-equality problems skip screening.
+      warm_start_threshold (float): Positive finite threshold for the
+        empirical warm-start screen (default 100.0). It does not bound the
+        distance to the path or the subsequent solve's iteration count.
       adaptive_step_size (bool): If True (the default), once mu < 1e-3
         the fraction-to-boundary scale follows min(0.9999,
         max(step_size_scale, 1 - 10*mu)) instead of the constant
@@ -892,12 +899,10 @@ class QTQP:
     self._best_almost_iterate = None
     status = SolutionStatus.UNFINISHED
 
-    # Certified warm start: ingest a caller-supplied (x, y, s) from a
-    # nearby problem, embed it interior at a few centering shifts, and
-    # accept the best embedding only when the certificate says it is
-    # actually near the path (lambda <= warm_start_threshold). A vetoed
-    # warm start falls back to the configured init: the certificate makes
-    # warm starting safe, which heuristic IPM warm starts are not.
+    # Empirical warm-start screen: try four interior embeddings and accept
+    # the smallest guarded local residual score below the threshold.
+    # Rejection falls back to cold initialization; acceptance guarantees
+    # neither proximity to the path nor fewer iterations than a cold solve.
     self.warm_lambda = None
     self.warm_accepted = False
     validated_warm = self._validate_warm_start(warm_start, warm_start_threshold)
@@ -907,6 +912,9 @@ class QTQP:
       wx, wy, ws = validated_warm
       if self.equilibration_strategy is not EquilibrationStrategy.NONE:
         wx, wy, ws = self._equilibrate_iterates(wx, wy, ws)
+      # Only y and s are shifted. Every candidate's x is the same wx times
+      # its radial normalization scale, so share these primal products.
+      awx, pwx = a @ wx, p @ wx
       best = (math.inf, None)
       for eta in (1e-6, 1e-4, 1e-2, 1.0):
         cx = wx.copy()
@@ -917,9 +925,14 @@ class QTQP:
         cs[: self.z] = 0.0
         ctau = 1.0
         cx, cy, ctau, cs = self._normalize(cx, cy, ctau, cs)
-        lam = self._lambda_local(cx, cy, cs, ctau, a, p, b, c)
+        # The pre-normalization tau is one, so ctau is exactly the scale
+        # applied to wx. Only A.T@cy needs a fresh matvec for this shift.
+        lam = self._lambda_local(
+            cx, cy, cs, ctau, a, p, b, c, ax=ctau * awx, px=ctau * pwx
+        )
         if lam < best[0]:
           best = (lam, (cx, cy, cs, ctau))
+      del awx, pwx  # Screening products are not needed by the IPM loop.
       self.warm_lambda = best[0]
       if best[0] <= warm_start_threshold:
         cx, cy, cs, ctau = best[1]
@@ -933,20 +946,20 @@ class QTQP:
       x, y, s, tau = cx, cy, cs, ctau
     else:
       # Cold start: the initialization factorization and solves run only
-      # when no warm start was given or the certificate vetoed it - an
-      # accepted warm start skips them entirely (certification costs three
-      # matvecs per centering shift, no factorization).
+      # when no warm start was given or screening vetoed it. An accepted
+      # warm start skips them (six screening matvecs, no factorization).
       x, y, s, tau, _ = self._init_variables(a, p, b, c)
 
-    # Initial-point diagnostic: the local-norm distance-to-path measure at
-    # the starting iterate (warm or configured init), before the first
-    # step. Healthy problems measure small (<= ~1e7 across NETLIB +
-    # Maros-Meszaros); pathologically scaled data announces itself here
-    # by tens of orders of magnitude — this diagnostic is how corrupted
-    # infinity-sentinel bounds in the benchmark datasets were found.
-    self.lambda_init = (
-        self._lambda_local(x, y, s, tau, a, p, b, c) if self.z < self.m else None
-    )
+    # The accepted candidate has already been scored at this exact point.
+    # Cold starts need their own initial diagnostic; equality-only problems
+    # have no inequality complementarity parameter and skip this score.
+    if self.warm_accepted:
+      self.lambda_init = self.warm_lambda
+    else:
+      self.lambda_init = (
+          self._lambda_local(x, y, s, tau, a, p, b, c)
+          if self.z < self.m else None
+      )
 
     self._log_header()
 

--- a/tests/test_product_reuse.py
+++ b/tests/test_product_reuse.py
@@ -67,6 +67,171 @@ def test_warm_local_metric_uses_one_p_product():
   assert counted_p.applies == 1
 
 
+def _dense_local_metric(x, y, s, tau, a, p, b, c, z):
+  """Independent dense evaluation on ordinary-scale, strictly interior data."""
+  mu = y @ s / (len(y) - z)
+  barrier = np.zeros(len(x) + len(y) + 1)
+  barrier[len(x) + z:-1] = -1 / y[z:]
+  barrier[-1] = -1 / tau
+  embedding = np.concatenate([
+      p @ x + a.T @ y + c * tau,
+      -a @ x + b * tau,
+      [-c @ x - b @ y - x @ p @ x / tau],
+  ])
+  residual = embedding + mu * (np.concatenate([x, y, [tau]]) + barrier)
+  diagonal = np.full(len(residual), mu)
+  diagonal[len(x) + z:-1] += mu / y[z:] ** 2
+  diagonal[-1] += mu / tau ** 2
+  return np.sqrt(residual @ np.linalg.solve(np.diag(diagonal), residual))
+
+
+@pytest.mark.parametrize('quadratic', [False, True])
+@pytest.mark.parametrize('cached', ['ax', 'px', 'both'])
+def test_cached_warm_metric_matches_standalone(quadratic, cached):
+  a = np.array([[1.0, -0.2], [0.3, 1.2], [-0.7, 0.5]])
+  p = np.array([[2.0, 0.3], [0.3, 1.5]]) if quadratic else np.zeros((2, 2))
+  b, c = np.array([0.4, 1.0, -0.2]), np.array([0.7, -0.1])
+  solver = qtqp.QTQP(
+      a=sparse.csc_matrix(a), b=b, c=c, p=sparse.csc_matrix(p), z=1
+  )
+  # Different scales and shifts catch a cache that accidentally retains the
+  # unnormalized product or a product from the preceding candidate.
+  for scale, shift in [(0.3, 1e-4), (1.2, 0.1)]:
+    x = scale * np.array([0.3, -0.7])
+    y = scale * np.array([-0.4, shift, 0.8])
+    s, tau = scale * np.array([0.0, 0.7, shift]), scale
+    kwargs = {}
+    if cached in ('ax', 'both'):
+      kwargs['ax'] = a @ x
+    if cached in ('px', 'both'):
+      kwargs['px'] = p @ x
+    counted_p = _CountingMatrix(p)
+    actual = solver._lambda_local(
+        x, y, s, tau, solver.a, counted_p, b, c, **kwargs
+    )
+    standalone = solver._lambda_local(x, y, s, tau, solver.a, solver.p, b, c)
+    expected = _dense_local_metric(x, y, s, tau, a, p, b, c, 1)
+    assert actual == pytest.approx(expected, rel=2e-13)
+    assert standalone == pytest.approx(expected, rel=2e-13)
+    assert counted_p.applies == (0 if 'px' in kwargs else 1)
+
+
+@pytest.mark.parametrize('equilibration', list(qtqp.EquilibrationStrategy))
+@pytest.mark.parametrize('quadratic, mode', [
+    (True, 'accepted'), (False, 'accepted'),
+    (True, 'vetoed'), (False, 'cold'),
+])
+def test_warm_screen_reuses_products_on_public_solve(
+    monkeypatch, equilibration, quadratic, mode,
+):
+  a = np.array([[1.0, -0.3], [1.0, 0.0], [-1.0, 0.0],
+                [0.0, 1.0], [0.0, -1.0]])
+  p = np.array([[2.0, 0.2], [0.2, 1.5]]) if quadratic else np.zeros((2, 2))
+  x_star = np.array([0.2, -0.4])
+  y_star = np.array([0.3, 1.0, 0.0, 0.7, 0.0])
+  s_star = np.array([0.0, 0.0, 2.0, 0.0, 3.0])
+  b, c = a @ x_star + s_star, -p @ x_star - a.T @ y_star
+  solver = qtqp.QTQP(
+      a=sparse.csc_matrix(a), b=b, c=c, p=sparse.csc_matrix(p), z=1
+  )
+  options = dict(verbose=False, collect_stats=True,
+                 linear_solver=qtqp.LinearSolver.SCIPY,
+                 equilibration_strategy=equilibration)
+  base = solver.solve(**options)
+  assert base.status == qtqp.SolutionStatus.SOLVED
+
+  state = {'screen': False, 'products': [], 'metrics': [], 'init_calls': 0}
+  original_validate = solver._validate_warm_start
+  original_metric = solver._lambda_local
+  original_init = solver._init_variables
+  original_check = solver._check_termination
+
+  def validate(*args):
+    result = original_validate(*args)
+    state['screen'] = result is not None
+    return result
+
+  def metric(x, y, s, tau, a, p, b, c, **kwargs):
+    dense_a, dense_p = a.toarray(), p.toarray()
+    expected = _dense_local_metric(x, y, s, tau, dense_a, dense_p, b, c, 1)
+    if state['screen']:
+      if kwargs.get('ax') is not None:
+        np.testing.assert_allclose(kwargs['ax'], dense_a @ x, rtol=2e-13, atol=1e-14)
+      if kwargs.get('px') is not None:
+        np.testing.assert_allclose(kwargs['px'], dense_p @ x, rtol=2e-13, atol=1e-14)
+    actual = original_metric(x, y, s, tau, a, p, b, c, **kwargs)
+    assert actual == pytest.approx(expected, rel=2e-12, abs=1e-12)
+    state['metrics'].append((state['screen'], actual))
+    return actual
+
+  def init(*args):
+    state['screen'] = False
+    state['init_calls'] += 1
+    return original_init(*args)
+
+  def check(*args):
+    state['screen'] = False
+    return original_check(*args)
+
+  # Observe actual sparse applications in the production screening window,
+  # including the precomputation before _lambda_local is called. A.T is CSR.
+  def count_products(original):
+    def matmul(matrix, vector):
+      if state['screen']:
+        state['products'].append(matrix.shape)
+      return original(matrix, vector)
+    return matmul
+
+  for matrix_type in (sparse.csc_matrix, sparse.csr_matrix):
+    monkeypatch.setattr(matrix_type, '__matmul__', count_products(matrix_type.__matmul__))
+  monkeypatch.setattr(solver, '_validate_warm_start', validate)
+  monkeypatch.setattr(solver, '_lambda_local', metric)
+  monkeypatch.setattr(solver, '_init_variables', init)
+  monkeypatch.setattr(solver, '_check_termination', check)
+
+  previous_score = None
+  for perturbation in (0.0, 0.02):
+    state.update(screen=False, products=[], metrics=[], init_calls=0)
+    warm_start = None if mode == 'cold' else (
+        base.x + perturbation * np.array([1.0, -0.5]),
+        base.y * (1 + perturbation), base.s + perturbation,
+    )
+    threshold = 1e-20 if mode == 'vetoed' else 100.0
+    result = solver.solve(
+        **options, warm_start=warm_start, warm_start_threshold=threshold
+    )
+    assert result.status == qtqp.SolutionStatus.SOLVED
+    np.testing.assert_allclose(a @ result.x + result.s, b, atol=1e-7, rtol=0)
+    np.testing.assert_allclose(p @ result.x + a.T @ result.y + c, 0, atol=1e-7)
+    np.testing.assert_allclose(result.x, x_star, atol=1e-7, rtol=0)
+
+    screen_scores = [score for screened, score in state['metrics'] if screened]
+    cold_scores = [score for screened, score in state['metrics'] if not screened]
+    if mode == 'cold':
+      assert state['products'] == []
+      assert screen_scores == []
+      assert solver.warm_lambda is None
+    else:
+      assert state['products'].count(a.shape) == 1
+      assert state['products'].count(p.shape) == 1
+      assert state['products'].count(a.T.shape) == 4
+      assert len(state['products']) == 6
+      assert len(screen_scores) == 4
+      assert solver.warm_lambda == min(screen_scores)
+      if previous_score is not None:
+        assert solver.warm_lambda != previous_score
+      previous_score = solver.warm_lambda
+    assert solver.warm_accepted == (mode == 'accepted')
+    if mode == 'accepted':
+      assert state['init_calls'] == 0
+      assert cold_scores == []
+      assert solver.lambda_init == solver.warm_lambda
+    else:
+      assert state['init_calls'] == 1
+      assert len(cold_scores) == 1
+      assert solver.lambda_init == cold_scores[0]
+
+
 def test_tau_products_shared_through_gondzio_trials(monkeypatch):
   rng = np.random.default_rng(2)
   n, m, z = 8, 20, 3


### PR DESCRIPTION
## Summary

Reuse matrix-vector products across the four warm-start candidates and correct the documentation's warm-start guarantees.

- Compute the working-frame `A @ wx` and `P @ wx` once. Only `y` and `s` are shifted, so each candidate's primal products are these shared products times its radial normalization scale. Each candidate still computes its own `A.T @ y`.
- Reuse the accepted candidate's `warm_lambda` as `lambda_init`, rather than evaluating the same score a fifth time.
- Keep caches local to this screening call and release the shared products before entering the IPM loop. Standalone `_lambda_local` calls still work; cached products are optional keyword arguments.
- Describe the screen as an empirical, guarded local-residual score. Remove the certified-distance and no-slowdown claims, distinguish it from the exact theoretical `eta < 1` bound, and document the actual screening cost.

Accepted warm-start screening plus its initial diagnostic now takes **6 rather than 15 matrix-vector products**: two shared primal products and four transpose products. This is an application-count reduction, not a claimed end-to-end wall-clock speedup.

The candidate shifts, normalization, score formula, epsilon guards and default threshold of 100 are unchanged. Product rescaling is algebraically equivalent; floating-point roundoff need not be bitwise identical. No new certificate-based acceptance rule is introduced.

This is independent of #133's initialization-statistics reset. The paper is not changed by this PR.

## Tests

- Independent dense-formula checks for cached and standalone scores, including LPs, QPs and equality rows.
- Actual sparse product counts through the public solve path under NONE, RUIZ and AUGMENTED scaling.
- Accepted, rejected and cold starts, including changed warm points on reused solver objects; rejection still computes the cold initial diagnostic.
- Both reuse mechanisms were mutation-checked: removing the cached products or re-evaluating the accepted diagnostic makes the product-count tests fail.

## Validation

- 120 related warm-start, initialization, equality and local-diagnostic tests passed.
- 82 tests across the other five test modules passed, including all 21 product-reuse tests.
- Ruff E9/F and `git diff --check` passed.

Local validation used Python 3.12, NumPy 2.4.2 and SciPy 1.16.3. For collection of `tests/test_qtqp.py`, an external import shim marked the optional PETSc/MUMPS backend unavailable because the installed import terminates this local test process; no solver implementation was stubbed. The five other modules ran without that shim. This is targeted validation, not a claim that the complete local suite ran; the PR CI matrix provides the broader gate.
