### PR TITLE
Document the checks, run the docstrings, and measure coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,17 @@ jobs:
           conda install -y -c conda-forge suitesparse scikit-umfpack nanoeigenpy
           python -m pip install 'scikit-sparse>=0.5'
           python -m pip install -U pip
-          python -m pip install qdldl pytest
+          python -m pip install qdldl pytest pytest-cov
           python -m pip install -e .[test] || python -m pip install -e .
 
-      - name: Run tests
+      - name: Run tests with coverage
         shell: bash -l {0}
+        # Coverage is measured on every leg, not just one: each installs a
+        # different subset of the optional linear solvers, so a single leg
+        # would report a floor no other leg has to meet. The threshold
+        # lives in pyproject.toml and pytest exits non-zero below it.
         run: |
-          pytest
+          pytest --cov --cov-report=term-missing
 
   build-and-publish:
     if: startsWith(github.ref, 'refs/tags/')

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ share/python-wheels/
 *.egg
 MANIFEST
 CLAUDE.md
+
+# Coverage data
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,48 @@ You generally only need to submit a CLA once, so if you've already submitted one
 (even if it was for a different project), you probably don't need to do it
 again.
 
+## Development
+
+### Environment
+
+The test suite needs a handful of optional sparse backends that are easiest to
+get from conda-forge. From a clone of the repository:
+
+```bash
+conda create -n qtqp python=3.12
+conda activate qtqp
+conda install -y -c conda-forge suitesparse scikit-umfpack nanoeigenpy
+python -m pip install 'scikit-sparse>=0.5' qdldl
+python -m pip install -e '.[test]'
+```
+
+Two backends are platform specific and are installed by the runtime
+dependencies where they are available: `py-mkl-pardiso` on Linux and Windows
+`x86_64`, and `macldlt` on macOS `arm64`. `petsc4py` (`conda install -y -c
+conda-forge petsc4py`) is optional and unavailable on Windows. Tests for a
+linear solver whose dependency is missing are skipped rather than failed, so a
+partial environment still gives a useful run.
+
+### Checks
+
+These are the same two gates CI runs, so a green run locally is a green run on
+the pull request:
+
+```bash
+ruff check --select E9,F src/   # syntax errors, undefined names, unused imports
+pytest                          # the full suite, including doctests in src/
+```
+
+Style rules are deliberately excluded from the lint gate; only correctness
+rules (`E9`, `F`) are enforced.
+
+To see what the suite reaches, run it with coverage. CI fails below the
+threshold committed in `pyproject.toml`:
+
+```bash
+pytest --cov=qtqp --cov-report=term-missing
+```
+
 ## Code reviews
 
 All submissions, including submissions by project members, require review. We

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The cutie QP solver is a primal-dual interior point method for solving
 convex quadratic programs (QPs), implemented in pure python. It solves the
 primal QP:
 
-```
+```text
     min. (1/2) x.T @ p @ x + c.T @ x
     s.t. a @ x + s = b
          s[:z] == 0
@@ -15,7 +15,7 @@ primal QP:
 
 With dual:
 
-```
+```text
     max. -(1/2) x.T @ p @ x - b.T @ y
     s.t. p @ x + a.T @ y = -c
          y[z:] >= 0
@@ -95,7 +95,7 @@ print(f'{sol.s=}')
 
 You should see output similar to
 
-```
+```text
 | QTQP v0.0.7: m=3, n=2, z=1, nnz(A)=4, nnz(P)=4, linear_solver=ACCELERATE, equilibration=RUIZ
 |------|------------|------------|----------|----------|----------|----------|----------|----------|----------|
 | iter |      pcost |      dcost |     pres |     dres |      gap |   infeas |       mu |  q, p, c |     time |
@@ -123,7 +123,7 @@ import qtqp
 
 This exposes the main solver class `qtqp.QTQP` with constructor:
 
-```python
+```text
 QTQP(
     *,
     a: scipy.sparse.csc_matrix,
@@ -154,7 +154,7 @@ Arguments:
 
 This class has a single API method `solve`:
 
-```python
+```text
 solve(
     *,
     tol_feas: float = 1e-8,
@@ -477,7 +477,7 @@ python -m pip install cupy-cuda12x
 
 Coming soon, in the meantime the closest work is:
 
-```
+```bibtex
 @article{odonoghue:21,
     author       = {Brendan O'Donoghue},
     title        = {Operator Splitting for a Homogeneous Embedding of the Linear Complementarity Problem},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest",
+    "pytest-cov",
 ]
 
 [tool.setuptools]
@@ -32,3 +33,30 @@ package-dir = {"" = "src"}
 [tool.setuptools.packages.find]
 where = ["src"]
 namespaces = false
+
+[tool.pytest.ini_options]
+# Docstring examples in the public API are part of the suite: a plain
+# `pytest` run executes them, so a docstring cannot drift from behaviour
+# without turning CI red.
+addopts = "--doctest-modules"
+testpaths = ["src", "tests"]
+
+[tool.coverage.run]
+source = ["qtqp"]
+# The CUDA backends cannot run on any CI runner we have, so counting them
+# would only push the threshold below what the rest of the package can be
+# held to. Lint (ruff E9,F) is what guards them instead.
+omit = ["*/qtqp/solvers_gpu.py"]
+
+[tool.coverage.report]
+show_missing = true
+# Every CI leg installs a different subset of the optional linear solvers,
+# so the floor is what the thinnest environment reaches (macOS/Accelerate
+# only, ~88%) with room for the spread between legs.
+fail_under = 85
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+]

--- a/src/qtqp/__init__.py
+++ b/src/qtqp/__init__.py
@@ -76,7 +76,33 @@ _SCALAR_MAX = 1e4
 
 
 class LinearSolver(enum.Enum):
-  """Available linear solvers."""
+  """Available linear solvers.
+
+  Each member names a backend for the KKT system solved at every interior
+  point iteration. AUTO picks the fastest backend importable on this
+  platform; every other member is a specific backend and raises if its
+  dependency is missing. SCIPY is always available.
+
+  Example:
+    The backend changes how the Newton system is factorized, not what the
+    problem is, so the answer does not depend on the choice:
+
+    >>> import numpy as np
+    >>> import scipy.sparse as sp
+    >>> import qtqp
+    >>> a = sp.csc_matrix(
+    ...     [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]]
+    ... )
+    >>> b = np.array([1.0, 1.0, 0.0, 0.0])
+    >>> c = np.array([-1.0, -1.0])
+    >>> problem = qtqp.QTQP(a=a, b=b, c=c, z=0)
+    >>> auto = problem.solve(verbose=False)
+    >>> scipy_backend = problem.solve(
+    ...     verbose=False, linear_solver=qtqp.LinearSolver.SCIPY
+    ... )
+    >>> bool(np.allclose(auto.x, scipy_backend.x, atol=1e-6))
+    True
+  """
 
   AUTO = "auto"
   ACCELERATE = direct.AccelerateSolver
@@ -188,7 +214,34 @@ def _resolve_linear_solver(
 
 
 class SolutionStatus(enum.Enum):
-  """Possible statuses of the QP solution."""
+  """Possible statuses of the QP solution.
+
+  SOLVED and ALMOST_SOLVED carry a primal-dual solution in (x, y, s);
+  INFEASIBLE and UNBOUNDED carry a certificate instead; HIT_MAX_ITER,
+  FAILED and UNFINISHED carry the best iterate seen, which satisfies
+  nothing in particular.
+
+  Example:
+    A bounded LP is solved, while dropping the bounds leaves the same
+    objective unbounded below:
+
+    >>> import numpy as np
+    >>> import scipy.sparse as sp
+    >>> import qtqp
+    >>> c = np.array([-1.0, -1.0])
+    >>> bounded = sp.csc_matrix(
+    ...     [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]]
+    ... )
+    >>> qtqp.QTQP(
+    ...     a=bounded, b=np.array([1.0, 1.0, 0.0, 0.0]), c=c, z=0
+    ... ).solve(verbose=False).status
+    <SolutionStatus.SOLVED: 'solved'>
+    >>> unbounded = sp.csc_matrix([[-1.0, 0.0], [0.0, -1.0]])
+    >>> qtqp.QTQP(
+    ...     a=unbounded, b=np.array([0.0, 0.0]), c=c, z=0
+    ... ).solve(verbose=False).status
+    <SolutionStatus.UNBOUNDED: 'unbounded'>
+  """
 
   SOLVED = "solved"
   INFEASIBLE = "infeasible"
@@ -240,6 +293,32 @@ class EquilibrationStrategy(enum.Enum):
     sigma * tau_eq), so iterate (un)equilibration must apply 1/sigma to
     keep the recovered x/tau, y/tau, s/tau in the original scale. This
     strategy has no objective scale (gamma == 1).
+
+  Example:
+    Equilibration rescales the data the solver works on and is undone
+    before the solution is returned, so the strategy is a conditioning
+    choice rather than a modelling one:
+
+    >>> import numpy as np
+    >>> import scipy.sparse as sp
+    >>> import qtqp
+    >>> a = sp.csc_matrix(
+    ...     [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]]
+    ... )
+    >>> problem = qtqp.QTQP(
+    ...     a=a,
+    ...     b=np.array([1.0, 1.0, 0.0, 0.0]),
+    ...     c=np.array([-1.0, -1.0]),
+    ...     z=0,
+    ... )
+    >>> for strategy in qtqp.EquilibrationStrategy:
+    ...   solution = problem.solve(
+    ...       verbose=False, equilibration_strategy=strategy
+    ...   )
+    ...   print(strategy.value, np.round(solution.x, 6))
+    none [1. 1.]
+    ruiz [1. 1.]
+    augmented [1. 1.]
   """
 
   NONE = "none"
@@ -259,6 +338,31 @@ class Solution:
     status: SolutionStatus enum indicating the status.
     iterations: Number of completed IPM steps, excluding initialization and
       failed step attempts. Available even when statistics are not collected.
+
+  Example:
+    `stats` is empty unless the solve was asked to collect it, while
+    `iterations` is always reported:
+
+    >>> import numpy as np
+    >>> import scipy.sparse as sp
+    >>> import qtqp
+    >>> a = sp.csc_matrix(
+    ...     [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]]
+    ... )
+    >>> solution = qtqp.QTQP(
+    ...     a=a,
+    ...     b=np.array([1.0, 1.0, 0.0, 0.0]),
+    ...     c=np.array([-1.0, -1.0]),
+    ...     z=0,
+    ... ).solve(verbose=False)
+    >>> np.round(solution.x, 6)
+    array([1., 1.])
+    >>> solution.s.shape, solution.y.shape
+    ((4,), (4,))
+    >>> solution.stats
+    []
+    >>> solution.iterations > 0
+    True
   """
 
   x: np.ndarray
@@ -291,6 +395,26 @@ class QTQP:
     max. -(1/2) x.T @ p @ x - b.T @ y
     s.t. p @ x + a.T @ y = -c
          y[z:] >= 0
+
+  The first `z` rows of `a` are the equality rows; the rest are
+  inequalities. Build the solver once for a given (a, b, c, p, z) and call
+  `solve` on it.
+
+  Example:
+    A two-variable QP with one equality row and two inequality rows:
+
+    >>> import numpy as np
+    >>> import scipy.sparse as sp
+    >>> import qtqp
+    >>> p = sp.csc_matrix([[3.0, -1.0], [-1.0, 2.0]])
+    >>> a = sp.csc_matrix([[-1.0, 1.0], [1.0, 0.0], [0.0, 1.0]])
+    >>> b = np.array([-1.0, 0.3, -0.5])
+    >>> c = np.array([-1.0, -1.0])
+    >>> solution = qtqp.QTQP(p=p, a=a, b=b, c=c, z=1).solve(verbose=False)
+    >>> solution.status
+    <SolutionStatus.SOLVED: 'solved'>
+    >>> np.round(solution.x, 6)
+    array([ 0.3, -0.7])
   """
 
   def __init__(
@@ -310,6 +434,37 @@ class QTQP:
       c: Cost vector (n,).
       z: The number of equality constraints (zero-cone size).
       p: QP matrix in CSC format (n x n). Assumed zero if None.
+
+    Raises:
+      TypeError: If `a` or `p` is not in CSC format.
+      ValueError: If the shapes disagree, the data is not finite, `z` is
+        outside [0, m], or nothing is left to solve after presolve.
+
+    Example:
+      Omitting `p` states an LP -- the quadratic term is taken as zero:
+
+      >>> import numpy as np
+      >>> import scipy.sparse as sp
+      >>> import qtqp
+      >>> a = sp.csc_matrix(
+      ...     [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]]
+      ... )
+      >>> problem = qtqp.QTQP(
+      ...     a=a,
+      ...     b=np.array([1.0, 1.0, 0.0, 0.0]),
+      ...     c=np.array([-1.0, -1.0]),
+      ...     z=0,
+      ... )
+      >>> problem.m, problem.n, problem.z
+      (4, 2, 0)
+
+      The arguments are keyword-only, so a mistyped one is rejected rather
+      than silently bound to the wrong matrix:
+
+      >>> qtqp.QTQP(a, np.array([1.0]), np.array([1.0]), 0)
+      Traceback (most recent call last):
+        ...
+      TypeError: QTQP.__init__() takes 1 positional argument but 5 were given
     """
     self.m, self.n = a.shape
     self.z = z
@@ -664,7 +819,50 @@ class QTQP:
       adaptive_step_size: bool = True,
       max_centrality_correctors: int = 1,
   ) -> Solution:
-    """Solves the QP using a primal-dual interior-point method."""
+    """Solves the QP using a primal-dual interior-point method.
+
+    Every argument is keyword-only and documented on the private
+    implementation below; the defaults solve to 1e-8 on all three
+    criteria with an automatically chosen backend.
+
+    Returns:
+      A `Solution`. Check `status` before reading `x`, `y` and `s`: only
+      SOLVED and ALMOST_SOLVED return a primal-dual solution, and the
+      infeasible statuses return a certificate in the same fields.
+
+    Example:
+      A solver can be reused: each call re-solves from scratch, and
+      tightening or loosening the tolerances does not require rebuilding
+      the problem.
+
+      >>> import numpy as np
+      >>> import scipy.sparse as sp
+      >>> import qtqp
+      >>> a = sp.csc_matrix(
+      ...     [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]]
+      ... )
+      >>> problem = qtqp.QTQP(
+      ...     a=a,
+      ...     b=np.array([1.0, 1.0, 0.0, 0.0]),
+      ...     c=np.array([-1.0, -1.0]),
+      ...     z=0,
+      ... )
+      >>> loose = problem.solve(verbose=False, tol_feas=1e-4)
+      >>> tight = problem.solve(verbose=False, tol_feas=1e-10)
+      >>> loose.status, tight.status
+      (<SolutionStatus.SOLVED: 'solved'>, <SolutionStatus.SOLVED: 'solved'>)
+
+      `collect_stats` fills `Solution.stats` with one row per iteration:
+
+      >>> detailed = problem.solve(verbose=False, collect_stats=True)
+      >>> len(detailed.stats) > 0
+      True
+
+      An iteration cap the problem cannot meet is reported, not raised:
+
+      >>> problem.solve(verbose=False, max_iter=1).status
+      <SolutionStatus.HIT_MAX_ITER: 'hit_max_iter'>
+    """
     self._linear_solver = None
     self._iterations = 0
     # Accepted warm starts skip initialization; its stats belong to this call.


### PR DESCRIPTION
Closes #150, closes #149, closes #145. Also addresses #144 and #146, which were closed as not planned during review.

Five quality gaps that share one property: nothing currently proves the documentation is still true.

### Documentation fences (#150, #144)

- The four untagged fences in `README.md` — the primal and dual problem statements, the quick-start output, and the citation — now declare a language, so a fence checker can reach every block.
- The two `python`-tagged fences showing the `QTQP(...)` and `solve(...)` signatures do not parse: a bare `*` is legal in a `def` but not in a call expression. They are pseudo-signature displays, so they are retagged `text` — consistent with how the other signature and pseudocode blocks are now tagged. Every remaining `python` fence passes `compile()`.

### Contributor onboarding (#145)

`CONTRIBUTING.md` gains a Development section naming the environment setup and the two gates CI runs (`ruff check --select E9,F src/` and `pytest`), so a contributor no longer has to read `ci.yml` to find them.

### Doctests (#149)

The public surface — `QTQP`, its constructor, `solve`, `Solution`, `SolutionStatus`, `LinearSolver` and `EquilibrationStrategy` — carries `>>>` examples, and `--doctest-modules` is in `addopts` so a plain `pytest` run executes them. The examples are chosen to assert things the solver actually guarantees rather than incidental output: that the backend choice does not change the answer, that all three equilibration strategies agree, that an iteration cap is reported rather than raised.

### Coverage (#146)

`pytest-cov` joins the `test` extra, coverage configuration lands in `pyproject.toml` with `fail_under = 85`, and the CI test step runs `pytest --cov --cov-report=term-missing`.

Two calls worth reviewing:

- **Threshold 85.** Set from the thinnest environment I could measure — macOS with Accelerate as the only optional backend — which reaches **88.70%**. Every CI leg installs strictly more backends than that, and the slack covers the spread between legs, whose coverage of `solvers_sparse.py` differs by which solvers they have.
- **`solvers_gpu.py` is omitted.** No CI runner can execute it, so counting it would only drag the threshold below what the rest of the package can be held to. Ruff's `E9,F` gate is what guards that module — the same reasoning already recorded in `ci.yml` for the `CupyDenseSolver.update_diag` `NameError`.

### Verification

Full suite on macOS / Python 3.14, Accelerate only:

```text
TOTAL                         1328    150    89%
Required test coverage of 85.0% reached. Total coverage: 88.70%
1222 passed, 25 skipped, 9 warnings in 53.02s
```

`ruff check --select E9,F src/` passes.

